### PR TITLE
feat: 종목발굴 다중전략 지원 (stock_data_daily 기반)

### DIFF
--- a/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
+++ b/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
@@ -51,6 +51,16 @@ const GRADE_PILL: Record<string, string> = {
 const gradePill = (g: string) =>
     GRADE_PILL[g] ?? "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400";
 
+const STRATEGY_BADGE: Record<string, string> = {
+    ncav:    "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-400",
+    low_pbr: "bg-blue-100 text-blue-700 dark:bg-blue-950/50 dark:text-blue-400",
+    low_per: "bg-orange-100 text-orange-700 dark:bg-orange-950/50 dark:text-orange-400",
+    s_rim:   "bg-violet-100 text-violet-700 dark:bg-violet-950/50 dark:text-violet-400",
+};
+const STRATEGY_LABEL: Record<string, string> = {
+    ncav: "NCAV", low_pbr: "저PBR", low_per: "저PER", s_rim: "S-RIM",
+};
+
 // =========================================================================
 // 전략 프리셋 + 유틸
 // =========================================================================
@@ -67,28 +77,28 @@ interface StrategyPreset {
 
 const STRATEGY_PRESETS: StrategyPreset[] = [
     {
-        id: "ncav", label: "NCAV 전략", desc: "그레이엄 청산가치 기준",
-        criteria: { min_ncav_ratio: 1.5, max_pbr: 1.0, min_eps: 1 },
-        criteriaChips: [{ label: "NCAV 업사이드", value: "≥ 1.5배" }, { label: "PBR", value: "≤ 1.0x" }, { label: "EPS", value: "≥ ₩1" }],
-        columns: ["NCAV 업사이드", "PBR", "EPS"],
+        id: "ncav", label: "NCAV", desc: "그레이엄 청산가치 기준",
+        criteria: { min_ncav_ratio: 1.0 },
+        criteriaChips: [{ label: "NCAV 비율", value: "≥ 1.0x" }],
+        columns: ["NCAV 업사이드"],
     },
     {
-        id: "low_pbr", label: "저PBR 가치", desc: "장부가 대비 저평가 종목",
-        criteria: { max_pbr: 0.7, min_eps: 1 },
-        criteriaChips: [{ label: "PBR", value: "≤ 0.7x" }, { label: "EPS", value: "≥ ₩1" }],
-        columns: ["PBR", "EPS"],
+        id: "low_pbr", label: "저PBR", desc: "PBR 0.5 미만 저평가",
+        criteria: { max_pbr: 0.5 },
+        criteriaChips: [{ label: "PBR", value: "< 0.5x" }],
+        columns: ["PBR"],
     },
     {
-        id: "stable", label: "안정 수익", desc: "수익성·저평가 동시 충족",
-        criteria: { max_per: 15, max_pbr: 1.5, min_eps: 1 },
-        criteriaChips: [{ label: "PER", value: "≤ 15x" }, { label: "PBR", value: "≤ 1.5x" }, { label: "EPS", value: "≥ ₩1" }],
-        columns: ["PER", "PBR", "EPS"],
+        id: "low_per", label: "저PER", desc: "PER 10 미만 수익성 종목",
+        criteria: { max_per: 10 },
+        criteriaChips: [{ label: "PER", value: "< 10x" }],
+        columns: ["PER"],
     },
     {
-        id: "deep_value", label: "딥밸류", desc: "PBR 0.5 이하 극단적 저평가",
-        criteria: { max_pbr: 0.5, min_eps: 1 },
-        criteriaChips: [{ label: "PBR", value: "≤ 0.5x" }, { label: "EPS", value: "≥ ₩1" }],
-        columns: ["PBR", "EPS"],
+        id: "s_rim", label: "S-RIM", desc: "ROE > 8% & PBR < 1.0 복합 가치",
+        criteria: {},
+        criteriaChips: [{ label: "ROE", value: "> 8%" }, { label: "PBR", value: "< 1.0x" }],
+        columns: ["ROE", "PBR"],
     },
 ];
 
@@ -409,7 +419,6 @@ function AlgorithmTradeContent() {
     const [mainTab, setMainTab] = useState<"discovery" | "strategy">("discovery");
     const [marketTab, setMarketTab] = useState<"kr" | "us">("kr");
     const [activeStrategyId, setActiveStrategyId] = useState<string | null>(null);
-    const [excludeByStrategy, setExcludeByStrategy] = useState(false);
     const [excludeHoldings, setExcludeHoldings] = useState(false);
     const [excludeJiju, setExcludeJiju] = useState(false);
     const [excludePreferred, setExcludePreferred] = useState(false);
@@ -488,18 +497,11 @@ function AlgorithmTradeContent() {
         if (excludeDeficit)   list = list.filter(item => safeNum(item.eps) > 0);
         if (ncavPositiveOnly) list = list.filter(item => safeNum(item.ncav_ratio) >= 1);
         if (minMarketCap > 0) list = list.filter(item => safeNum(item.market_cap) >= minMarketCap);
-        if (excludeByStrategy && activePreset) {
-            const c = activePreset.criteria;
-            list = list.filter(item => {
-                if (c.min_ncav_ratio !== undefined && safeNum(item.ncav_ratio) < c.min_ncav_ratio) return false;
-                if (c.max_pbr !== undefined && safeNum(item.pbr) > 0 && safeNum(item.pbr) > c.max_pbr) return false;
-                if (c.min_eps !== undefined && safeNum(item.eps) < c.min_eps) return false;
-                if (c.max_per !== undefined && safeNum(item.per) > 0 && safeNum(item.per) > c.max_per) return false;
-                return true;
-            });
+        if (activeStrategyId) {
+            list = list.filter(item => (item.strategies ?? []).includes(activeStrategyId));
         }
         return list;
-    }, [ncavDailyList.list, excludeHoldings, excludeJiju, excludePreferred, excludeSpac, excludeDeficit, ncavPositiveOnly, minMarketCap, excludeByStrategy, activePreset]);
+    }, [ncavDailyList.list, excludeHoldings, excludeJiju, excludePreferred, excludeSpac, excludeDeficit, ncavPositiveOnly, minMarketCap, activeStrategyId]);
 
     const krCandidateEntries = useMemo(() => {
         if (!activeStrategy?.candidates) return [] as [string, any][];
@@ -980,6 +982,10 @@ function AlgorithmTradeContent() {
                                     </button>
                                     {otherDates.map(d => {
                                         const isSelected = ncavDailySelectedDate === d.scan_date;
+                                        const stratCnt = activeStrategyId
+                                            ? (d as any)[`${activeStrategyId}_cnt`] ?? null
+                                            : null;
+                                        const displayCnt = stratCnt !== null ? stratCnt : d.total_cnt ?? d.cnt;
                                         return (
                                             <button
                                                 key={d.scan_date}
@@ -997,7 +1003,7 @@ function AlgorithmTradeContent() {
                                             >
                                                 {fmtDate(d.scan_date)}
                                                 <span className={cn("text-[10px] font-mono", isSelected ? "text-indigo-200" : "text-zinc-400")}>
-                                                    {d.cnt}개
+                                                    {displayCnt}개
                                                 </span>
                                             </button>
                                         );
@@ -1090,12 +1096,7 @@ function AlgorithmTradeContent() {
                                         <button
                                             key={preset.id}
                                             onClick={() => {
-                                                if (activeStrategyId === preset.id) {
-                                                    setActiveStrategyId(null);
-                                                    setExcludeByStrategy(false);
-                                                } else {
-                                                    setActiveStrategyId(preset.id);
-                                                }
+                                                setActiveStrategyId(p => p === preset.id ? null : preset.id);
                                                 setDailyDisplayCount(DAILY_PAGE_SIZE);
                                             }}
                                             className={cn(
@@ -1114,42 +1115,25 @@ function AlgorithmTradeContent() {
 
                         {/* 전략 기준 배너 */}
                         {activePreset && (
-                            <div className="bg-violet-50 dark:bg-violet-950/20 border border-violet-200 dark:border-violet-800/40 rounded-xl p-4 space-y-3">
-                                <div>
-                                    <div className="flex items-center gap-2 mb-2">
-                                        <p className="text-[10px] font-black text-violet-600 dark:text-violet-400 uppercase tracking-wider">{activePreset.label}</p>
-                                        <span className="text-[10px] text-zinc-400">— {activePreset.desc}</span>
-                                    </div>
-                                    <div className="flex flex-wrap gap-2">
-                                        {activePreset.criteriaChips.map(({ label, value }) => (
-                                            <div key={label} className="flex items-center gap-1.5 bg-white dark:bg-zinc-900 border border-violet-200 dark:border-violet-800/50 rounded-lg px-3 py-1.5">
-                                                <span className="text-[11px] font-bold text-zinc-500 dark:text-zinc-400">{label}</span>
-                                                <span className="text-[11px] font-black font-mono text-violet-700 dark:text-violet-300">{value}</span>
-                                            </div>
-                                        ))}
-                                    </div>
+                            <div className="bg-violet-50 dark:bg-violet-950/20 border border-violet-200 dark:border-violet-800/40 rounded-xl p-4 space-y-2">
+                                <div className="flex items-center gap-2 flex-wrap">
+                                    <span className={cn("px-2 py-0.5 rounded text-[10px] font-black uppercase", STRATEGY_BADGE[activePreset.id])}>
+                                        {STRATEGY_LABEL[activePreset.id] ?? activePreset.label}
+                                    </span>
+                                    <span className="text-[10px] text-zinc-400">{activePreset.desc}</span>
+                                    <span className="ml-auto text-[10px] font-medium text-violet-600 dark:text-violet-400">
+                                        {filteredDailyList.length}개 종목
+                                    </span>
                                 </div>
-                                <div className="flex flex-wrap items-center gap-4 pt-1 border-t border-violet-100 dark:border-violet-900/40">
-                                    <div className="flex items-center gap-1.5">
-                                        <div className="w-3 h-3 rounded bg-amber-50 dark:bg-amber-950/30 border border-amber-300 dark:border-amber-700 shrink-0" />
-                                        <span className="text-[10px] font-medium text-zinc-500 dark:text-zinc-400">NCAV 기준 미달</span>
-                                    </div>
-                                    <div className="flex items-center gap-1.5">
-                                        <div className="w-3 h-3 rounded bg-red-50 dark:bg-red-950/30 border border-red-300 dark:border-red-700 shrink-0" />
-                                        <span className="text-[10px] font-medium text-zinc-500 dark:text-zinc-400">PBR / EPS / PER 기준 미달</span>
-                                    </div>
-                                    <button
-                                        onClick={() => { setExcludeByStrategy(p => !p); setDailyDisplayCount(DAILY_PAGE_SIZE); }}
-                                        className={cn(
-                                            "flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-[11px] font-bold border transition-all ml-auto",
-                                            excludeByStrategy
-                                                ? "bg-violet-600 border-violet-600 text-white shadow-sm"
-                                                : "bg-white dark:bg-zinc-900 border-violet-200 dark:border-violet-700 text-violet-600 dark:text-violet-400 hover:border-violet-400"
-                                        )}
-                                    >
-                                        {excludeByStrategy ? "기준 미달 제외 중" : "기준 미달 제외"}
-                                    </button>
+                                <div className="flex flex-wrap gap-2">
+                                    {activePreset.criteriaChips.map(({ label, value }) => (
+                                        <div key={label} className="flex items-center gap-1.5 bg-white dark:bg-zinc-900 border border-violet-200 dark:border-violet-800/50 rounded-lg px-3 py-1.5">
+                                            <span className="text-[11px] font-bold text-zinc-500 dark:text-zinc-400">{label}</span>
+                                            <span className="text-[11px] font-black font-mono text-violet-700 dark:text-violet-300">{value}</span>
+                                        </div>
+                                    ))}
                                 </div>
+                                <p className="text-[10px] text-zinc-400 pt-0.5">백엔드 스캔 시 이 조건을 충족한 종목만 표시됩니다.</p>
                             </div>
                         )}
 
@@ -1202,6 +1186,7 @@ function AlgorithmTradeContent() {
                                                 {([
                                                     { label: "티커",          align: "" },
                                                     { label: "종목명",        align: "" },
+                                                    { label: "전략",          align: "" },
                                                     { label: "NCAV 업사이드", align: "text-right" },
                                                     { label: "유동자산(억)",  align: "text-right" },
                                                     { label: "총부채(억)",    align: "text-right" },
@@ -1209,6 +1194,7 @@ function AlgorithmTradeContent() {
                                                     { label: "현재가",        align: "text-right" },
                                                     { label: "PER",           align: "text-right" },
                                                     { label: "PBR",           align: "text-right" },
+                                                    { label: "ROE",           align: "text-right" },
                                                     { label: "EPS",           align: "text-right" },
                                                     { label: "BPS",           align: "text-right" },
                                                 ] as { label: string; align: string }[]).map(({ label, align }) => {
@@ -1234,18 +1220,29 @@ function AlgorithmTradeContent() {
                                             {filteredDailyList.slice(0, dailyDisplayCount).map((item) => {
                                                 const upsidePct = (safeNum(item.ncav_ratio) - 1) * 100;
                                                 const isPositive = upsidePct >= 0;
-                                                const crit = activePreset?.criteria ?? null;
-                                                const ncavFail = crit && crit.min_ncav_ratio !== undefined && safeNum(item.ncav_ratio) < crit.min_ncav_ratio;
-                                                const pbrFail  = crit && crit.max_pbr !== undefined && safeNum(item.pbr) > 0 && safeNum(item.pbr) > crit.max_pbr;
-                                                const epsFail  = crit && crit.min_eps !== undefined && safeNum(item.eps) < crit.min_eps;
-                                                const perFail  = crit && crit.max_per !== undefined && safeNum(item.per) > 0 && safeNum(item.per) > crit.max_per;
+                                                const strategies: string[] = item.strategies ?? [];
+                                                const roePct = item.roe != null ? item.roe * 100 : null;
                                                 return (
                                                     <tr key={item.ticker} className="hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors text-sm">
                                                         <td className="py-3 px-4 font-mono font-black text-zinc-900 dark:text-zinc-100 whitespace-nowrap">{item.ticker}</td>
                                                         <td className="py-3 px-4 text-zinc-700 dark:text-zinc-300 max-w-[160px] truncate">{item.name}</td>
+                                                        <td className="py-3 px-4">
+                                                            <div className="flex flex-wrap gap-1">
+                                                                {strategies.map(s => (
+                                                                    <span key={s} className={cn(
+                                                                        "px-1.5 py-0.5 rounded text-[9px] font-black uppercase",
+                                                                        STRATEGY_BADGE[s] ?? "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400"
+                                                                    )}>
+                                                                        {STRATEGY_LABEL[s] ?? s}
+                                                                    </span>
+                                                                ))}
+                                                                {strategies.length === 0 && (
+                                                                    <span className="text-[10px] text-zinc-300 dark:text-zinc-600">—</span>
+                                                                )}
+                                                            </div>
+                                                        </td>
                                                         <td className={cn(
                                                             "py-3 px-4 text-right font-mono font-black whitespace-nowrap",
-                                                            ncavFail ? "bg-amber-50 dark:bg-amber-950/30" : "",
                                                             isPositive ? "text-emerald-600 dark:text-emerald-400" : "text-red-500 dark:text-red-400"
                                                         )}>
                                                             {isPositive ? "+" : ""}{upsidePct.toFixed(1)}%
@@ -1262,22 +1259,16 @@ function AlgorithmTradeContent() {
                                                         <td className="py-3 px-4 text-right font-mono text-zinc-700 dark:text-zinc-300 whitespace-nowrap">
                                                             {safeNum(item.last_price) > 0 ? `₩${safeNum(item.last_price).toLocaleString()}` : "—"}
                                                         </td>
-                                                        <td className={cn(
-                                                            "py-3 px-4 text-right font-mono whitespace-nowrap",
-                                                            perFail ? "bg-red-50 dark:bg-red-950/30 text-red-500 dark:text-red-400" : "text-zinc-500 dark:text-zinc-400"
-                                                        )}>
+                                                        <td className="py-3 px-4 text-right font-mono text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
                                                             {safeNum(item.per) === 0 ? "—" : `${safeNum(item.per).toFixed(1)}x`}
                                                         </td>
-                                                        <td className={cn(
-                                                            "py-3 px-4 text-right font-mono whitespace-nowrap",
-                                                            pbrFail ? "bg-red-50 dark:bg-red-950/30 text-red-500 dark:text-red-400" : "text-zinc-500 dark:text-zinc-400"
-                                                        )}>
+                                                        <td className="py-3 px-4 text-right font-mono text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
                                                             {safeNum(item.pbr) === 0 ? "—" : `${safeNum(item.pbr).toFixed(2)}x`}
                                                         </td>
-                                                        <td className={cn(
-                                                            "py-3 px-4 text-right font-mono text-xs whitespace-nowrap",
-                                                            epsFail ? "bg-red-50 dark:bg-red-950/30 text-red-500 dark:text-red-400" : "text-zinc-500 dark:text-zinc-400"
-                                                        )}>
+                                                        <td className="py-3 px-4 text-right font-mono text-zinc-500 dark:text-zinc-400 whitespace-nowrap">
+                                                            {roePct === null ? "—" : `${roePct.toFixed(1)}%`}
+                                                        </td>
+                                                        <td className="py-3 px-4 text-right font-mono text-zinc-500 dark:text-zinc-400 text-xs whitespace-nowrap">
                                                             {safeNum(item.eps).toLocaleString()}
                                                         </td>
                                                         <td className="py-3 px-4 text-right font-mono text-zinc-500 dark:text-zinc-400 text-xs whitespace-nowrap">

--- a/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeAPI.tsx
+++ b/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeAPI.tsx
@@ -43,19 +43,20 @@ export const getQuantRuleDesc: any = async () => {
     return getAlgorithmTradeRequest(subUrl, additionalHeaders);
 }
 
-export const getNcavDailyList: any = async (date?: string) => {
+export const getScanDailyList: any = async (date?: string, strategy?: string) => {
     const dateParam = date ?? "latest";
-    const subUrl = `/ncav/daily?date=${encodeURIComponent(dateParam)}&min_ratio=0&limit=200`;
+    const strategyParam = strategy ?? "all";
+    const subUrl = `/scan/daily?date=${encodeURIComponent(dateParam)}&strategy=${strategyParam}&limit=300&sort=ncav_ratio&order=desc`;
     return getAlgorithmTradeRequest(subUrl);
 }
 
-export const getNcavDailyDates: any = async () => {
-    const subUrl = `/ncav/daily/dates`;
+export const getScanDailyDates: any = async () => {
+    const subUrl = `/scan/daily/dates`;
     return getAlgorithmTradeRequest(subUrl);
 }
 
-export const checkNcavDailyDate: any = async (date: string) => {
-    const subUrl = `/ncav/daily?date=${encodeURIComponent(date)}&min_ratio=0&limit=1`;
+export const checkScanDailyDate: any = async (date: string) => {
+    const subUrl = `/scan/daily?date=${encodeURIComponent(date)}&strategy=all&limit=1`;
     return getAlgorithmTradeRequest(subUrl);
 }
 

--- a/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeSlice.tsx
+++ b/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeSlice.tsx
@@ -1,15 +1,15 @@
 import { PayloadAction } from "@reduxjs/toolkit";
 import { createAppSlice } from "@/lib/createAppSlice";
-import { 
-    getCapitalToken, 
-    getKrPurchaseLogLatest, 
-    getQuantRule, 
-    getQuantRuleDesc, 
-    getUsCapitalToken, 
+import {
+    getCapitalToken,
+    getKrPurchaseLogLatest,
+    getQuantRule,
+    getQuantRuleDesc,
+    getUsCapitalToken,
     getUsPurchaseLogLatest,
-    getNcavDailyList,
-    getNcavDailyDates,
-    checkNcavDailyDate,
+    getScanDailyList,
+    getScanDailyDates,
+    checkScanDailyDate,
 } from "./algorithmTradeAPI";
 
 const DEBUG = false;
@@ -130,7 +130,7 @@ interface StrategyList {
     updatedAt: string;
 }
 
-// --- D1 NCAV Daily 인터페이스 ---
+// --- D1 stock_data_daily 인터페이스 ---
 export interface NcavDailyItem {
     ticker: string;
     name: string;
@@ -145,11 +145,18 @@ export interface NcavDailyItem {
     pbr: number;
     eps: number;
     bps: number;
+    roe: number | null;
+    strategies: string[];
 }
 
 export interface NcavDailyDateItem {
     scan_date: string;
     cnt: number;
+    total_cnt: number;
+    ncav_cnt: number;
+    low_pbr_cnt: number;
+    low_per_cnt: number;
+    s_rim_cnt: number;
 }
 
 export interface NcavDailyState {
@@ -365,17 +372,25 @@ export const algorithmTradeSlice = createAppSlice({
         ),
         reqGetNcavDailyDates: create.asyncThunk(
             async () => {
-                const result = await getNcavDailyDates();
+                const result = await getScanDailyDates();
                 if (result?.success === false) throw new Error(result?.error ?? "API error");
                 return result;
             },
             {
                 pending: (state) => { state.ncavDailyDates.state = "pending"; state.ncavDailyDates.error = null; },
                 fulfilled: (state, action) => {
-                    const raw: NcavDailyDateItem[] = action.payload?.data ?? [];
+                    const raw: any[] = action.payload?.data ?? [];
                     const seen = new Set<string>();
                     state.ncavDailyDates.dates = raw
-                        .map(d => ({ ...d, scan_date: normalizeDate(d.scan_date) }))
+                        .map(d => ({
+                            scan_date: normalizeDate(d.scan_date),
+                            cnt: d.total_cnt ?? d.cnt ?? 0,
+                            total_cnt: d.total_cnt ?? d.cnt ?? 0,
+                            ncav_cnt: d.ncav_cnt ?? 0,
+                            low_pbr_cnt: d.low_pbr_cnt ?? 0,
+                            low_per_cnt: d.low_per_cnt ?? 0,
+                            s_rim_cnt: d.s_rim_cnt ?? 0,
+                        }))
                         .filter(d => { if (seen.has(d.scan_date)) return false; seen.add(d.scan_date); return true; })
                         .sort((a, b) => b.scan_date.localeCompare(a.scan_date));
                     state.ncavDailyDates.state = "fulfilled";
@@ -388,15 +403,20 @@ export const algorithmTradeSlice = createAppSlice({
         ),
         reqGetNcavDailyList: create.asyncThunk(
             async (date?: string) => {
-                const result = await getNcavDailyList(date);
+                const result = await getScanDailyList(date);
                 if (result?.success === false) throw new Error(result?.error ?? "API error");
                 return result;
             },
             {
                 pending: (state) => { state.ncavDailyList.state = "pending"; state.ncavDailyList.error = null; },
                 fulfilled: (state, action) => {
-                    state.ncavDailyList.list = action.payload?.data ?? [];
-                    state.ncavDailyList.scanDate = action.payload?.meta?.scanDate ?? null;
+                    const raw: any[] = action.payload?.data ?? [];
+                    state.ncavDailyList.list = raw.map(item => ({
+                        ...item,
+                        strategies: Array.isArray(item.strategies)
+                            ? item.strategies
+                            : (() => { try { return JSON.parse(item.strategies ?? "[]"); } catch { return []; } })(),
+                    }));
                     state.ncavDailyList.total = action.payload?.meta?.total ?? 0;
                     state.ncavDailyList.state = "fulfilled";
                     const rawScanDate = action.payload?.meta?.scanDate;
@@ -404,7 +424,16 @@ export const algorithmTradeSlice = createAppSlice({
                     if (scanDate) {
                         state.ncavDailyList.scanDate = scanDate;
                         if (!state.ncavDailyDates.dates.find(d => d.scan_date === scanDate)) {
-                            const merged = [...state.ncavDailyDates.dates, { scan_date: scanDate, cnt: action.payload?.meta?.total ?? 0 }];
+                            const total = action.payload?.meta?.total ?? 0;
+                            const merged = [...state.ncavDailyDates.dates, {
+                                scan_date: scanDate,
+                                cnt: total,
+                                total_cnt: total,
+                                ncav_cnt: 0,
+                                low_pbr_cnt: 0,
+                                low_per_cnt: 0,
+                                s_rim_cnt: 0,
+                            }];
                             state.ncavDailyDates.dates = merged.sort((a, b) => b.scan_date.localeCompare(a.scan_date));
                         }
                     }
@@ -418,15 +447,21 @@ export const algorithmTradeSlice = createAppSlice({
         reqDiscoverNcavDates: create.asyncThunk(
             async (baseDate: string) => {
                 const datesToProbe = Array.from({ length: 7 }, (_, i) => addDays(baseDate, -(i + 1)));
-                const results = await Promise.allSettled(datesToProbe.map(d => checkNcavDailyDate(d)));
+                const results = await Promise.allSettled(datesToProbe.map(d => checkScanDailyDate(d)));
                 const found: NcavDailyDateItem[] = [];
                 for (let i = 0; i < results.length; i++) {
                     const r = results[i];
                     if (r.status === 'fulfilled' && r.value?.success && r.value?.data?.length > 0) {
                         const sd = r.value.meta?.scanDate ?? datesToProbe[i];
+                        const total = r.value.meta?.total ?? r.value.data.length;
                         found.push({
                             scan_date: normalizeDate(sd),
-                            cnt: r.value.meta?.total ?? r.value.data.length,
+                            cnt: total,
+                            total_cnt: total,
+                            ncav_cnt: 0,
+                            low_pbr_cnt: 0,
+                            low_per_cnt: 0,
+                            s_rim_cnt: 0,
                         });
                     }
                 }


### PR DESCRIPTION
## Summary

- 백엔드의 `stock_data_daily` 확장에 맞춰 종목발굴 기능을 다중전략 지원으로 전환
- API 엔드포인트를 `/ncav/daily` → `/scan/daily`로 교체, 4가지 전략 필터 지원
- 전략 배지 컬럼·ROE 컬럼 추가, 날짜별 전략 종목 수 표시

## 변경 파일

### `algorithmTradeAPI.tsx`
- `getNcavDailyList/Dates/checkNcavDailyDate` → `getScanDailyList/Dates/checkScanDailyDate`
- 엔드포인트: `/scan/daily?strategy=all&limit=300`, `/scan/daily/dates`

### `algorithmTradeSlice.tsx`
- `NcavDailyItem`: `strategies: string[]`, `roe: number | null` 필드 추가
- `NcavDailyDateItem`: `total_cnt`, `ncav_cnt`, `low_pbr_cnt`, `low_per_cnt`, `s_rim_cnt` 추가
- D1 JSON 문자열 `strategies` 자동 파싱 처리

### `page.tsx`
- **전략 프리셋** 백엔드 기준으로 재정의: NCAV(≥1.0x) · 저PBR(<0.5x) · 저PER(<10x) · S-RIM(ROE>8%&PBR<1.0x)
- **필터링**: `item.strategies.includes(strategyId)` 기반 클라이언트 필터 (API 재요청 없음)
- **전략 배지 컬럼**: 각 종목이 속한 전략을 색상 배지로 표시 (녹=NCAV · 파=저PBR · 주=저PER · 보=S-RIM)
- **ROE 컬럼** 추가
- **날짜 버튼**: 전략 선택 시 해당 전략의 종목 수 표시
- `excludeByStrategy` 토글 제거 (전략 선택 자체가 필터 역할)

## Test plan

- [ ] 종목발굴 탭 진입 시 `/scan/daily?strategy=all` 호출 확인
- [ ] 전략 버튼(NCAV/저PBR/저PER/S-RIM) 클릭 시 해당 전략 배지를 가진 종목만 필터링되는지 확인
- [ ] 전략 컬럼에 배지가 정상 표시되는지 확인
- [ ] ROE 컬럼 표시 확인 (null이면 —)
- [ ] 날짜 버튼에서 전략 선택 시 해당 전략 종목 수로 변경되는지 확인
- [ ] 기존 필터(홀딩스 제외, 시총 필터 등) 정상 동작 확인

https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA)_