### PR TITLE
fix: 모바일 input 포커스 시 화면 자동 확대 방지

### DIFF
--- a/cf-idiotquant/app/layout.tsx
+++ b/cf-idiotquant/app/layout.tsx
@@ -1,4 +1,12 @@
 import "@/app/global.css";
+import type { Viewport } from "next";
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+};
 import { StoreProvider } from "./StoreProvider";
 import NavbarWithSimpleLinks from "@/components/navigation";
 import { ThemeProviderClient } from "./ThemeProviderClient";


### PR DESCRIPTION
## Summary

- `app/layout.tsx`에 Next.js `Viewport` export 추가
- `maximumScale: 1`, `userScalable: false` 설정

## 원인

iOS Safari는 `font-size < 16px`인 input에 포커스할 때 자동으로 화면을 확대함. 앱 전체의 수치 필터 입력창 등이 작은 폰트를 사용하고 있어 클릭 시 확대 발생.

## Test plan

- [ ] 모바일(iOS Safari / Android Chrome)에서 수치 필터 input 탭 시 화면 확대 없음 확인
- [ ] 검색창, 기타 input 포커스 시 동일하게 확대 없음 확인

https://claude.ai/code/session_01KgcgHqnKu48Mu4hNAt4ntg

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgcgHqnKu48Mu4hNAt4ntg)_