### PR TITLE
feat: 로그인 페이지 상용 제품 수준 UI 재설계

### DIFF
--- a/cf-idiotquant/app/(login)/login/page.tsx
+++ b/cf-idiotquant/app/(login)/login/page.tsx
@@ -1,7 +1,109 @@
-import AuthButton from '@/components/authButton';
+import AuthButton from "@/components/authButton";
+import Link from "next/link";
+
+const BENEFITS = [
+    { label: "매일 자동 스캔", desc: "NCAV · 저PBR · 저PER · S-RIM 기준으로 저평가 종목을 매일 갱신" },
+    { label: "9가지 전략 필터", desc: "그레이엄 · 마법공식 · 퀄리티밸류 등 전략 조합 AND/OR 필터" },
+    { label: "적정 주가 계산", desc: "7가지 밸류에이션 모델 기반 종목별 안전마진 분석" },
+];
 
 export default function LoginPage() {
-    return <>
-        <AuthButton />
-    </>;
+    return (
+        <div className="min-h-[calc(100vh-3.5rem)] flex flex-col items-center justify-center px-4 py-12 bg-gradient-to-b from-zinc-50 to-white dark:from-zinc-950 dark:to-zinc-900 relative overflow-hidden">
+
+            {/* Background blobs */}
+            <div className="pointer-events-none absolute inset-0 overflow-hidden">
+                <div className="absolute -top-40 -right-40 w-96 h-96 rounded-full bg-blue-500/6 blur-3xl" />
+                <div className="absolute -bottom-40 -left-40 w-96 h-96 rounded-full bg-indigo-500/6 blur-3xl" />
+            </div>
+
+            <div className="relative w-full max-w-sm flex flex-col gap-8">
+
+                {/* Brand mark */}
+                <div className="flex justify-center">
+                    <Link href="/" className="group flex items-center gap-3">
+                        <div className="w-11 h-11 bg-blue-600 rounded-2xl flex items-center justify-center shadow-lg shadow-blue-600/30 group-hover:shadow-blue-600/50 transition-shadow">
+                            <span className="text-white text-[13px] font-black italic leading-none">IQ</span>
+                        </div>
+                        <span className="font-black tracking-tighter text-xl text-zinc-900 dark:text-white">
+                            IDIOT<span className="text-blue-600">QUANT</span>
+                        </span>
+                    </Link>
+                </div>
+
+                {/* Card */}
+                <div className="bg-white dark:bg-zinc-900 rounded-3xl border border-zinc-200/80 dark:border-zinc-800 shadow-xl shadow-zinc-900/6 dark:shadow-black/40 overflow-hidden">
+
+                    {/* Card header */}
+                    <div className="px-8 pt-8 pb-6 text-center border-b border-zinc-100 dark:border-zinc-800">
+                        <h1 className="text-[1.6rem] font-black leading-tight text-zinc-900 dark:text-white">
+                            저평가 종목을<br />매일 발굴해드립니다
+                        </h1>
+                        <p className="mt-2.5 text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed">
+                            가치투자 기준으로 매일 자동 스캔하는<br />국내 주식 퀀트 도구
+                        </p>
+                    </div>
+
+                    {/* Benefits */}
+                    <div className="px-8 py-6 space-y-4 border-b border-zinc-100 dark:border-zinc-800">
+                        {BENEFITS.map((b) => (
+                            <div key={b.label} className="flex items-start gap-3">
+                                <div className="mt-0.5 w-5 h-5 rounded-full bg-blue-100 dark:bg-blue-950/60 flex items-center justify-center shrink-0">
+                                    <svg className="w-2.5 h-2.5 text-blue-600 dark:text-blue-400" viewBox="0 0 10 8" fill="none">
+                                        <path d="M1 4l2.5 2.5L9 1" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+                                    </svg>
+                                </div>
+                                <div>
+                                    <p className="text-sm font-bold text-zinc-800 dark:text-zinc-200 leading-snug">{b.label}</p>
+                                    <p className="text-xs text-zinc-400 dark:text-zinc-500 mt-0.5 leading-snug">{b.desc}</p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+
+                    {/* Login area */}
+                    <div className="px-8 py-6">
+                        <AuthButton />
+
+                        <div className="flex items-center gap-3 my-5">
+                            <div className="flex-1 h-px bg-zinc-100 dark:bg-zinc-800" />
+                            <span className="text-[10px] font-bold text-zinc-300 dark:text-zinc-600 uppercase tracking-widest">무료 · 1초 가입</span>
+                            <div className="flex-1 h-px bg-zinc-100 dark:bg-zinc-800" />
+                        </div>
+
+                        <div className="flex justify-center gap-4 text-[11px] text-zinc-400 dark:text-zinc-500">
+                            <span className="flex items-center gap-1.5">
+                                <svg className="w-3 h-3" viewBox="0 0 12 12" fill="none">
+                                    <path d="M6 1L7.5 4.5L11 5L8.5 7.5L9.2 11L6 9.2L2.8 11L3.5 7.5L1 5L4.5 4.5L6 1Z" stroke="currentColor" strokeWidth="1" strokeLinejoin="round" fill="none"/>
+                                </svg>
+                                무료 이용
+                            </span>
+                            <span className="flex items-center gap-1.5">
+                                <svg className="w-3 h-3" viewBox="0 0 12 12" fill="none">
+                                    <rect x="1" y="4" width="10" height="7" rx="1.5" stroke="currentColor" strokeWidth="1"/>
+                                    <path d="M4 4V3a2 2 0 114 0v1" stroke="currentColor" strokeWidth="1" strokeLinecap="round"/>
+                                </svg>
+                                개인정보 보호
+                            </span>
+                            <span className="flex items-center gap-1.5">
+                                <svg className="w-3 h-3" viewBox="0 0 12 12" fill="none">
+                                    <path d="M6 1v10M1 6h10" stroke="currentColor" strokeWidth="1" strokeLinecap="round"/>
+                                </svg>
+                                언제든 탈퇴
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Footer */}
+                <p className="text-center text-[11px] text-zinc-400 dark:text-zinc-500">
+                    로그인 시{" "}
+                    <span className="underline underline-offset-2 cursor-pointer hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors">이용약관</span>
+                    {" "}및{" "}
+                    <span className="underline underline-offset-2 cursor-pointer hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors">개인정보 처리방침</span>
+                    에 동의합니다.
+                </p>
+            </div>
+        </div>
+    );
 }

--- a/cf-idiotquant/components/authButton.tsx
+++ b/cf-idiotquant/components/authButton.tsx
@@ -1,84 +1,69 @@
 "use client"
 import { useSession, signIn } from "next-auth/react"
-import { useState } from "react"
-import UserProfile from "./user-profile"
+import { useRouter } from "next/navigation"
+import { useState, useEffect } from "react"
+
+function KakaoIcon({ size = 20 }: { size?: number }) {
+    return (
+        <svg width={size} height={size} viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path
+                d="M10 2.5C5.86 2.5 2.5 5.22 2.5 8.57c0 2.12 1.33 3.99 3.37 5.15l-.82 3.02c-.07.27.23.5.46.35l3.55-2.3c.3.03.61.05.92.05 4.14 0 7.5-2.72 7.5-6.07S14.14 2.5 10 2.5z"
+                fill="currentColor"
+            />
+        </svg>
+    )
+}
 
 export default function AuthButton() {
     const { data: session, status } = useSession()
-    // 직접 클릭했을 때의 로딩 상태 관리
     const [isPending, setIsPending] = useState(false)
+    const router = useRouter()
 
-    // 세션 로딩 중이거나 사용자가 버튼을 이미 눌렀을 때 true
-    const isLoading = status === "loading" || isPending
+    useEffect(() => {
+        if (status === "authenticated") {
+            router.replace("/screener")
+        }
+    }, [status, router])
 
-    // 1. 세션 로딩 중 (스켈레톤 UI)
     if (status === "loading") {
+        return <div className="w-full h-12 rounded-xl bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+    }
+
+    if (session) {
         return (
-            <div className="mx-auto w-full max-w-sm rounded-md border border-gray-200 p-4">
-                <div className="flex animate-pulse space-x-4">
-                    <div className="size-10 rounded-full bg-gray-200"></div>
-                    <div className="flex-1 space-y-6 py-1">
-                        <div className="h-2 rounded bg-gray-200"></div>
-                        <div className="space-y-3">
-                            <div className="grid grid-cols-3 gap-4">
-                                <div className="col-span-2 h-2 rounded bg-gray-200"></div>
-                                <div className="col-span-1 h-2 rounded bg-gray-200"></div>
-                            </div>
-                            <div className="h-2 rounded bg-gray-200"></div>
-                        </div>
-                    </div>
-                </div>
+            <div className="flex items-center justify-center gap-2 py-3 text-sm text-zinc-500 dark:text-zinc-400">
+                <span className="inline-block w-4 h-4 rounded-full border-2 border-zinc-300 border-t-zinc-600 animate-spin" />
+                스크리너로 이동 중...
             </div>
         )
     }
 
-    // 2. 로그인 완료 상태
-    if (session) {
-        return <UserProfile user={session.user} />
-    }
-
-    // 3. 로그인 미완료 상태 (로그인 버튼)
     const handleLogin = async () => {
         setIsPending(true)
         try {
-            await signIn("kakao", { redirectTo: "/" })
-        } catch (error) {
-            console.error("Login failed:", error)
-            setIsPending(false) // 실패 시 다시 버튼 활성화
+            await signIn("kakao", { redirectTo: "/screener" })
+        } catch {
+            setIsPending(false)
         }
     }
 
     return (
-        <div className="max-w-md mx-auto mt-10 p-6 bg-white rounded-xl shadow-md flex flex-col items-center">
-            <button
-                onClick={handleLogin}
-                disabled={isLoading}
-                className={`
-                    w-full bg-[#FEE500] text-[#191919] px-4 py-3 rounded-md font-bold
-                    transition-all duration-200
-                    ${isLoading
-                        ? "opacity-50 cursor-not-allowed scale-[0.98]"
-                        : "hover:!bg-[#FADA0A] active:scale-95 shadow-sm hover:shadow-md"
-                    }
-                `}
-            >
-                {isPending ? (
-                    <span className="flex items-center justify-center gap-2">
-                        <svg className="animate-spin h-4 w-4 text-black" viewBox="0 0 24 24">
-                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                        </svg>
-                        카카오 인증 연결 중...
-                    </span>
-                ) : (
-                    "카카오로 로그인하기"
-                )}
-            </button>
-
-            {/* 로그인 안내 문구 추가 (선택사항) */}
-            <p className="mt-4 text-xs text-gray-400">
-                1초 만에 가입하고 모든 기능을 이용해 보세요.
-            </p>
-        </div>
+        <button
+            onClick={handleLogin}
+            disabled={isPending}
+            className="w-full flex items-center justify-center gap-3 bg-[#FEE500] hover:bg-[#F6DC00] active:scale-[0.98] text-[#191919] font-black text-sm py-3.5 px-5 rounded-xl transition-all duration-150 shadow-sm hover:shadow-md disabled:opacity-60 disabled:cursor-not-allowed select-none"
+        >
+            {isPending ? (
+                <>
+                    <span className="inline-block w-4 h-4 rounded-full border-2 border-[#191919]/30 border-t-[#191919] animate-spin" />
+                    카카오 연결 중...
+                </>
+            ) : (
+                <>
+                    <KakaoIcon size={20} />
+                    카카오로 로그인
+                </>
+            )}
+        </button>
     )
 }


### PR DESCRIPTION
## Summary

- 로그인 페이지를 단순 버튼 1개 → 풀페이지 온보딩 카드 레이아웃으로 재설계
- 브랜드 마크 · 가치 제안 헤드라인 · 혜택 목록 · 카카오 로그인 CTA 구조
- 카카오 버튼에 공식 버블 아이콘 + 로딩 스피너 추가
- 로그인 완료 시 `/screener`로 자동 리다이렉트

## 변경 내용

### `app/(login)/login/page.tsx`

| 항목 | 기존 | 변경 |
|---|---|---|
| 레이아웃 | 버튼 하나 + 한 줄 안내 | 풀페이지 중앙 정렬 카드 |
| 배경 | 흰 배경 | 그라디언트 + 블러 데코레이션 |
| 브랜드 | 없음 | IQ 로고 + IDIOTQUANT 워드마크 |
| 가치 제안 | 없음 | 헤드라인 + 부제목 |
| 혜택 목록 | 없음 | 체크리스트 3항목 (매일 자동 스캔 · 9가지 전략 필터 · 적정 주가 계산) |
| 신뢰 요소 | 없음 | 무료 이용 · 개인정보 보호 · 언제든 탈퇴 |
| 약관 안내 | 없음 | 하단 이용약관 · 개인정보처리방침 링크 |

### `components/authButton.tsx`

- 카카오 버블 아이콘 SVG 추가 (공식 스펙 기반)
- 로딩 스피너 CSS 기반으로 교체 (svg animate-spin → border spin)
- 이미 로그인된 상태로 `/login` 진입 시 `/screener` 자동 리다이렉트
- 버튼 스타일 개선: `rounded-xl` · `font-black` · `hover:shadow-md`

https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA)_