### PR TITLE
feat: 스크리너 필터 URL 유지 + 전체 초기화 버튼

### DIFF
--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -3,7 +3,7 @@
 export const dynamic = 'force-dynamic';
 
 import { useEffect, useMemo, useState, useCallback, useRef, Suspense } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import {
     selectNcavDailyDates, selectNcavDailyList,
@@ -299,21 +299,39 @@ function StockRowCard({ item, onClick }: { item: any; onClick: (ticker: string, 
 // =========================================================================
 // 메인 스크리너
 // =========================================================================
+const VALID_SORT_KEYS: DiscoverySortKey[] = ["ticker", "ncav_ratio", "per", "pbr", "roe", "market_cap", "last_price"];
+
 function ScreenerContent() {
     const dispatch = useAppDispatch();
     const router = useRouter();
+    const searchParams = useSearchParams();
     const ncavDailyDates = useAppSelector(selectNcavDailyDates);
     const ncavDailyList = useAppSelector(selectNcavDailyList);
 
-    const [activeStrategyIds, setActiveStrategyIds] = useState<Set<string>>(new Set());
-    const [filterMode, setFilterMode] = useState<'OR' | 'AND'>('OR');
+    // URL query params → 상태 초기화 (페이지 재진입 시에도 필터 유지)
+    const [activeStrategyIds, setActiveStrategyIds] = useState<Set<string>>(() => {
+        const s = searchParams.get('strategies');
+        return s ? new Set(s.split(',').filter(id => STRATEGY_PRESETS.some(p => p.id === id))) : new Set();
+    });
+    const [filterMode, setFilterMode] = useState<'OR' | 'AND'>(() =>
+        searchParams.get('mode') === 'AND' ? 'AND' : 'OR'
+    );
     const [showGuide, setShowGuide] = useState(false);
-    const [sortKey, setSortKey] = useState<DiscoverySortKey>("ncav_ratio");
-    const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+    const [sortKey, setSortKey] = useState<DiscoverySortKey>(() => {
+        const s = searchParams.get('sort') as DiscoverySortKey;
+        return VALID_SORT_KEYS.includes(s) ? s : 'ncav_ratio';
+    });
+    const [sortOrder, setSortOrder] = useState<SortOrder>(() =>
+        searchParams.get('order') === 'asc' ? 'asc' : 'desc'
+    );
     const [searchQuery, setSearchQuery] = useState("");
     const [displayCount, setDisplayCount] = useState(DAILY_PAGE_SIZE);
-    const [excludeHoldings, setExcludeHoldings] = useState(false);
-    const [excludeDeficit, setExcludeDeficit] = useState(false);
+    const [excludeHoldings, setExcludeHoldings] = useState(() =>
+        searchParams.get('exclude')?.split(',').includes('holdings') ?? false
+    );
+    const [excludeDeficit, setExcludeDeficit] = useState(() =>
+        searchParams.get('exclude')?.split(',').includes('deficit') ?? false
+    );
     const [filterOpen, setFilterOpen] = useState(false);
 
     const hasDiscovered = useRef(false);
@@ -334,6 +352,27 @@ function ScreenerContent() {
             dispatch(reqDiscoverNcavDates(ncavDailyList.scanDate));
         }
     }, [ncavDailyList.state, ncavDailyList.scanDate, ncavDailyDates.dates.length, dispatch]);
+
+    // 필터 상태 → URL 동기화 (다른 페이지 다녀와도 필터 유지)
+    useEffect(() => {
+        const params = new URLSearchParams();
+        if (activeStrategyIds.size > 0)
+            params.set('strategies', Array.from(activeStrategyIds).join(','));
+        if (filterMode !== 'OR')
+            params.set('mode', filterMode);
+        if (sortKey !== 'ncav_ratio')
+            params.set('sort', sortKey);
+        if (sortOrder !== 'desc')
+            params.set('order', sortOrder);
+        const excludeList = [
+            excludeHoldings ? 'holdings' : null,
+            excludeDeficit ? 'deficit' : null,
+        ].filter(Boolean).join(',');
+        if (excludeList) params.set('exclude', excludeList);
+
+        const qs = params.toString();
+        router.replace(qs ? `/screener?${qs}` : '/screener', { scroll: false });
+    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, router]);
 
     const handleRefresh = useCallback(() => {
         dispatch(reqGetNcavDailyList("latest"));
@@ -362,6 +401,17 @@ function ScreenerContent() {
     const clearStrategies = useCallback(() => {
         setActiveStrategyIds(new Set());
         setFilterMode('OR');
+        setDisplayCount(DAILY_PAGE_SIZE);
+    }, []);
+
+    const resetAllFilters = useCallback(() => {
+        setActiveStrategyIds(new Set());
+        setFilterMode('OR');
+        setSortKey('ncav_ratio');
+        setSortOrder('desc');
+        setSearchQuery('');
+        setExcludeHoldings(false);
+        setExcludeDeficit(false);
         setDisplayCount(DAILY_PAGE_SIZE);
     }, []);
 
@@ -435,6 +485,7 @@ function ScreenerContent() {
 
     const activeFilterCount = [excludeHoldings, excludeDeficit].filter(Boolean).length;
     const isAllActive = activeStrategyIds.size === 0;
+    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || sortKey !== 'ncav_ratio' || sortOrder !== 'desc';
 
     return (
         <Tooltip.Provider delayDuration={300}>
@@ -545,6 +596,18 @@ function ScreenerContent() {
                             <Info size={12} />
                             <span className="hidden sm:inline">전략 안내</span>
                         </button>
+
+                        {/* 필터 초기화 버튼 */}
+                        {hasActiveFilters && (
+                            <button
+                                onClick={resetAllFilters}
+                                className="shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-red-200 dark:border-red-800/50 text-xs font-bold text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/20 transition-all bg-white dark:bg-zinc-900"
+                                title="모든 필터 초기화"
+                            >
+                                <X size={12} />
+                                <span className="hidden sm:inline">초기화</span>
+                            </button>
+                        )}
                     </div>
 
                     {/* 선택된 전략 조합 안내 */}


### PR DESCRIPTION
## Summary

- 전략·정렬·제외조건 필터를 URL query param으로 동기화해 페이지 이탈 후 복귀해도 필터 유지
- 활성 필터가 있을 때 상단 탭 우측에 **초기화** 버튼 표시

## 변경 내용

### `app/(screener)/screener/page.tsx`

#### URL query param 동기화
필터 상태 변경 시 `router.replace()` 로 URL 업데이트 (히스토리 미추가):

| param | 값 예시 | 설명 |
|---|---|---|
| `strategies` | `ncav,low_pbr` | 선택된 전략 ID 목록 |
| `mode` | `AND` | OR(기본값) 생략, AND일 때만 표시 |
| `sort` | `pbr` | 정렬 키 (기본값 `ncav_ratio` 생략) |
| `order` | `asc` | 정렬 방향 (기본값 `desc` 생략) |
| `exclude` | `holdings,deficit` | 제외 조건 |

예: `/screener?strategies=ncav,low_pbr&mode=AND&exclude=deficit`

#### 초기값 복원
`useState` 초기화 함수에서 `searchParams`를 읽어 필터 상태 복원:
- 다른 페이지 이동 후 뒤로가기 → 동일 필터 유지
- URL 공유 시 수신자도 같은 필터 상태로 진입

#### 초기화 버튼 (`resetAllFilters`)
- 활성 필터(전략/정렬/제외조건)가 하나라도 있으면 전략 탭 우측에 빨간 **초기화** 버튼 표시
- 클릭 시 전략·조합모드·정렬·검색어·제외조건 전체 리셋

https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA)_