### PR TITLE
fix(algorithm-trade): 전략 기준 보기 항상 활성화되도록 수정

### DIFF
--- a/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
+++ b/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
@@ -1029,23 +1029,17 @@ function AlgorithmTradeContent() {
                                 <span className="text-[10px] font-black text-zinc-400 uppercase tracking-wider w-12 shrink-0">전략</span>
                                 <button
                                     onClick={() => setStrategyFilterOn(p => !p)}
-                                    disabled={quantRule.state !== "fulfilled"}
-                                    title={quantRule.state !== "fulfilled" ? "전략 설정 로딩 중..." : undefined}
                                     className={cn(
                                         "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold border transition-all",
                                         strategyFilterOn
                                             ? "bg-violet-600 border-violet-600 text-white shadow-sm"
-                                            : quantRule.state !== "fulfilled"
-                                                ? "bg-zinc-100 dark:bg-zinc-800 border-zinc-200 dark:border-zinc-700 text-zinc-400 cursor-not-allowed"
-                                                : "bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 hover:border-zinc-400"
+                                            : "bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800 text-zinc-500 dark:text-zinc-400 hover:border-zinc-400"
                                     )}
                                 >
                                     전략 기준 보기
-                                    {quantRule.state === "fulfilled" && (
-                                        <span className={cn("text-[9px] font-mono", strategyFilterOn ? "text-violet-200" : "text-zinc-400")}>
-                                            NCAV≥{quantRule.value.ncav_ratio} · PBR≤{quantRule.value.max_pbr} · EPS≥{quantRule.value.min_eps}
-                                        </span>
-                                    )}
+                                    <span className={cn("text-[9px] font-mono", strategyFilterOn ? "text-violet-200" : "text-zinc-400")}>
+                                        NCAV≥{quantRule.value.ncav_ratio} · PBR≤{quantRule.value.max_pbr} · EPS≥{quantRule.value.min_eps}
+                                    </span>
                                 </button>
                             </div>
                         </div>
@@ -1119,7 +1113,7 @@ function AlgorithmTradeContent() {
                                             {filteredDailyList.slice(0, dailyDisplayCount).map((item) => {
                                                 const upsidePct = (Number(item.ncav_ratio) - 1) * 100;
                                                 const isPositive = upsidePct >= 0;
-                                                const qr = strategyFilterOn && quantRule.state === "fulfilled" ? quantRule.value : null;
+                                                const qr = strategyFilterOn ? quantRule.value : null;
                                                 const ncavFail = qr && Number(item.ncav_ratio) < Number(qr.ncav_ratio);
                                                 const pbrFail  = qr && item.pbr !== 0 && Number(item.pbr) > Number(qr.max_pbr);
                                                 const epsFail  = qr && Number(item.eps) < Number(qr.min_eps);


### PR DESCRIPTION
## Summary

- `quantRule.state === "fulfilled"` 조건으로 버튼이 `disabled` 상태에 머물러 작동하지 않던 문제 수정
- 초기 Redux 상태에 기본값(`ncav_ratio: 1.5`, `max_pbr: 1`, `min_eps: 1`)이 이미 있으므로 API 완료 여부와 무관하게 즉시 활성화
- API가 나중에 응답하면 실제 전략 기준값으로 자동 업데이트됨

## Test plan

- [ ] "전략 기준 보기" 버튼 클릭 가능 확인 (비활성화 아님)
- [ ] 토글 ON 시 NCAV/PBR/EPS 미달 셀 하이라이트 확인
- [ ] 버튼에 기준값 표시 (`NCAV≥1.5 · PBR≤1.0 · EPS≥1`) 확인

https://claude.ai/code/session_01XVQXLLyiNsZH1VBPCfj797

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVQXLLyiNsZH1VBPCfj797)_