### PR TITLE
fix: NCAV 날짜 드롭다운 자동 발견 (date auto-discovery)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+All commands run inside `cf-idiotquant/`:
+
+| Command | Purpose |
+|---|---|
+| `npm run dev` | Local dev server (`next dev`) |
+| `npm run build` | Production build |
+| `npx tsc --noEmit` | Type check (pre-push) |
+
+## Folder Structure
+
+```
+cf-idiotquant/
+├── app/                        # Next.js App Router 페이지
+│   ├── (algorithm-trade)/      # 자동매매 / NCAV 스크리너
+│   ├── (search)/               # 종목 검색
+│   └── api/proxy/[...path]/    # Cloudflare Worker 프록시
+├── lib/
+│   ├── features/               # Redux Toolkit slices + API 함수
+│   │   ├── algorithmTrade/     # 자동매매 상태 (slice + API)
+│   │   ├── backtest/           # 백테스트 slice
+│   │   ├── koreaInvestment/    # KIS 국내 시장 slice
+│   │   └── koreaInvestmentUsMarket/ # KIS 미국 시장 slice
+│   ├── store.ts                # Redux store
+│   ├── hooks.ts                # typed dispatch / selector hooks
+│   └── createAppSlice.ts       # createAppSlice wrapper
+├── components/                 # 공통 컴포넌트
+│   └── utils/financeCalc.ts    # NCAV 비율 계산 유틸
+└── public/data/                # 종목 코드 JSON (validCorpCode, usStockSymbols)
+```
+
+## Architecture
+
+- **Pages** — `app/` 하위 route별 `page.tsx`. `"use client"` 컴포넌트에서 Redux dispatch.
+- **Proxy** — `app/api/proxy/[...path]/route.ts` 가 모든 백엔드 호출을 `NEXT_PUBLIC_WORKER_BASE_URL`로 포워딩.
+- **Redux pattern** — `createAppSlice` + `create.asyncThunk`. fulfilled/rejected 핸들러에서 `result?.success === false` 시 throw해서 rejected 상태로 전환.
+- **D1 NCAV section** — `algorithmTrade` slice의 `ncavDailyList` / `ncavDailyDates` 상태. `/ncav/daily` 배포된 엔드포인트 사용. `/ncav/daily/dates` 미배포 시 `reqDiscoverNcavDates` thunk로 클라이언트 자동 탐색.
+
+## PR 생성 규칙
+
+작업 완료 후 PR을 만들기 전에 항상 기존 PR 상태를 확인한다.
+
+1. `mcp__github__list_pull_requests` (state: `all`, head: 현재 브랜치)로 기존 PR을 조회한다.
+2. **PR이 없거나 open 상태**이면 현재 브랜치에서 바로 PR을 생성한다.
+3. **PR이 이미 merged**이면 (`merged_at` 값이 있으면 merged로 판단):
+   - `git fetch origin main` 후 `git rebase origin/main` 으로 브랜치를 main tip에 맞춘다.
+   - `git push -u origin <branch> --force-with-lease` 로 푸시한다.
+   - 미반영 커밋(`git log origin/main..HEAD`)이 있으면 새 PR을 생성한다.
+   - 미반영 커밋이 없으면 PR 생성 없이 사용자에게 알린다.
+4. PR base는 항상 `main`으로 한다.

--- a/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
+++ b/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
@@ -16,7 +16,7 @@ import {
     selectStockByTicker, updateStockDetail, setStockState,
     selectNcavDailyDates, selectNcavDailyList,
     reqGetNcavDailyDates, reqGetNcavDailyList,
-    setNcavDailySelectedDate,
+    setNcavDailySelectedDate, reqDiscoverNcavDates,
 } from "@/lib/features/algorithmTrade/algorithmTradeSlice";
 import { selectStrategyNcavLatest, reqGetNcavLatest } from "@/lib/features/backtest/backtestSlice";
 import { reqGetInquirePrice, reqGetBalanceSheet, reqGetIncomeStatement, reqGetInquireDailyItemChartPrice } from "@/lib/features/koreaInvestment/koreaInvestmentSlice";
@@ -365,6 +365,7 @@ function AlgorithmTradeContent() {
 
     const observerTarget = useRef<HTMLDivElement>(null);
     const listRef = useRef<HTMLDivElement>(null);
+    const hasDiscovered = useRef(false);
 
     useEffect(() => { dispatch(reqGetNcavLatest()); }, [dispatch]);
 
@@ -372,6 +373,18 @@ function AlgorithmTradeContent() {
         dispatch(reqGetNcavDailyDates());
         dispatch(reqGetNcavDailyList("latest"));
     }, [dispatch]);
+
+    useEffect(() => {
+        if (
+            ncavDailyList.state === "fulfilled" &&
+            ncavDailyList.scanDate &&
+            !hasDiscovered.current &&
+            ncavDailyDates.dates.length < 2
+        ) {
+            hasDiscovered.current = true;
+            dispatch(reqDiscoverNcavDates(ncavDailyList.scanDate));
+        }
+    }, [ncavDailyList.state, ncavDailyList.scanDate, ncavDailyDates.dates.length, dispatch]);
 
     useEffect(() => {
         setDisplayCount(PAGE_SIZE);

--- a/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeAPI.tsx
+++ b/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeAPI.tsx
@@ -54,6 +54,11 @@ export const getNcavDailyDates: any = async () => {
     return getAlgorithmTradeRequest(subUrl);
 }
 
+export const checkNcavDailyDate: any = async (date: string) => {
+    const subUrl = `/ncav/daily?date=${encodeURIComponent(date)}&min_ratio=0&limit=1`;
+    return getAlgorithmTradeRequest(subUrl);
+}
+
 async function getAlgorithmTradeRequest(subUrl: string, additionalHeaders?: AdditionalHeaders) {
     const url = `/api/proxy${subUrl}`;
     const options: RequestInit = {

--- a/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeSlice.tsx
+++ b/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeSlice.tsx
@@ -9,9 +9,22 @@ import {
     getUsPurchaseLogLatest,
     getNcavDailyList,
     getNcavDailyDates,
+    checkNcavDailyDate,
 } from "./algorithmTradeAPI";
 
 const DEBUG = false;
+
+function addDays(dateStr: string, days: number): string {
+    const y = parseInt(dateStr.slice(0, 4));
+    const m = parseInt(dateStr.slice(4, 6)) - 1;
+    const d = parseInt(dateStr.slice(6, 8));
+    const dt = new Date(y, m, d + days);
+    return [
+        dt.getFullYear(),
+        String(dt.getMonth() + 1).padStart(2, '0'),
+        String(dt.getDate()).padStart(2, '0'),
+    ].join('');
+}
 
 // --- 기존 인터페이스 유지 ---
 interface CapitalTokenTypeValueTimestamp {
@@ -377,11 +390,44 @@ export const algorithmTradeSlice = createAppSlice({
                     state.ncavDailyList.scanDate = action.payload?.meta?.scanDate ?? null;
                     state.ncavDailyList.total = action.payload?.meta?.total ?? 0;
                     state.ncavDailyList.state = "fulfilled";
+                    const scanDate = action.payload?.meta?.scanDate;
+                    if (scanDate && !state.ncavDailyDates.dates.find(d => d.scan_date === scanDate)) {
+                        const merged = [...state.ncavDailyDates.dates, { scan_date: scanDate, cnt: action.payload?.meta?.total ?? 0 }];
+                        state.ncavDailyDates.dates = merged.sort((a, b) => b.scan_date.localeCompare(a.scan_date));
+                    }
                 },
                 rejected: (state, action) => {
                     state.ncavDailyList.state = "rejected";
                     state.ncavDailyList.error = action.error?.message ?? null;
                 },
+            }
+        ),
+        reqDiscoverNcavDates: create.asyncThunk(
+            async (baseDate: string) => {
+                const datesToProbe = Array.from({ length: 7 }, (_, i) => addDays(baseDate, -(i + 1)));
+                const results = await Promise.allSettled(datesToProbe.map(d => checkNcavDailyDate(d)));
+                const found: NcavDailyDateItem[] = [];
+                for (let i = 0; i < results.length; i++) {
+                    const r = results[i];
+                    if (r.status === 'fulfilled' && r.value?.success && r.value?.data?.length > 0) {
+                        found.push({
+                            scan_date: r.value.meta?.scanDate ?? datesToProbe[i],
+                            cnt: r.value.meta?.total ?? r.value.data.length,
+                        });
+                    }
+                }
+                return found;
+            },
+            {
+                pending: () => {},
+                fulfilled: (state, action) => {
+                    const existing = state.ncavDailyDates.dates;
+                    const added = action.payload.filter(d => !existing.find(e => e.scan_date === d.scan_date));
+                    if (added.length > 0) {
+                        state.ncavDailyDates.dates = [...existing, ...added].sort((a, b) => b.scan_date.localeCompare(a.scan_date));
+                    }
+                },
+                rejected: () => {},
             }
         ),
     }),
@@ -417,6 +463,7 @@ export const {
     setNcavDailySelectedDate,
     reqGetNcavDailyDates,
     reqGetNcavDailyList,
+    reqDiscoverNcavDates,
 } = algorithmTradeSlice.actions;
 
 export const { 


### PR DESCRIPTION
## Summary

- `/ncav/daily/dates` 엔드포인트 미배포 상태에서도 날짜 드롭다운이 올바르게 채워지도록 클라이언트 사이드 date auto-discovery 구현
- `reqGetNcavDailyList` fulfilled 시 반환된 `scanDate`를 `ncavDailyDates.dates` 배열에 자동 추가
- `reqDiscoverNcavDates` 신규 thunk: 최신 scanDate 기준 7일 이전 날짜를 병렬로 탐색하여 데이터 있는 날짜만 드롭다운에 추가
- `checkNcavDailyDate` API 추가 (limit=1로 날짜 존재 여부만 확인)
- `page.tsx`: `hasDiscovered` ref로 한 번만 탐색 실행, dates.length < 2일 때 자동 트리거

## Test plan

- [ ] algorithm-trade 페이지 접속 시 NCAV 일별 스캔 결과 날짜 드롭다운에 20260601, 20260602 모두 표시 확인
- [ ] 날짜 선택 시 해당 일자 데이터 로드 확인
- [ ] `/ncav/daily/dates` 엔드포인트 배포 후에도 정상 동작 확인 (dates.length >= 2면 discovery skip)

https://claude.ai/code/session_01R6miGDmYGnidXdbPdeRbdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01R6miGDmYGnidXdbPdeRbdi)_