### PR TITLE
feat: 전략 필터 AND/OR 전환 + 초기화 버튼 위치 개선

### DIFF
--- a/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
+++ b/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
@@ -428,6 +428,7 @@ function AlgorithmTradeContent() {
     const [mainTab, setMainTab] = useState<"discovery" | "strategy">("discovery");
     const [marketTab, setMarketTab] = useState<"kr" | "us">("kr");
     const [activeStrategyIds, setActiveStrategyIds] = useState<string[]>([]);
+    const [strategyCondition, setStrategyCondition] = useState<"or" | "and">("or");
     const [excludeHoldings, setExcludeHoldings] = useState(false);
     const [excludeJiju, setExcludeJiju] = useState(false);
     const [excludePreferred, setExcludePreferred] = useState(false);
@@ -502,7 +503,7 @@ function AlgorithmTradeContent() {
     }, []);
 
     const clearAllFilters = useCallback(() => {
-        setActiveStrategyIds([]);
+        setActiveStrategyIds([]); setStrategyCondition("or");
         setMinNcavRatio(""); setMaxPbr(""); setMaxPer(""); setMinRoe("");
         setExcludeHoldings(false); setExcludeJiju(false); setExcludePreferred(false);
         setExcludeSpac(false); setExcludeDeficit(false); setNcavPositiveOnly(false);
@@ -537,8 +538,12 @@ function AlgorithmTradeContent() {
         if (excludeDeficit)   list = list.filter(item => safeNum(item.eps) > 0);
         if (ncavPositiveOnly) list = list.filter(item => safeNum(item.ncav_ratio) >= 1);
         if (minMarketCap > 0) list = list.filter(item => safeNum(item.market_cap) >= minMarketCap);
-        if (activeStrategyIds.length > 0)
-            list = list.filter(item => (item.strategies ?? []).some(s => activeStrategyIds.includes(s)));
+        if (activeStrategyIds.length > 0) {
+            const strats = item => item.strategies ?? [];
+            list = strategyCondition === "and"
+                ? list.filter(item => activeStrategyIds.every(s => strats(item).includes(s)))
+                : list.filter(item => activeStrategyIds.some(s => strats(item).includes(s)));
+        }
         const nv = minNcavRatio ? parseFloat(minNcavRatio) : null;
         const pb = maxPbr ? parseFloat(maxPbr) : null;
         const pe = maxPer ? parseFloat(maxPer) : null;
@@ -548,7 +553,7 @@ function AlgorithmTradeContent() {
         if (pe !== null && !isNaN(pe)) list = list.filter(item => safeNum(item.per) > 0 && safeNum(item.per) <= pe);
         if (ro !== null && !isNaN(ro)) list = list.filter(item => item.roe !== null && safeNum(item.roe) * 100 >= ro);
         return list;
-    }, [ncavDailyList.list, excludeHoldings, excludeJiju, excludePreferred, excludeSpac, excludeDeficit, ncavPositiveOnly, minMarketCap, activeStrategyIds, minNcavRatio, maxPbr, maxPer, minRoe]);
+    }, [ncavDailyList.list, excludeHoldings, excludeJiju, excludePreferred, excludeSpac, excludeDeficit, ncavPositiveOnly, minMarketCap, activeStrategyIds, strategyCondition, minNcavRatio, maxPbr, maxPer, minRoe]);
 
     const krCandidateEntries = useMemo(() => {
         if (!activeStrategy?.candidates) return [] as [string, any][];
@@ -1099,9 +1104,16 @@ function AlgorithmTradeContent() {
                                     )}
                                     {!filterPanelOpen && activeFilterCount > 0 && (
                                         <div className="flex flex-wrap gap-1 min-w-0">
-                                            {activeStrategyIds.map(id => (
-                                                <span key={id} className={cn("px-1.5 py-0.5 rounded text-[9px] font-black shrink-0", STRATEGY_BADGE[id])}>
-                                                    {STRATEGY_LABEL[id]}
+                                            {activeStrategyIds.map((id, i) => (
+                                                <span key={id} className="flex items-center gap-1 shrink-0">
+                                                    <span className={cn("px-1.5 py-0.5 rounded text-[9px] font-black", STRATEGY_BADGE[id])}>
+                                                        {STRATEGY_LABEL[id]}
+                                                    </span>
+                                                    {i < activeStrategyIds.length - 1 && (
+                                                        <span className="text-[9px] font-black text-zinc-400 dark:text-zinc-500">
+                                                            {strategyCondition.toUpperCase()}
+                                                        </span>
+                                                    )}
                                                 </span>
                                             ))}
                                             {minNcavRatio && <span className="px-1.5 py-0.5 rounded text-[9px] font-mono font-bold bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300 shrink-0">NCAV≥{minNcavRatio}</span>}
@@ -1111,16 +1123,7 @@ function AlgorithmTradeContent() {
                                         </div>
                                     )}
                                 </div>
-                                <div className="flex items-center gap-3 shrink-0 ml-2">
-                                    {activeFilterCount > 0 && (
-                                        <span
-                                            role="button"
-                                            onClick={e => { e.stopPropagation(); clearAllFilters(); }}
-                                            className="text-[11px] text-zinc-400 hover:text-red-500 font-medium transition-colors"
-                                        >
-                                            초기화
-                                        </span>
-                                    )}
+                                <div className="shrink-0 ml-2">
                                     {filterPanelOpen
                                         ? <ChevronUp className="w-4 h-4 text-zinc-400" />
                                         : <ChevronDown className="w-4 h-4 text-zinc-400" />
@@ -1132,11 +1135,47 @@ function AlgorithmTradeContent() {
                             {filterPanelOpen && (
                                 <div className="border-t border-zinc-100 dark:border-zinc-800 divide-y divide-zinc-100 dark:divide-zinc-800">
 
-                                    {/* 전략 (다중 선택 OR) */}
+                                    {/* 활성 필터 수 + 초기화 */}
+                                    {activeFilterCount > 0 && (
+                                        <div className="px-4 py-2.5 flex items-center justify-between bg-indigo-50/60 dark:bg-indigo-950/20">
+                                            <span className="text-[11px] font-bold text-indigo-600 dark:text-indigo-400">
+                                                활성 필터 {activeFilterCount}개 적용 중
+                                            </span>
+                                            <button
+                                                onClick={clearAllFilters}
+                                                className="text-[11px] font-bold text-indigo-400 hover:text-red-500 dark:text-indigo-500 dark:hover:text-red-400 transition-colors"
+                                            >
+                                                모두 초기화
+                                            </button>
+                                        </div>
+                                    )}
+
+                                    {/* 전략 (다중 선택, OR / AND 전환) */}
                                     <div className="px-4 py-3.5 flex items-start gap-4">
                                         <div className="w-14 shrink-0 pt-1">
                                             <p className="text-[10px] font-black text-zinc-400 uppercase tracking-wider">전략</p>
-                                            <p className="text-[9px] text-zinc-300 dark:text-zinc-600 mt-0.5">OR 조건</p>
+                                            {/* OR / AND 토글 */}
+                                            {activeStrategyIds.length >= 2 && (
+                                                <div className="flex items-center mt-1.5 rounded-md border border-zinc-200 dark:border-zinc-700 overflow-hidden w-fit">
+                                                    {(["or", "and"] as const).map(cond => (
+                                                        <button
+                                                            key={cond}
+                                                            onClick={() => setStrategyCondition(cond)}
+                                                            className={cn(
+                                                                "px-1.5 py-0.5 text-[9px] font-black uppercase transition-colors",
+                                                                strategyCondition === cond
+                                                                    ? "bg-indigo-600 text-white"
+                                                                    : "text-zinc-400 dark:text-zinc-500 hover:text-zinc-600 dark:hover:text-zinc-300"
+                                                            )}
+                                                        >
+                                                            {cond}
+                                                        </button>
+                                                    ))}
+                                                </div>
+                                            )}
+                                            {activeStrategyIds.length < 2 && (
+                                                <p className="text-[9px] text-zinc-300 dark:text-zinc-600 mt-0.5">다중 선택</p>
+                                            )}
                                         </div>
                                         <div className="flex flex-wrap gap-2">
                                             {STRATEGY_PRESETS.map(preset => {

--- a/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
+++ b/cf-idiotquant/app/(algorithm-trade)/algorithm-trade/page.tsx
@@ -539,10 +539,9 @@ function AlgorithmTradeContent() {
         if (ncavPositiveOnly) list = list.filter(item => safeNum(item.ncav_ratio) >= 1);
         if (minMarketCap > 0) list = list.filter(item => safeNum(item.market_cap) >= minMarketCap);
         if (activeStrategyIds.length > 0) {
-            const strats = item => item.strategies ?? [];
             list = strategyCondition === "and"
-                ? list.filter(item => activeStrategyIds.every(s => strats(item).includes(s)))
-                : list.filter(item => activeStrategyIds.some(s => strats(item).includes(s)));
+                ? list.filter(item => activeStrategyIds.every(s => (item.strategies ?? []).includes(s)))
+                : list.filter(item => activeStrategyIds.some(s => (item.strategies ?? []).includes(s)));
         }
         const nv = minNcavRatio ? parseFloat(minNcavRatio) : null;
         const pb = maxPbr ? parseFloat(maxPbr) : null;


### PR DESCRIPTION
## Summary

- 전략 필터에 **OR / AND 조건 전환** 추가
- **초기화 버튼**을 토글 헤더 우측에서 패널 내부 상단으로 이동 (닫기 버튼과 분리)

## 상세 변경

### AND / OR 전환
- 전략 2개 이상 선택 시 전략 라벨 아래에 `OR` / `AND` 토글 자동 표시
  - **OR**: 선택한 전략 중 하나라도 해당하면 표시 (기존 동작, 기본값)
  - **AND**: 선택한 모든 전략을 동시에 만족하는 종목만 표시
- 접힌 상태 요약 칩에 구분자 표시: `NCAV OR 저PBR`, `NCAV AND S-RIM`
- 초기화 시 조건도 OR로 리셋

### 초기화 버튼 위치
- 헤더 우측(닫기 아이콘 옆) → 패널 내부 상단 "활성 필터 N개 적용 중" 바 우측으로 이동
- 활성 필터가 없을 때는 표시되지 않음
- 버튼 텍스트: `초기화` → `모두 초기화`로 명확화

## Test plan

- [ ] 전략 1개 선택 시 OR/AND 토글 미표시 확인
- [ ] 전략 2개 이상 선택 시 OR/AND 토글 표시 확인
- [ ] AND 선택 후 두 전략 모두 해당하는 종목만 남는지 확인
- [ ] OR ↔ AND 전환 시 목록 즉시 갱신 확인
- [ ] 접힌 상태 요약 칩에 OR/AND 구분자 표시 확인
- [ ] "모두 초기화" 클릭 시 조건도 OR로 초기화 확인
- [ ] 초기화 버튼이 닫기(^) 버튼과 분리되어 표시되는지 확인

https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA)_