### PR TITLE
feat(search): 로그인 시 관심 종목 서버 저장

### DIFF
--- a/cf-idiotquant/app/(actions)/actions/stockLike.ts
+++ b/cf-idiotquant/app/(actions)/actions/stockLike.ts
@@ -1,0 +1,89 @@
+"use server";
+
+import { auth } from "@/auth";
+
+const CREATE_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS stock_likes (
+    user_id   TEXT    NOT NULL,
+    ticker    TEXT    NOT NULL,
+    is_us     INTEGER NOT NULL DEFAULT 0,
+    stock_name TEXT,
+    added_at  INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    PRIMARY KEY (user_id, ticker),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  )
+`;
+
+function getDb() {
+  const { env } = (process as any).env;
+  return env.db as any;
+}
+
+/** 관심 종목 토글 (추가/제거). 로그인 필요. */
+export async function toggleStockLike(
+  ticker: string,
+  isUs: boolean,
+  stockName?: string,
+): Promise<{ success: boolean; liked: boolean; message?: string }> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return { success: false, liked: false, message: "로그인이 필요합니다." };
+  }
+
+  const db = getDb();
+
+  try {
+    await db.prepare(CREATE_TABLE_SQL).run();
+
+    const existing = await db
+      .prepare("SELECT user_id FROM stock_likes WHERE user_id = ? AND ticker = ?")
+      .bind(session.user.id, ticker)
+      .first();
+
+    if (existing) {
+      await db
+        .prepare("DELETE FROM stock_likes WHERE user_id = ? AND ticker = ?")
+        .bind(session.user.id, ticker)
+        .run();
+      return { success: true, liked: false };
+    } else {
+      await db
+        .prepare(
+          "INSERT INTO stock_likes (user_id, ticker, is_us, stock_name, added_at) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(
+          session.user.id,
+          ticker,
+          isUs ? 1 : 0,
+          stockName ?? null,
+          Math.floor(Date.now() / 1000),
+        )
+        .run();
+      return { success: true, liked: true };
+    }
+  } catch (e) {
+    console.error("toggleStockLike error:", e);
+    return { success: false, liked: false, message: "저장 중 오류가 발생했습니다." };
+  }
+}
+
+/** 로그인한 유저의 관심 종목 ticker 목록 반환. */
+export async function getMyStockLikes(): Promise<string[]> {
+  const session = await auth();
+  if (!session?.user?.id) return [];
+
+  const db = getDb();
+
+  try {
+    await db.prepare(CREATE_TABLE_SQL).run();
+
+    const result = await db
+      .prepare("SELECT ticker FROM stock_likes WHERE user_id = ? ORDER BY added_at DESC")
+      .bind(session.user.id)
+      .all();
+
+    return ((result.results ?? []) as any[]).map((r) => r.ticker as string);
+  } catch {
+    return [];
+  }
+}

--- a/cf-idiotquant/app/(search)/search/page.tsx
+++ b/cf-idiotquant/app/(search)/search/page.tsx
@@ -11,6 +11,8 @@ import {
   startTransition
 } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { toggleStockLike, getMyStockLikes } from '@/app/(actions)/actions/stockLike';
 import dynamic from 'next/dynamic';
 import { useAppSelector, useAppDispatch } from '@/lib/hooks';
 import { useStockSearch } from './hooks/useStockSearch';
@@ -376,6 +378,7 @@ function SearchContent() {
   const krMarketHistory = useAppSelector(selectKrMarketHistory);
   const popularStocks = useAppSelector(selectPopularStocks) || [];
 
+  const { data: session } = useSession();
   const isOnline = useOnlineStatus();
   const { toasts, addToast, dismissToast } = useToast();
 
@@ -417,6 +420,19 @@ function SearchContent() {
       if (wl) setWatchlist(JSON.parse(wl));
     } catch (e) { console.error('Failed to load watchlist:', e); }
   }, [dispatch, addToast]);
+
+  // 로그인 시 서버 저장 관심 종목 불러와 로컬과 병합
+  useEffect(() => {
+    if (!session?.user) return;
+    getMyStockLikes().then(serverLikes => {
+      if (serverLikes.length === 0) return;
+      setWatchlist(prev => {
+        const merged = [...new Set([...prev, ...serverLikes])];
+        try { window.localStorage.setItem('idiotquant_watchlist_v1', JSON.stringify(merged)); } catch {}
+        return merged;
+      });
+    }).catch(() => {});
+  }, [session?.user]);
 
   const awardStockXp = useCallback((ticker: string, gainedXp: number) => {
     const key = normalizeTickerKey(ticker);
@@ -474,6 +490,9 @@ function SearchContent() {
   }, [name, krOrUs, addToast]);
 
   const toggleWatchlist = useCallback((ticker: string) => {
+    if (!session?.user) {
+      addToast({ type: 'info', message: '로그인 후 관심 종목이 서버에 저장됩니다.' });
+    }
     setWatchlist(prev => {
       const isAdded = prev.includes(ticker);
       const next = isAdded ? prev.filter(t => t !== ticker) : [...prev, ticker];
@@ -481,9 +500,13 @@ function SearchContent() {
         window.localStorage.setItem('idiotquant_watchlist_v1', JSON.stringify(next));
         addToast({ type: isAdded ? 'info' : 'success', message: isAdded ? '관심 종목에서 제거되었습니다.' : '관심 종목에 추가되었습니다.' });
       } catch { }
+      // 로그인 상태면 서버에도 저장
+      if (session?.user) {
+        toggleStockLike(ticker, krOrUs === 'US', name ?? undefined).catch(() => {});
+      }
       return next;
     });
-  }, [addToast]);
+  }, [addToast, session, krOrUs, name]);
 
   useEffect(() => {
     const ticker = searchParams.get('ticker');

--- a/cf-idiotquant/schema.sql
+++ b/cf-idiotquant/schema.sql
@@ -57,3 +57,14 @@ CREATE TABLE IF NOT EXISTS usage_limits (
     lastResetDate INTEGER DEFAULT (strftime('%s', 'now')), -- 초기화 날짜
     FOREIGN KEY (userId) REFERENCES users (id) ON DELETE CASCADE
 );
+
+-- 5. 관심 종목 (로그인 유저 서버 저장)
+CREATE TABLE IF NOT EXISTS stock_likes (
+    user_id    TEXT    NOT NULL,
+    ticker     TEXT    NOT NULL,        -- 검색 키 (KR: 종목명, US: 티커)
+    is_us      INTEGER NOT NULL DEFAULT 0, -- 0: KR, 1: US
+    stock_name TEXT,                    -- 종목 표시명 (optional)
+    added_at   INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+    PRIMARY KEY (user_id, ticker),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary

- **`stock_likes` 테이블 추가** (`schema.sql`): `user_id`, `ticker`, `is_us`, `stock_name`, `added_at` 컬럼, `(user_id, ticker)` 복합 PK
- **`stockLike` 서버 액션 신규 작성** (`app/(actions)/actions/stockLike.ts`):
  - `toggleStockLike(ticker, isUs, stockName)` — Cloudflare D1에 관심 종목 추가/제거 토글
  - `getMyStockLikes()` — 로그인 유저의 저장된 관심 종목 목록 반환
- **`search/page.tsx` 변경**:
  - `useSession`으로 로그인 상태 감지
  - 로그인 시 서버 likes를 로컬 watchlist와 병합 (기기 간 동기화)
  - `toggleWatchlist`: 로그인 상태면 D1 DB에도 자동 동기화
  - 비로그인 클릭 시 "로그인 후 서버 저장 가능" 안내 toast

## 동작 방식

| 상황 | 동작 |
|------|------|
| 비로그인 + 관심 클릭 | localStorage에만 저장 + 안내 toast |
| 로그인 + 관심 클릭 | localStorage + 서버 D1 DB 동시 저장 |
| 로그인 후 페이지 진입 | 서버 likes를 로컬과 병합 |

## Test plan

- [ ] 비로그인 상태에서 관심 종목 추가 → localStorage 저장 + "로그인 후 서버 저장 가능" toast 확인
- [ ] 로그인 후 관심 종목 추가 → DB 저장 및 새로고침 후에도 유지 확인
- [ ] 다른 기기(또는 시크릿 창) 로그인 후 관심 종목이 동기화되는지 확인
- [ ] Cloudflare Pages 빌드 성공 확인

https://claude.ai/code/session_01LUqJqHLfWgNaSYMn78fSVf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUqJqHLfWgNaSYMn78fSVf)_