### PR TITLE
feat: 온보딩 유입 개선 + 스크리너 가독성 향상

### DIFF
--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useRef, useState, useEffect } from "react";
+import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import {
   Search, Calculator, BarChart3, Lock, ArrowRight,
-  TrendingUp, ChevronRight, CheckCircle2, Loader2, Activity,
+  TrendingUp, ChevronRight, CheckCircle2, Loader2, Activity, Sparkles,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -21,6 +22,15 @@ interface PreviewStock {
 const STRATEGY_LABEL: Record<string, string> = {
   ncav: "NCAV", low_pbr: "저PBR", low_per: "저PER", s_rim: "S-RIM",
   graham_number: "그레이엄", magic_formula: "마법공식",
+};
+
+const STRATEGY_BADGE_CLS: Record<string, string> = {
+  ncav: "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-400 border-emerald-200/60 dark:border-emerald-800/50",
+  low_pbr: "bg-blue-50 dark:bg-blue-950/40 text-blue-700 dark:text-blue-400 border-blue-200/60 dark:border-blue-800/50",
+  low_per: "bg-orange-50 dark:bg-orange-950/40 text-orange-700 dark:text-orange-400 border-orange-200/60 dark:border-orange-800/50",
+  s_rim: "bg-violet-50 dark:bg-violet-950/40 text-violet-700 dark:text-violet-400 border-violet-200/60 dark:border-violet-800/50",
+  graham_number: "bg-teal-50 dark:bg-teal-950/40 text-teal-700 dark:text-teal-400 border-teal-200/60 dark:border-teal-800/50",
+  magic_formula: "bg-rose-50 dark:bg-rose-950/40 text-rose-700 dark:text-rose-400 border-rose-200/60 dark:border-rose-800/50",
 };
 
 const HOW_IT_WORKS = [
@@ -47,8 +57,56 @@ const HOW_IT_WORKS = [
   },
 ];
 
+function StockPreviewRow({ item }: { item: PreviewStock }) {
+  const ncav = item.ncav_ratio;
+  return (
+    <div className="flex items-center gap-3 px-5 py-3.5 border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <p className="font-bold text-sm text-zinc-900 dark:text-white">{item.name}</p>
+          {item.strategies.slice(0, 2).map(s => (
+            <span key={s} className={cn(
+              "text-[9px] font-extrabold px-1.5 py-0.5 rounded border",
+              STRATEGY_BADGE_CLS[s] ?? "bg-zinc-100 text-zinc-500 border-zinc-200"
+            )}>
+              {STRATEGY_LABEL[s] ?? s}
+            </span>
+          ))}
+        </div>
+        <p className="text-[10px] text-zinc-400 font-mono mt-0.5">{item.ticker}</p>
+      </div>
+      <div className="flex items-center gap-4 shrink-0">
+        <div className="text-right hidden sm:block">
+          <p className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider">PBR</p>
+          <p className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
+            {item.pbr > 0 ? `${item.pbr.toFixed(2)}x` : "—"}
+          </p>
+        </div>
+        <div className="text-right hidden sm:block">
+          <p className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider">PER</p>
+          <p className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
+            {item.per > 0 ? `${item.per.toFixed(1)}x` : "—"}
+          </p>
+        </div>
+        <div className="text-right">
+          <p className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider">NCAV</p>
+          <p className={cn(
+            "text-sm font-black font-mono",
+            ncav >= 1 ? "text-emerald-600 dark:text-emerald-400" :
+            ncav >= 0.7 ? "text-amber-600 dark:text-amber-400" : "text-zinc-400"
+          )}>
+            {ncav > 0 ? `${ncav.toFixed(2)}x` : "—"}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function HomePage() {
   const heroRef = useRef<HTMLDivElement>(null);
+  const { data: session } = useSession();
+  const isLoggedIn = !!session;
 
   const [preview, setPreview] = useState<{
     items: PreviewStock[];
@@ -70,6 +128,12 @@ export default function HomePage() {
       .catch(() => setPreview(p => ({ ...p, loading: false })));
   }, []);
 
+  const publicItems = preview.items.slice(0, 3);
+  const lockedItems = preview.items.slice(3);
+  const formattedDate = preview.scanDate
+    ? `${preview.scanDate.slice(0, 4)}.${preview.scanDate.slice(4, 6)}.${preview.scanDate.slice(6, 8)}`
+    : null;
+
   return (
     <div className="min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-50 antialiased">
 
@@ -89,7 +153,7 @@ export default function HomePage() {
           transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
           className="max-w-3xl mx-auto text-center"
         >
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-blue-500/8 border border-blue-500/20 mb-8">
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-blue-500/8 border border-blue-500/20 mb-6">
             <Activity size={11} className="text-blue-500 animate-pulse" />
             <span className="text-[11px] font-extrabold text-blue-600 dark:text-blue-400 uppercase tracking-[0.18em]">
               KOSPI · KOSDAQ &nbsp;·&nbsp; 매일 자동 스캔
@@ -103,19 +167,52 @@ export default function HomePage() {
             </span>
           </h1>
 
-          <p className="text-zinc-500 dark:text-zinc-400 text-base md:text-lg font-medium leading-relaxed mb-8 max-w-xl mx-auto">
+          <p className="text-zinc-500 dark:text-zinc-400 text-base md:text-lg font-medium leading-relaxed mb-6 max-w-xl mx-auto">
             벤자민 그레이엄의 NCAV 원칙 기반 퀀트 스크리너.
             <br className="hidden md:block" />
             감이 아닌 데이터로 저평가 종목을 발굴하세요.
           </p>
 
+          {/* 실시간 발굴 수 — 데이터 로드 후 등장 */}
+          <div className="min-h-[36px] flex justify-center mb-6">
+            {!preview.loading && preview.total > 0 && (
+              <motion.div
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ duration: 0.4 }}
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-200/70 dark:border-emerald-800/50"
+              >
+                <Sparkles size={12} className="text-emerald-600 dark:text-emerald-400" />
+                <span className="text-sm font-bold text-emerald-700 dark:text-emerald-400">
+                  오늘 <span className="font-black text-emerald-800 dark:text-emerald-300">{preview.total}개</span> 저평가 종목 발견
+                  {formattedDate && <span className="text-emerald-600/70 dark:text-emerald-500/70 font-medium ml-1.5">· {formattedDate}</span>}
+                </span>
+              </motion.div>
+            )}
+            {preview.loading && (
+              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
+                <Loader2 size={12} className="animate-spin text-zinc-400" />
+                <span className="text-sm text-zinc-400 font-medium">오늘의 종목 집계 중...</span>
+              </div>
+            )}
+          </div>
+
           <div className="flex flex-wrap justify-center gap-3 mb-7">
-            <Link href="/login"
-              className="group inline-flex items-center gap-2 px-6 py-3 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-bold shadow-lg shadow-blue-600/25 transition-all"
-            >
-              무료로 시작하기
-              <ArrowRight size={15} className="group-hover:translate-x-0.5 transition-transform" />
-            </Link>
+            {isLoggedIn ? (
+              <Link href="/screener"
+                className="group inline-flex items-center gap-2 px-6 py-3 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-bold shadow-lg shadow-blue-600/25 transition-all"
+              >
+                종목 발굴하기
+                <ArrowRight size={15} className="group-hover:translate-x-0.5 transition-transform" />
+              </Link>
+            ) : (
+              <Link href="/login"
+                className="group inline-flex items-center gap-2 px-6 py-3 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-bold shadow-lg shadow-blue-600/25 transition-all"
+              >
+                무료로 시작하기
+                <ArrowRight size={15} className="group-hover:translate-x-0.5 transition-transform" />
+              </Link>
+            )}
             <Link href="/analyze"
               className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 text-sm font-bold hover:border-zinc-400 dark:hover:border-zinc-500 transition-all"
             >
@@ -140,22 +237,20 @@ export default function HomePage() {
           initial={{ opacity: 0, y: 16 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          className="mb-5 flex items-end justify-between gap-4"
+          className="mb-4 flex items-end justify-between gap-4"
         >
           <div>
             <h2 className="text-lg font-black tracking-tight">오늘의 발굴 종목</h2>
-            {preview.scanDate && !preview.loading && (
-              <p className="text-xs text-zinc-400 mt-0.5">
-                {preview.scanDate.slice(0, 4)}.{preview.scanDate.slice(4, 6)}.{preview.scanDate.slice(6, 8)} 스캔 기준
-                {preview.total > 0 && <> · 총 <span className="font-bold text-zinc-600 dark:text-zinc-300">{preview.total}개</span></>}
-              </p>
-            )}
+            <p className="text-xs text-zinc-400 mt-0.5">
+              {isLoggedIn ? "로그인 중 · 전체 목록은 스크리너에서 확인하세요" : "상위 3개 무료 공개 · 전체 목록은 로그인 후 확인 가능"}
+            </p>
           </div>
           <Link
-            href="/login"
-            className="shrink-0 flex items-center gap-1 text-xs font-bold text-blue-600 hover:text-blue-700 dark:text-blue-400 transition-colors"
+            href={isLoggedIn ? "/screener" : "/login"}
+            className="shrink-0 flex items-center gap-1 text-xs font-bold text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors whitespace-nowrap"
           >
-            전체 보기 <ChevronRight size={12} />
+            전체 {preview.total > 0 ? `${preview.total}개` : ""} 보기
+            <ChevronRight size={12} />
           </Link>
         </motion.div>
 
@@ -166,15 +261,18 @@ export default function HomePage() {
           transition={{ delay: 0.06 }}
           className="rounded-2xl border border-zinc-200 dark:border-zinc-800 overflow-hidden bg-white dark:bg-zinc-900 shadow-sm"
         >
-          <div className="px-5 py-2.5 bg-zinc-50 dark:bg-zinc-800/60 border-b border-zinc-200 dark:border-zinc-800 hidden sm:grid grid-cols-[1fr_80px_60px_60px] gap-4">
+          {/* 테이블 헤더 */}
+          <div className="px-5 py-2 bg-zinc-50 dark:bg-zinc-800/60 border-b border-zinc-200 dark:border-zinc-800 hidden sm:flex items-center justify-between gap-4">
             <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider">종목</span>
-            <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider text-right">NCAV 비율</span>
-            <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider text-right">PBR</span>
-            <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider text-right">PER</span>
+            <div className="flex items-center gap-6">
+              <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider hidden sm:block">PBR</span>
+              <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider hidden sm:block">PER</span>
+              <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider">NCAV 비율</span>
+            </div>
           </div>
 
           {preview.loading ? (
-            <div className="flex items-center justify-center py-12 gap-2 text-zinc-400">
+            <div className="flex items-center justify-center py-14 gap-2 text-zinc-400">
               <Loader2 size={16} className="animate-spin" />
               <span className="text-sm">불러오는 중...</span>
             </div>
@@ -182,66 +280,53 @@ export default function HomePage() {
             <div className="py-12 text-center text-zinc-400 text-sm">스캔 데이터가 없습니다.</div>
           ) : (
             <>
-              {preview.items.slice(0, 3).map((item) => (
-                <div
-                  key={item.ticker}
-                  className="px-5 py-3 border-b border-zinc-100 dark:border-zinc-800/60 flex sm:grid sm:grid-cols-[1fr_80px_60px_60px] gap-3 sm:gap-4 items-center"
-                >
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-1.5 flex-wrap">
-                      <p className="font-bold text-sm text-zinc-900 dark:text-white truncate">{item.name}</p>
-                      {item.strategies.slice(0, 2).map(s => (
-                        <span key={s} className="text-[9px] font-extrabold px-1.5 py-0.5 rounded bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 border border-blue-200/50 dark:border-blue-800/50">
-                          {STRATEGY_LABEL[s] ?? s}
-                        </span>
-                      ))}
-                    </div>
-                    <p className="text-[10px] text-zinc-400 font-mono mt-0.5">{item.ticker}</p>
-                  </div>
-                  <span className="text-sm font-black tabular-nums text-blue-600 dark:text-blue-400 text-right">
-                    {item.ncav_ratio != null ? `${item.ncav_ratio.toFixed(2)}x` : "-"}
-                  </span>
-                  <span className="text-sm tabular-nums text-zinc-500 text-right hidden sm:block">
-                    {item.pbr != null ? item.pbr.toFixed(2) : "-"}
-                  </span>
-                  <span className="text-sm tabular-nums text-zinc-500 text-right hidden sm:block">
-                    {item.per != null && item.per > 0 ? item.per.toFixed(1) : "-"}
-                  </span>
-                </div>
+              {/* 공개 항목 (항상 표시) */}
+              {publicItems.map(item => (
+                <StockPreviewRow key={item.ticker} item={item} />
               ))}
 
-              {preview.items.length > 3 && (
+              {/* 잠긴 항목 */}
+              {lockedItems.length > 0 && (
                 <div className="relative">
-                  {preview.items.slice(3).map((item) => (
+                  {lockedItems.map(item => (
                     <div
                       key={item.ticker}
-                      className="px-5 py-3 border-b border-zinc-100 dark:border-zinc-800/60 flex sm:grid sm:grid-cols-[1fr_80px_60px_60px] gap-3 sm:gap-4 items-center blur-sm select-none pointer-events-none"
+                      className={cn(
+                        "transition-all duration-300",
+                        !isLoggedIn && "blur-sm select-none pointer-events-none"
+                      )}
                     >
-                      <div className="flex-1 min-w-0">
-                        <p className="font-bold text-sm text-zinc-900 dark:text-white">{item.name}</p>
-                        <p className="text-[10px] text-zinc-400 font-mono mt-0.5">{item.ticker}</p>
-                      </div>
-                      <span className="text-sm font-black tabular-nums text-blue-600 dark:text-blue-400 text-right">
-                        {item.ncav_ratio != null ? `${item.ncav_ratio.toFixed(2)}x` : "-"}
-                      </span>
-                      <span className="text-sm tabular-nums text-zinc-500 text-right hidden sm:block">
-                        {item.pbr != null ? item.pbr.toFixed(2) : "-"}
-                      </span>
-                      <span className="text-sm tabular-nums text-zinc-500 text-right hidden sm:block">
-                        {item.per != null && item.per > 0 ? item.per.toFixed(1) : "-"}
-                      </span>
+                      <StockPreviewRow item={item} />
                     </div>
                   ))}
-                  <div className="absolute inset-0 flex items-center justify-center bg-white/70 dark:bg-zinc-900/70 backdrop-blur-[1px]">
-                    <Link
-                      href="/login"
-                      className="group flex items-center gap-2 px-5 py-2.5 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-extrabold shadow-lg shadow-blue-600/20 transition-all"
-                    >
-                      <Lock size={13} />
-                      로그인하여 전체 {preview.total}개 보기
-                      <ArrowRight size={13} className="group-hover:translate-x-0.5 transition-transform" />
-                    </Link>
-                  </div>
+                  {/* 비로그인 시 오버레이 */}
+                  {!isLoggedIn && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-white/75 dark:bg-zinc-900/75 backdrop-blur-[2px]">
+                      <Link
+                        href="/login"
+                        className="group flex items-center gap-2 px-5 py-2.5 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-extrabold shadow-lg shadow-blue-600/20 transition-all"
+                      >
+                        <Lock size={13} />
+                        로그인하여 전체 {preview.total}개 보기
+                        <ArrowRight size={13} className="group-hover:translate-x-0.5 transition-transform" />
+                      </Link>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* 로그인 후 스크리너 바로가기 CTA */}
+              {isLoggedIn && (
+                <div className="px-5 py-3 bg-blue-50 dark:bg-blue-950/20 border-t border-blue-100 dark:border-blue-900/40 flex items-center justify-between gap-4">
+                  <p className="text-xs text-blue-700 dark:text-blue-400 font-medium">
+                    전체 <span className="font-black">{preview.total}개</span> 종목을 전략 필터와 함께 확인하세요.
+                  </p>
+                  <Link
+                    href="/screener"
+                    className="shrink-0 flex items-center gap-1 text-xs font-bold text-blue-700 dark:text-blue-400 hover:underline"
+                  >
+                    스크리너 열기 <ChevronRight size={11} />
+                  </Link>
                 </div>
               )}
             </>
@@ -303,7 +388,7 @@ export default function HomePage() {
 
           <div className="flex items-center gap-4">
             {[
-              { label: "종목 발굴", href: "/login" },
+              { label: "종목 발굴", href: isLoggedIn ? "/screener" : "/login" },
               { label: "종목 분석", href: "/analyze" },
               { label: "계산기", href: "/calculator" },
             ].map(l => (

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -153,12 +153,12 @@ function TableRow({ item, onClick }: { item: any; onClick: (ticker: string, name
 
     return (
         <div
-            className="group grid grid-cols-[minmax(140px,2fr)_minmax(100px,1fr)_80px_64px_64px_64px_80px] gap-4 items-center px-5 py-3.5 hover:bg-zinc-50 dark:hover:bg-zinc-800/40 cursor-pointer transition-colors"
+            className="group grid grid-cols-[minmax(160px,2.5fr)_minmax(110px,1fr)_88px_68px_68px_68px_88px] gap-4 items-center px-5 py-4 hover:bg-blue-50/40 dark:hover:bg-zinc-800/50 cursor-pointer transition-colors border-b border-zinc-100 dark:border-zinc-800 last:border-0"
             onClick={() => onClick(item.ticker, item.name)}
         >
             <div className="min-w-0">
-                <p className="font-mono font-black text-sm text-zinc-900 dark:text-white tracking-tight">{item.ticker}</p>
-                <p className="text-xs text-zinc-400 truncate font-medium mt-0.5">{item.name}</p>
+                <p className="font-bold text-sm text-zinc-900 dark:text-white truncate leading-tight">{item.name}</p>
+                <p className="text-[11px] text-zinc-400 font-mono mt-0.5 tracking-wider">{item.ticker}</p>
             </div>
 
             <div className="flex flex-wrap gap-1">
@@ -176,7 +176,7 @@ function TableRow({ item, onClick }: { item: any; onClick: (ticker: string, name
 
             <div className="text-right">
                 <span className={cn(
-                    "text-xs font-mono font-bold tabular-nums",
+                    "text-sm font-mono font-black tabular-nums",
                     ncav >= 1 ? "text-emerald-600 dark:text-emerald-400" :
                     ncav >= 0.7 ? "text-amber-500" : "text-zinc-400"
                 )}>
@@ -185,23 +185,24 @@ function TableRow({ item, onClick }: { item: any; onClick: (ticker: string, name
             </div>
 
             <div className="text-right">
-                <span className="text-xs font-mono text-zinc-600 dark:text-zinc-400 tabular-nums">
-                    {safeNum(item.pbr) > 0 ? `${safeNum(item.pbr).toFixed(2)}x` : "—"}
+                <span className="text-sm font-mono text-zinc-600 dark:text-zinc-300 tabular-nums">
+                    {safeNum(item.pbr) > 0 ? `${safeNum(item.pbr).toFixed(2)}` : "—"}
                 </span>
             </div>
 
             <div className="text-right">
-                <span className="text-xs font-mono text-zinc-600 dark:text-zinc-400 tabular-nums">
-                    {safeNum(item.per) > 0 ? `${safeNum(item.per).toFixed(1)}x` : "—"}
+                <span className="text-sm font-mono text-zinc-600 dark:text-zinc-300 tabular-nums">
+                    {safeNum(item.per) > 0 ? `${safeNum(item.per).toFixed(1)}` : "—"}
                 </span>
             </div>
 
             <div className="text-right">
                 <span className={cn(
-                    "text-xs font-mono tabular-nums",
-                    roe && roe > 15 ? "text-emerald-600 dark:text-emerald-400 font-bold" : "text-zinc-500"
+                    "text-sm font-mono tabular-nums",
+                    roe && roe > 15 ? "text-emerald-600 dark:text-emerald-400 font-bold" :
+                    roe && roe > 0 ? "text-zinc-600 dark:text-zinc-300" : "text-zinc-400"
                 )}>
-                    {roe !== null ? `${roe.toFixed(1)}%` : "—"}
+                    {roe !== null && roe > 0 ? `${roe.toFixed(1)}%` : "—"}
                 </span>
             </div>
 
@@ -228,16 +229,16 @@ function StockRowCard({ item, onClick }: { item: any; onClick: (ticker: string, 
 
     return (
         <div
-            className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 p-4 cursor-pointer hover:border-zinc-300 dark:hover:border-zinc-700 hover:shadow-md transition-all active:scale-[0.99]"
+            className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 p-4 cursor-pointer hover:border-blue-300 dark:hover:border-blue-700/50 hover:shadow-md transition-all active:scale-[0.99]"
             onClick={() => onClick(item.ticker, item.name)}
         >
             <div className="flex items-start justify-between gap-2 mb-3">
                 <div className="min-w-0">
-                    <p className="font-mono font-black text-sm text-zinc-900 dark:text-white">{item.ticker}</p>
-                    <p className="text-xs text-zinc-400 font-medium mt-0.5 truncate">{item.name}</p>
+                    <p className="font-bold text-base text-zinc-900 dark:text-white truncate leading-tight">{item.name}</p>
+                    <p className="text-[11px] text-zinc-400 font-mono tracking-wider mt-0.5">{item.ticker}</p>
                 </div>
                 <div className={cn(
-                    "shrink-0 px-2 py-1 rounded-lg text-xs font-black font-mono",
+                    "shrink-0 px-2.5 py-1.5 rounded-xl text-sm font-black font-mono",
                     ncav >= 1
                         ? "bg-emerald-100 dark:bg-emerald-950/50 text-emerald-700 dark:text-emerald-400"
                         : ncav >= 0.7
@@ -260,18 +261,18 @@ function StockRowCard({ item, onClick }: { item: any; onClick: (ticker: string, 
 
             <div className="grid grid-cols-3 gap-2 mb-3">
                 {[
-                    { label: "PBR", value: safeNum(item.pbr) > 0 ? `${safeNum(item.pbr).toFixed(2)}x` : "—" },
-                    { label: "PER", value: safeNum(item.per) > 0 ? `${safeNum(item.per).toFixed(1)}x` : "—" },
-                    { label: "ROE", value: roe !== null ? `${roe.toFixed(1)}%` : "—" },
+                    { label: "PBR", value: safeNum(item.pbr) > 0 ? `${safeNum(item.pbr).toFixed(2)}` : "—" },
+                    { label: "PER", value: safeNum(item.per) > 0 ? `${safeNum(item.per).toFixed(1)}` : "—" },
+                    { label: "ROE", value: roe !== null && roe > 0 ? `${roe.toFixed(1)}%` : "—" },
                 ].map(m => (
-                    <div key={m.label} className="text-center p-2 bg-zinc-50 dark:bg-zinc-800/50 rounded-lg">
+                    <div key={m.label} className="text-center p-2.5 bg-zinc-50 dark:bg-zinc-800/60 rounded-xl">
                         <p className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider">{m.label}</p>
-                        <p className="text-xs font-mono font-bold text-zinc-700 dark:text-zinc-300 mt-0.5">{m.value}</p>
+                        <p className="text-sm font-mono font-bold text-zinc-700 dark:text-zinc-200 mt-0.5">{m.value}</p>
                     </div>
                 ))}
             </div>
 
-            <button className="w-full flex items-center justify-center gap-1.5 py-2 rounded-xl bg-zinc-100 dark:bg-zinc-800 hover:bg-blue-600 hover:text-white text-zinc-600 dark:text-zinc-400 text-xs font-bold transition-all">
+            <button className="w-full flex items-center justify-center gap-1.5 py-2.5 rounded-xl bg-zinc-100 dark:bg-zinc-800 hover:bg-blue-600 hover:text-white text-zinc-600 dark:text-zinc-400 text-xs font-bold transition-all">
                 상세 분석
                 <ChevronRight size={12} />
             </button>
@@ -602,9 +603,9 @@ function ScreenerContent() {
                     <>
                         {/* 데스크탑 테이블 */}
                         <div className="hidden md:block">
-                            <div className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 overflow-hidden">
-                                <div className="grid grid-cols-[minmax(140px,2fr)_minmax(100px,1fr)_80px_64px_64px_64px_80px] gap-4 items-center px-5 py-3 border-b border-zinc-100 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-800/50">
-                                    <SortableHeader label="종목" sortKey="ticker" currentKey={sortKey} order={sortOrder} onToggle={toggleSort} />
+                            <div className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 overflow-hidden shadow-sm">
+                                <div className="grid grid-cols-[minmax(160px,2.5fr)_minmax(110px,1fr)_88px_68px_68px_68px_88px] gap-4 items-center px-5 py-3.5 bg-zinc-50 dark:bg-zinc-800/60 border-b border-zinc-200 dark:border-zinc-700/60">
+                                    <SortableHeader label="종목명" sortKey="ticker" currentKey={sortKey} order={sortOrder} onToggle={toggleSort} />
                                     <div className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider">전략</div>
                                     <SortableHeader label="NCAV 비율" sortKey="ncav_ratio" currentKey={sortKey} order={sortOrder} onToggle={toggleSort} />
                                     <SortableHeader label="PBR" sortKey="pbr" currentKey={sortKey} order={sortOrder} onToggle={toggleSort} />
@@ -612,7 +613,7 @@ function ScreenerContent() {
                                     <SortableHeader label="ROE" sortKey="roe" currentKey={sortKey} order={sortOrder} onToggle={toggleSort} />
                                     <div />
                                 </div>
-                                <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                                <div>
                                     {visibleList.map((item: any) => (
                                         <TableRow key={item.ticker} item={item} onClick={handleStockClick} />
                                     ))}


### PR DESCRIPTION
## Summary

- 온보딩 페이지: 로그인 여부에 따라 동적 분기, 실시간 발굴 수 배지, 스크리너 바로가기 CTA 추가
- 온보딩 페이지: "전체 보기" 로그인 시 `/screener`, 비로그인 시 `/login`으로 분기
- 스크리너 페이지: 종목명 → 1차, 티커 → 2차로 변경하여 가독성 개선

## 변경 내용

### `app/(home)/page.tsx`

#### 유입 요소 강화
- `useSession()` 도입 — 로그인 상태에 따라 버튼/링크 분기
- Hero에 **실시간 발굴 수 배지** 추가 (데이터 로드 후 애니메이션 등장)
  - 예시: `✦ 오늘 42개 저평가 종목 발견 · 2026.06.04`
- 로그인 사용자: "무료로 시작하기" → "종목 발굴하기" 버튼 표시, 클릭 시 `/screener` 이동

#### 미리보기 섹션 조건부 렌더링
| 상태 | 미리보기 | 잠긴 항목 | "전체 보기" |
|---|---|---|---|
| 비로그인 | 상위 3개 공개 | blur + 로그인 오버레이 | → `/login` |
| 로그인 | 상위 3개 공개 | **그대로 표시 (blur 없음)** | → `/screener` |

- 로그인 후 미리보기 하단에 **스크리너 바로가기 CTA** 배너 표시
- 각 전략 배지 색상을 배경+테두리 포함 더 구분되게 개선

### `app/(screener)/screener/page.tsx`

#### TableRow (데스크탑)
- 종목명 1차(`font-bold text-sm`), 티커 2차(`font-mono text-[11px] tracking-wider`) — 기존 반대
- NCAV 비율 숫자 크기 `text-xs → text-sm font-black` 으로 더 명확하게
- PBR/PER 단위 `x` 제거 → 숫자만 표시 (ROE는 % 유지)
- 행 hover: `blue-50` 배경으로 더 명확한 포커스

#### StockRowCard (모바일)
- 종목명 1차(`font-bold text-base`), 티커 2차(`font-mono text-[11px]`)
- NCAV 배지 크기 확대(`text-sm`, `px-2.5 py-1.5`)
- 지표 셀 padding 확대 + 숫자 `text-sm`으로 가독성 향상

#### 테이블 컨테이너
- 헤더 컬럼명 "종목" → "종목명"
- 테이블에 `shadow-sm` 추가
- 행 간 구분선이 TableRow 자체에서 처리 (`border-b last:border-0`)

https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA)_