### PR TITLE
fix: D1 NCAV 일별 스캔 결과 표시 버그 수정

### DIFF
--- a/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
+++ b/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
@@ -805,10 +805,18 @@ function AlgorithmTradeContent() {
                     </div>
 
                     <div className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm overflow-hidden">
-                        {ncavDailyList.state === "pending" ? (
+                        {(ncavDailyList.state === "pending" || ncavDailyList.state === "init") ? (
                             <div className="flex items-center justify-center py-16 gap-3">
                                 <Loader2 className="w-5 h-5 text-blue-500 animate-spin" />
                                 <span className="text-sm text-zinc-400 font-medium">불러오는 중...</span>
+                            </div>
+                        ) : ncavDailyList.state === "rejected" ? (
+                            <div className="flex flex-col items-center justify-center py-16 gap-3 text-center px-4">
+                                <div className="p-3 bg-red-50 dark:bg-red-950/20 rounded-xl">
+                                    <AlertTriangle className="w-7 h-7 text-red-400 dark:text-red-500" />
+                                </div>
+                                <p className="text-sm font-bold text-red-500 dark:text-red-400">데이터를 불러오지 못했습니다.</p>
+                                <p className="text-xs text-zinc-400 dark:text-zinc-500 max-w-sm">{ncavDailyList.error ?? "API 오류가 발생했습니다. Worker 배포 상태와 D1 바인딩을 확인해주세요."}</p>
                             </div>
                         ) : ncavDailyList.list.length === 0 ? (
                             <div className="flex flex-col items-center justify-center py-16 gap-3 text-center px-4">

--- a/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeAPI.tsx
+++ b/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeAPI.tsx
@@ -45,12 +45,12 @@ export const getQuantRuleDesc: any = async () => {
 
 export const getNcavDailyList: any = async (date?: string) => {
     const dateParam = date ?? "latest";
-    const subUrl = `/algorithm/trade/ncav/daily?date=${encodeURIComponent(dateParam)}`;
+    const subUrl = `/ncav/daily?date=${encodeURIComponent(dateParam)}&min_ratio=0&limit=200`;
     return getAlgorithmTradeRequest(subUrl);
 }
 
 export const getNcavDailyDates: any = async () => {
-    const subUrl = `/algorithm/trade/ncav/daily/dates`;
+    const subUrl = `/ncav/daily/dates`;
     return getAlgorithmTradeRequest(subUrl);
 }
 

--- a/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeSlice.tsx
+++ b/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeSlice.tsx
@@ -140,12 +140,14 @@ export interface NcavDailyState {
     list: NcavDailyItem[];
     scanDate: string | null;
     total: number;
+    error: string | null;
 }
 
 export interface NcavDailyDatesState {
     state: "init" | "pending" | "fulfilled" | "rejected";
     dates: NcavDailyDateItem[];
     selectedDate: string;
+    error: string | null;
 }
 
 interface AlgorithmTradeType {
@@ -222,8 +224,8 @@ const initialState: AlgorithmTradeType = {
     },
     stockDetails: {},
     strategyLists: {},
-    ncavDailyDates: { state: "init", dates: [], selectedDate: "latest" },
-    ncavDailyList: { state: "init", list: [], scanDate: null, total: 0 },
+    ncavDailyDates: { state: "init", dates: [], selectedDate: "latest", error: null },
+    ncavDailyList: { state: "init", list: [], scanDate: null, total: 0, error: null },
 }
 
 export const algorithmTradeSlice = createAppSlice({
@@ -345,27 +347,41 @@ export const algorithmTradeSlice = createAppSlice({
             }
         ),
         reqGetNcavDailyDates: create.asyncThunk(
-            async () => await getNcavDailyDates(),
+            async () => {
+                const result = await getNcavDailyDates();
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
             {
-                pending: (state) => { state.ncavDailyDates.state = "pending"; },
+                pending: (state) => { state.ncavDailyDates.state = "pending"; state.ncavDailyDates.error = null; },
                 fulfilled: (state, action) => {
                     state.ncavDailyDates.dates = action.payload?.data ?? [];
                     state.ncavDailyDates.state = "fulfilled";
                 },
-                rejected: (state) => { state.ncavDailyDates.state = "rejected"; },
+                rejected: (state, action) => {
+                    state.ncavDailyDates.state = "rejected";
+                    state.ncavDailyDates.error = action.error?.message ?? null;
+                },
             }
         ),
         reqGetNcavDailyList: create.asyncThunk(
-            async (date?: string) => await getNcavDailyList(date),
+            async (date?: string) => {
+                const result = await getNcavDailyList(date);
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
             {
-                pending: (state) => { state.ncavDailyList.state = "pending"; },
+                pending: (state) => { state.ncavDailyList.state = "pending"; state.ncavDailyList.error = null; },
                 fulfilled: (state, action) => {
                     state.ncavDailyList.list = action.payload?.data ?? [];
                     state.ncavDailyList.scanDate = action.payload?.meta?.scanDate ?? null;
                     state.ncavDailyList.total = action.payload?.meta?.total ?? 0;
                     state.ncavDailyList.state = "fulfilled";
                 },
-                rejected: (state) => { state.ncavDailyList.state = "rejected"; },
+                rejected: (state, action) => {
+                    state.ncavDailyList.state = "rejected";
+                    state.ncavDailyList.error = action.error?.message ?? null;
+                },
             }
         ),
     }),


### PR DESCRIPTION
## Summary

- `/algorithm/trade/ncav/daily` (미배포 엔드포인트) → `/ncav/daily` (기존 배포된 엔드포인트)로 API URL 변경, 목록이 즉시 표시되도록 수정
- `init` 상태에서도 로딩 스피너 표시 (첫 렌더 시 빈 화면 flash 방지)
- API 오류(`{ success: false }`) 시 `rejected` 상태로 처리하여 에러 메시지 표시
- `NcavDailyState` / `NcavDailyDatesState`에 `error: string | null` 필드 추가

## Test plan

- [ ] algorithm-trade 페이지 접속 시 NCAV 일별 스캔 결과 섹션에 목록 표시 확인
- [ ] 날짜 드롭다운 변경 시 해당 일자 데이터 로드 확인
- [ ] 새로고침 버튼 동작 확인
- [ ] Worker 배포 전: 날짜 드롭다운에 "최신 일자"만 표시되는 것 확인 (목록은 정상)
- [ ] Worker 배포 후: 날짜 드롭다운에 스캔 일자 목록 표시 확인

https://claude.ai/code/session_01R6miGDmYGnidXdbPdeRbdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6miGDmYGnidXdbPdeRbdi)_