### PR TITLE
fix(algorithm-trade): 일별 스캔 날짜 버튼 중복 표시 버그 수정

### DIFF
--- a/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
+++ b/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
@@ -866,7 +866,7 @@ function AlgorithmTradeContent() {
                         {/* 날짜 선택 */}
                         <div className="flex items-center gap-2 flex-wrap">
                             {(() => {
-                                const latestScanDate = ncavDailyList.scanDate;
+                                const latestScanDate = ncavDailyDates.dates[0]?.scan_date ?? ncavDailyList.scanDate;
                                 const fmtDate = (d: string) =>
                                     d.length === 8
                                         ? `${d.slice(0, 4)}-${d.slice(4, 6)}-${d.slice(6, 8)}`

--- a/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeSlice.tsx
+++ b/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeSlice.tsx
@@ -373,8 +373,10 @@ export const algorithmTradeSlice = createAppSlice({
                 pending: (state) => { state.ncavDailyDates.state = "pending"; state.ncavDailyDates.error = null; },
                 fulfilled: (state, action) => {
                     const raw: NcavDailyDateItem[] = action.payload?.data ?? [];
+                    const seen = new Set<string>();
                     state.ncavDailyDates.dates = raw
                         .map(d => ({ ...d, scan_date: normalizeDate(d.scan_date) }))
+                        .filter(d => { if (seen.has(d.scan_date)) return false; seen.add(d.scan_date); return true; })
                         .sort((a, b) => b.scan_date.localeCompare(a.scan_date));
                     state.ncavDailyDates.state = "fulfilled";
                 },


### PR DESCRIPTION
## Summary

- `latestScanDate`를 `ncavDailyList.scanDate`(마지막 fetch 날짜) → `ncavDailyDates.dates[0]?.scan_date`(정렬된 목록의 실제 최신 날짜)로 변경
- 날짜 API 응답에 중복 항목이 있을 경우 dedup 처리 추가 (방어적 fix)

**버그 재현 흐름:**
1. 초기 로드 → `latestScanDate = "20260602"` → 최신 버튼 정상 표시
2. 과거 날짜 클릭 → API 응답으로 `ncavDailyList.scanDate = "20260601"` 로 변경
3. `latestScanDate`가 "20260601"로 바뀌며 "20260602"가 `otherDates`에 재등장 → 중복 버튼 생성
4. 반복할수록 버튼이 계속 늘어나는 현상

## Test plan

- [ ] 최신 날짜 버튼 선택 후 과거 날짜 클릭 시 날짜 버튼 목록이 변하지 않는지 확인
- [ ] 여러 날짜를 번갈아 클릭해도 버튼이 중복 생성되지 않는지 확인
- [ ] 수동 날짜 입력 후 검색해도 날짜 버튼 목록이 정상인지 확인

https://claude.ai/code/session_01XVQXLLyiNsZH1VBPCfj797

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVQXLLyiNsZH1VBPCfj797)_