### PR TITLE
fix: analyze 검색 헤더 sticky 위치 수정

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -401,7 +401,7 @@ function AnalyzeContent() {
       </div>
 
       {/* ── 헤더 ── */}
-      <header className="sticky top-14 z-30 bg-white dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800 shadow-sm">
+      <header className="sticky top-0 z-30 bg-white dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800 shadow-sm">
         {fromScreener && (
           <div className="border-b border-zinc-100 dark:border-zinc-800/60">
             <div className="max-w-4xl mx-auto px-4 py-2">


### PR DESCRIPTION
## 원인

`layout.tsx`의 `<main>` 이 `overflow-y-auto` 를 가져 독자 스크롤 컨텍스트를 형성합니다.

이 안에서 `sticky top-14` (56px) 는 **"main 최상단 + 56px"** 로 해석되어,  
실제 뷰포트 기준으로는 navbar 하단(56px) + 56px = **112px** 위치에 붙었습니다.

## 수정

```diff
- <header className="sticky top-14 z-30 ...">
+ <header className="sticky top-0 z-30 ...">
```

`top-0` 으로 변경하면 main 스크롤 컨텍스트 최상단 = 뷰포트 56px(navbar 바로 아래)에 붙습니다.

## 참고

screener 페이지의 전략 탭도 동일한 `sticky top-14` 를 사용 중이며 같은 원인으로 위치가 내려가 있습니다. 별도 이슈로 처리 가능합니다.

https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA)_