### PR TITLE
feat: 스크리너 시가총액 필터 + 홈 온보딩 상용 제품 수준 UI 재설계

### DIFF
--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -6,7 +6,8 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import {
   Search, Calculator, BarChart3, Lock, ArrowRight,
-  TrendingUp, ChevronRight, CheckCircle2, Loader2, Activity, Sparkles,
+  TrendingUp, ChevronRight, CheckCircle2, Loader2, Activity,
+  Zap, ShieldCheck, LayoutGrid,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -20,96 +21,140 @@ interface PreviewStock {
   market_cap?: number;
 }
 
-const HOME_MKTCAP_MIN = 500; // 억원
+const HOME_MKTCAP_MIN = 500;
 
 const STRATEGY_LABEL: Record<string, string> = {
   ncav: "NCAV", low_pbr: "저PBR", low_per: "저PER", s_rim: "S-RIM",
   graham_number: "그레이엄", magic_formula: "마법공식",
+  quality_value: "퀄리티", near_ncav: "NCAV근접", balanced_value: "균형가치",
 };
 
 const STRATEGY_BADGE_CLS: Record<string, string> = {
-  ncav: "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-400 border-emerald-200/60 dark:border-emerald-800/50",
-  low_pbr: "bg-blue-50 dark:bg-blue-950/40 text-blue-700 dark:text-blue-400 border-blue-200/60 dark:border-blue-800/50",
-  low_per: "bg-orange-50 dark:bg-orange-950/40 text-orange-700 dark:text-orange-400 border-orange-200/60 dark:border-orange-800/50",
-  s_rim: "bg-violet-50 dark:bg-violet-950/40 text-violet-700 dark:text-violet-400 border-violet-200/60 dark:border-violet-800/50",
-  graham_number: "bg-teal-50 dark:bg-teal-950/40 text-teal-700 dark:text-teal-400 border-teal-200/60 dark:border-teal-800/50",
-  magic_formula: "bg-rose-50 dark:bg-rose-950/40 text-rose-700 dark:text-rose-400 border-rose-200/60 dark:border-rose-800/50",
+  ncav:           "bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800/60",
+  low_pbr:        "bg-blue-50 dark:bg-blue-950/40 text-blue-700 dark:text-blue-400 border-blue-200 dark:border-blue-800/60",
+  low_per:        "bg-orange-50 dark:bg-orange-950/40 text-orange-700 dark:text-orange-400 border-orange-200 dark:border-orange-800/60",
+  s_rim:          "bg-violet-50 dark:bg-violet-950/40 text-violet-700 dark:text-violet-400 border-violet-200 dark:border-violet-800/60",
+  graham_number:  "bg-teal-50 dark:bg-teal-950/40 text-teal-700 dark:text-teal-400 border-teal-200 dark:border-teal-800/60",
+  magic_formula:  "bg-rose-50 dark:bg-rose-950/40 text-rose-700 dark:text-rose-400 border-rose-200 dark:border-rose-800/60",
+  quality_value:  "bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800/60",
+  near_ncav:      "bg-indigo-50 dark:bg-indigo-950/40 text-indigo-700 dark:text-indigo-400 border-indigo-200 dark:border-indigo-800/60",
+  balanced_value: "bg-cyan-50 dark:bg-cyan-950/40 text-cyan-700 dark:text-cyan-400 border-cyan-200 dark:border-cyan-800/60",
 };
 
-const HOW_IT_WORKS = [
+const FEATURES = [
   {
-    step: "01",
-    icon: BarChart3,
-    title: "종목 발굴",
-    desc: "NCAV·저PBR·저PER 등 9가지 전략으로 매일 자동 스캔된 KOSPI·KOSDAQ 저평가 종목을 확인합니다.",
+    icon: LayoutGrid,
+    color: "text-blue-600 dark:text-blue-400",
+    bg: "bg-blue-50 dark:bg-blue-950/30",
+    title: "9가지 퀀트 전략",
+    desc: "NCAV·저PBR·저PER·S-RIM·그레이엄·마법공식 등 검증된 전략으로 KOSPI·KOSDAQ 전 종목을 매일 자동 스캔합니다.",
     link: "/screener",
+    linkLabel: "종목 발굴하기",
   },
   {
-    step: "02",
     icon: Search,
-    title: "상세 분석",
-    desc: "관심 종목을 클릭하면 NCAV·S-RIM·PBR·PER 등 복수 모델로 적정 주가와 안전마진을 즉시 산출합니다.",
+    color: "text-violet-600 dark:text-violet-400",
+    bg: "bg-violet-50 dark:bg-violet-950/30",
+    title: "멀티 모델 밸류에이션",
+    desc: "종목 검색 한 번으로 NCAV·S-RIM·PBR·PER 4개 모델의 적정 주가와 현재 주가 괴리율을 즉시 확인합니다.",
     link: "/analyze",
+    linkLabel: "종목 분석하기",
   },
   {
-    step: "03",
     icon: Calculator,
-    title: "수익 시뮬레이션",
-    desc: "매수 시나리오별 세후 순수익과 연환산 수익률을 거래세·수수료까지 반영해 계산합니다.",
+    color: "text-emerald-600 dark:text-emerald-400",
+    bg: "bg-emerald-50 dark:bg-emerald-950/30",
+    title: "세후 수익 계산기",
+    desc: "거래세·수수료를 반영한 세후 순수익과 연환산 수익률을 시나리오별로 즉시 계산합니다.",
     link: "/calculator",
+    linkLabel: "계산해보기",
   },
 ];
 
-function StockPreviewRow({ item }: { item: PreviewStock }) {
-  const ncav = item.ncav_ratio;
+function NcavBar({ ratio }: { ratio: number }) {
+  const pct = Math.min(ratio * 100, 200);
   return (
-    <div className="flex items-center gap-3 px-5 py-3.5 border-b border-zinc-100 dark:border-zinc-800/60 last:border-0">
+    <div className="w-full bg-zinc-100 dark:bg-zinc-800 rounded-full h-1.5 overflow-hidden">
+      <div
+        className={cn(
+          "h-full rounded-full transition-all duration-700",
+          ratio >= 1 ? "bg-emerald-500" : ratio >= 0.7 ? "bg-amber-400" : "bg-zinc-300 dark:bg-zinc-600"
+        )}
+        style={{ width: `${Math.min(pct, 100)}%` }}
+      />
+    </div>
+  );
+}
+
+function StockPreviewRow({ item, index }: { item: PreviewStock; index: number }) {
+  const ncav = item.ncav_ratio;
+  const strategies = item.strategies?.slice(0, 2) ?? [];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -8 }}
+      whileInView={{ opacity: 1, x: 0 }}
+      viewport={{ once: true }}
+      transition={{ delay: 0.04 * index }}
+      className="group flex items-center gap-4 px-5 py-4 border-b border-zinc-100 dark:border-zinc-800/60 last:border-0 hover:bg-blue-50/40 dark:hover:bg-zinc-800/30 transition-colors"
+    >
+      {/* 순위 */}
+      <span className="w-5 text-[11px] font-black text-zinc-300 dark:text-zinc-600 tabular-nums shrink-0">
+        {index + 1}
+      </span>
+
+      {/* 종목 정보 */}
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 flex-wrap">
-          <p className="font-bold text-sm text-zinc-900 dark:text-white">{item.name}</p>
-          {item.strategies.slice(0, 2).map(s => (
+        <div className="flex items-center gap-2 mb-0.5 flex-wrap">
+          <p className="font-bold text-[13px] text-zinc-900 dark:text-white truncate leading-tight">{item.name}</p>
+          {strategies.map(s => (
             <span key={s} className={cn(
-              "text-[9px] font-extrabold px-1.5 py-0.5 rounded border",
+              "text-[9px] font-extrabold px-1.5 py-0.5 rounded-md border leading-none",
               STRATEGY_BADGE_CLS[s] ?? "bg-zinc-100 text-zinc-500 border-zinc-200"
             )}>
               {STRATEGY_LABEL[s] ?? s}
             </span>
           ))}
         </div>
-        <p className="text-[10px] text-zinc-400 font-mono mt-0.5">{item.ticker}</p>
+        <p className="text-[10px] text-zinc-400 font-mono">{item.ticker}</p>
       </div>
-      <div className="flex items-center gap-4 shrink-0">
-        <div className="text-right hidden sm:block">
-          <p className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider">PBR</p>
-          <p className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
-            {item.pbr > 0 ? `${item.pbr.toFixed(2)}x` : "—"}
-          </p>
-        </div>
-        <div className="text-right hidden sm:block">
-          <p className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider">PER</p>
-          <p className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
-            {item.per > 0 ? `${item.per.toFixed(1)}x` : "—"}
+
+      {/* 지표 */}
+      <div className="hidden sm:flex items-center gap-5 shrink-0">
+        <div className="text-right">
+          <p className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider mb-0.5">PBR</p>
+          <p className="text-xs font-mono font-semibold text-zinc-600 dark:text-zinc-300">
+            {item.pbr > 0 ? `${item.pbr.toFixed(2)}` : "—"}
           </p>
         </div>
         <div className="text-right">
-          <p className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider">NCAV</p>
-          <p className={cn(
-            "text-sm font-black font-mono",
-            ncav >= 1 ? "text-emerald-600 dark:text-emerald-400" :
-            ncav >= 0.7 ? "text-amber-600 dark:text-amber-400" : "text-zinc-400"
-          )}>
-            {ncav > 0 ? `${ncav.toFixed(2)}x` : "—"}
+          <p className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider mb-0.5">PER</p>
+          <p className="text-xs font-mono font-semibold text-zinc-600 dark:text-zinc-300">
+            {item.per > 0 ? `${item.per.toFixed(1)}` : "—"}
           </p>
         </div>
       </div>
-    </div>
+
+      {/* NCAV 비율 + 바 */}
+      <div className="shrink-0 w-20 text-right">
+        <p className={cn(
+          "text-sm font-black font-mono tabular-nums",
+          ncav >= 1 ? "text-emerald-600 dark:text-emerald-400" :
+          ncav >= 0.7 ? "text-amber-600 dark:text-amber-400" : "text-zinc-400"
+        )}>
+          {ncav > 0 ? `${ncav.toFixed(2)}x` : "—"}
+        </p>
+        <NcavBar ratio={ncav} />
+      </div>
+    </motion.div>
   );
 }
 
 export default function HomePage() {
   const heroRef = useRef<HTMLDivElement>(null);
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const isLoggedIn = !!session;
+  const sessionLoading = status === "loading";
 
   const [preview, setPreview] = useState<{
     items: PreviewStock[];
@@ -125,7 +170,6 @@ export default function HomePage() {
       .then((data: any) => {
         if (data.success) {
           const all: PreviewStock[] = data.data;
-          // 시가총액 500억+ 필터 (단위: 억원)
           const filtered = all.filter(item => (item.market_cap ?? 0) >= HOME_MKTCAP_MIN);
           setPreview({
             items: filtered.slice(0, 5),
@@ -148,244 +192,304 @@ export default function HomePage() {
     : null;
 
   return (
-    <div className="min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-50 antialiased">
+    <div className="min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-50">
 
       {/* ── 히어로 ── */}
-      <header ref={heroRef} className="relative pt-24 pb-16 px-6 overflow-hidden">
-        <div className="absolute inset-0 -z-10 opacity-[0.03] dark:opacity-[0.06]"
-          style={{
-            backgroundImage: "linear-gradient(#3b82f6 1px, transparent 1px), linear-gradient(90deg, #3b82f6 1px, transparent 1px)",
-            backgroundSize: "44px 44px",
-          }}
-        />
-        <div className="absolute -top-32 -left-16 w-[600px] h-[400px] bg-blue-500/6 blur-[140px] rounded-full -z-10" />
+      <header ref={heroRef} className="relative overflow-hidden">
+        {/* 배경 그라데이션 */}
+        <div className="absolute inset-0 -z-10">
+          <div className="absolute inset-0 bg-gradient-to-b from-blue-50/60 via-white to-white dark:from-blue-950/20 dark:via-zinc-950 dark:to-zinc-950" />
+          <div className="absolute top-0 left-1/4 w-[600px] h-[500px] bg-blue-400/8 dark:bg-blue-600/8 blur-[100px] rounded-full" />
+          <div className="absolute top-20 right-1/4 w-[400px] h-[400px] bg-violet-400/6 dark:bg-violet-600/6 blur-[120px] rounded-full" />
+        </div>
 
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
-          className="max-w-3xl mx-auto text-center"
-        >
-          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-blue-500/8 border border-blue-500/20 mb-6">
-            <Activity size={11} className="text-blue-500 animate-pulse" />
-            <span className="text-[11px] font-extrabold text-blue-600 dark:text-blue-400 uppercase tracking-[0.18em]">
-              KOSPI · KOSDAQ &nbsp;·&nbsp; 매일 자동 스캔
+        <div className="max-w-4xl mx-auto px-6 pt-20 pb-16 text-center">
+          {/* 뱃지 */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 shadow-sm mb-7"
+          >
+            <span className="relative flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-emerald-500" />
             </span>
-          </div>
-
-          <h1 className="text-[clamp(2.2rem,6vw,4.5rem)] font-black leading-[1.06] tracking-tight mb-5">
-            <span className="block text-zinc-900 dark:text-white">오늘 저평가된</span>
-            <span className="block text-transparent bg-clip-text bg-gradient-to-r from-blue-500 via-indigo-500 to-violet-500">
-              국내 주식을 찾아드립니다.
+            <span className="text-[11px] font-bold text-zinc-600 dark:text-zinc-400">
+              매일 자동 스캔 &nbsp;·&nbsp; KOSPI · KOSDAQ 전 종목
             </span>
-          </h1>
+          </motion.div>
 
-          <p className="text-zinc-500 dark:text-zinc-400 text-base md:text-lg font-medium leading-relaxed mb-6 max-w-xl mx-auto">
-            벤자민 그레이엄의 NCAV 원칙 기반 퀀트 스크리너.
-            <br className="hidden md:block" />
-            감이 아닌 데이터로 저평가 종목을 발굴하세요.
-          </p>
+          {/* 헤드라인 */}
+          <motion.h1
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.08 }}
+            className="text-[clamp(2.4rem,7vw,5rem)] font-black leading-[1.04] tracking-tight mb-5"
+          >
+            <span className="block text-zinc-900 dark:text-white">저평가 국내 주식,</span>
+            <span className="block text-transparent bg-clip-text bg-gradient-to-r from-blue-500 via-blue-600 to-violet-600">
+              데이터가 먼저 찾아드립니다.
+            </span>
+          </motion.h1>
 
-          {/* 실시간 발굴 수 — 데이터 로드 후 등장 */}
-          <div className="min-h-[36px] flex justify-center mb-6">
-            {!preview.loading && preview.total > 0 && (
-              <motion.div
-                initial={{ opacity: 0, scale: 0.9 }}
-                animate={{ opacity: 1, scale: 1 }}
-                transition={{ duration: 0.4 }}
-                className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-50 dark:bg-emerald-950/40 border border-emerald-200/70 dark:border-emerald-800/50"
-              >
-                <Sparkles size={12} className="text-emerald-600 dark:text-emerald-400" />
-                <span className="text-sm font-bold text-emerald-700 dark:text-emerald-400">
-                  오늘 <span className="font-black text-emerald-800 dark:text-emerald-300">{preview.total}개</span> 저평가 종목 발견
-                  {formattedDate && <span className="text-emerald-600/70 dark:text-emerald-500/70 font-medium ml-1.5">· {formattedDate}</span>}
-                </span>
-              </motion.div>
-            )}
-            {preview.loading && (
-              <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-50 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
-                <Loader2 size={12} className="animate-spin text-zinc-400" />
-                <span className="text-sm text-zinc-400 font-medium">오늘의 종목 집계 중...</span>
-              </div>
-            )}
-          </div>
+          <motion.p
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.15 }}
+            className="text-zinc-500 dark:text-zinc-400 text-base md:text-lg font-medium leading-relaxed mb-8 max-w-xl mx-auto"
+          >
+            벤자민 그레이엄의 NCAV 원칙을 포함한 9가지 퀀트 전략으로
+            감이 아닌 데이터 기반의 종목 발굴을 시작하세요.
+          </motion.p>
 
-          <div className="flex flex-wrap justify-center gap-3 mb-7">
-            {isLoggedIn ? (
+          {/* CTA */}
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.22 }}
+            className="flex flex-wrap justify-center gap-3 mb-8"
+          >
+            {!sessionLoading && (isLoggedIn ? (
               <Link href="/screener"
-                className="group inline-flex items-center gap-2 px-6 py-3 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-bold shadow-lg shadow-blue-600/25 transition-all"
+                className="group inline-flex items-center gap-2.5 px-7 py-3.5 rounded-full bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white text-sm font-bold shadow-lg shadow-blue-600/30 transition-all duration-200"
               >
+                <TrendingUp size={16} strokeWidth={2.5} />
                 종목 발굴하기
                 <ArrowRight size={15} className="group-hover:translate-x-0.5 transition-transform" />
               </Link>
             ) : (
               <Link href="/login"
-                className="group inline-flex items-center gap-2 px-6 py-3 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-bold shadow-lg shadow-blue-600/25 transition-all"
+                className="group inline-flex items-center gap-2.5 px-7 py-3.5 rounded-full bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white text-sm font-bold shadow-lg shadow-blue-600/30 transition-all duration-200"
               >
-                무료로 시작하기
+                카카오로 무료 시작
                 <ArrowRight size={15} className="group-hover:translate-x-0.5 transition-transform" />
               </Link>
-            )}
+            ))}
             <Link href="/analyze"
-              className="inline-flex items-center gap-2 px-6 py-3 rounded-full bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 text-zinc-700 dark:text-zinc-300 text-sm font-bold hover:border-zinc-400 dark:hover:border-zinc-500 transition-all"
+              className="inline-flex items-center gap-2 px-6 py-3.5 rounded-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 hover:border-zinc-400 dark:hover:border-zinc-500 text-zinc-700 dark:text-zinc-300 text-sm font-bold transition-all shadow-sm"
             >
-              종목 분석 해보기
+              종목 직접 분석하기
             </Link>
-          </div>
+          </motion.div>
 
-          <div className="flex flex-wrap justify-center items-center gap-x-5 gap-y-1.5 text-xs text-zinc-400 dark:text-zinc-500">
-            {["카카오 로그인 30초", "무료 플랜 영구 제공", "한국투자증권 API 연동"].map(t => (
-              <span key={t} className="flex items-center gap-1.5">
+          {/* 신뢰 지표 */}
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ delay: 0.35 }}
+            className="flex flex-wrap justify-center items-center gap-x-5 gap-y-2 text-xs text-zinc-400 dark:text-zinc-500"
+          >
+            {[
+              "카카오 로그인 30초",
+              "무료 플랜 영구 제공",
+              "한국투자증권 API 연동",
+              "9가지 퀀트 전략",
+            ].map(t => (
+              <span key={t} className="flex items-center gap-1.5 font-medium">
                 <CheckCircle2 size={11} className="text-emerald-500 shrink-0" />
                 {t}
               </span>
             ))}
+          </motion.div>
+        </div>
+
+        {/* 라이브 스탯 스트립 */}
+        <div className="border-t border-zinc-200/60 dark:border-zinc-800/60 bg-white/80 dark:bg-zinc-900/50 backdrop-blur-sm">
+          <div className="max-w-4xl mx-auto px-6 py-4 flex flex-wrap items-center justify-center gap-6 sm:gap-10">
+            {preview.loading ? (
+              <div className="flex items-center gap-2 text-zinc-400 py-1">
+                <Loader2 size={13} className="animate-spin" />
+                <span className="text-xs">데이터 집계 중...</span>
+              </div>
+            ) : preview.total > 0 ? (
+              <>
+                <Stat
+                  value={preview.total}
+                  label="오늘 발굴된 저평가 종목"
+                  color="text-blue-600 dark:text-blue-400"
+                />
+                <div className="h-6 w-px bg-zinc-200 dark:bg-zinc-700 hidden sm:block" />
+                <Stat
+                  value={preview.filteredTotal}
+                  label="시가총액 500억+ 종목"
+                  color="text-emerald-600 dark:text-emerald-400"
+                />
+                <div className="h-6 w-px bg-zinc-200 dark:bg-zinc-700 hidden sm:block" />
+                <div className="text-center">
+                  <p className="text-[11px] font-extrabold text-zinc-400 uppercase tracking-wider mb-0.5">업데이트</p>
+                  <p className="text-sm font-black text-zinc-700 dark:text-zinc-200">
+                    {formattedDate ?? "—"}
+                  </p>
+                </div>
+                <div className="h-6 w-px bg-zinc-200 dark:bg-zinc-700 hidden sm:block" />
+                <div className="text-center">
+                  <p className="text-[11px] font-extrabold text-zinc-400 uppercase tracking-wider mb-0.5">스캔 전략</p>
+                  <p className="text-sm font-black text-zinc-700 dark:text-zinc-200">9가지</p>
+                </div>
+              </>
+            ) : (
+              <div className="flex items-center gap-2 text-zinc-400 text-xs py-1">
+                <Activity size={13} className="text-zinc-300" />
+                스캔 데이터를 불러오는 중입니다.
+              </div>
+            )}
           </div>
-        </motion.div>
+        </div>
       </header>
 
       {/* ── 오늘의 발굴 종목 미리보기 ── */}
-      <section className="max-w-3xl mx-auto px-6 pb-20">
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          className="mb-4 flex items-end justify-between gap-4"
-        >
-          <div>
-            <div className="flex items-center gap-2 flex-wrap">
-              <h2 className="text-lg font-black tracking-tight">오늘의 발굴 종목</h2>
-              <span className="text-[10px] font-extrabold px-2 py-0.5 rounded-full bg-blue-50 dark:bg-blue-950/30 text-blue-600 dark:text-blue-400 border border-blue-200/60 dark:border-blue-800/40">
-                시가총액 500억+
-              </span>
-            </div>
-            <p className="text-xs text-zinc-400 mt-0.5">
-              {isLoggedIn ? "로그인 중 · 전체 목록은 스크리너에서 확인하세요" : "상위 3개 무료 공개 · 전체 목록은 로그인 후 확인 가능"}
-            </p>
-          </div>
-          <Link
-            href={isLoggedIn ? "/screener?mincap=500" : "/login"}
-            className="shrink-0 flex items-center gap-1 text-xs font-bold text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors whitespace-nowrap"
+      <section className="py-16 px-6 bg-white dark:bg-zinc-950">
+        <div className="max-w-3xl mx-auto">
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="flex items-end justify-between gap-4 mb-5"
           >
-            전체 {preview.filteredTotal > 0 ? `${preview.filteredTotal}개` : ""} 보기
-            <ChevronRight size={12} />
-          </Link>
-        </motion.div>
-
-        <motion.div
-          initial={{ opacity: 0, y: 16 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ delay: 0.06 }}
-          className="rounded-2xl border border-zinc-200 dark:border-zinc-800 overflow-hidden bg-white dark:bg-zinc-900 shadow-sm"
-        >
-          {/* 테이블 헤더 */}
-          <div className="px-5 py-2 bg-zinc-50 dark:bg-zinc-800/60 border-b border-zinc-200 dark:border-zinc-800 hidden sm:flex items-center justify-between gap-4">
-            <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider">종목</span>
-            <div className="flex items-center gap-6">
-              <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider hidden sm:block">PBR</span>
-              <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider hidden sm:block">PER</span>
-              <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider">NCAV 비율</span>
+            <div>
+              <p className="text-[11px] font-extrabold text-blue-500 uppercase tracking-[0.18em] mb-2">Today&apos;s Picks</p>
+              <div className="flex items-center gap-2.5 flex-wrap">
+                <h2 className="text-2xl font-black tracking-tight text-zinc-900 dark:text-white">오늘의 발굴 종목</h2>
+                <span className="text-[10px] font-extrabold px-2.5 py-1 rounded-full bg-blue-600 text-white">
+                  시가총액 500억+
+                </span>
+              </div>
+              <p className="text-xs text-zinc-400 mt-1.5">
+                {isLoggedIn
+                  ? `NCAV 비율 높은 순 · 전체 ${preview.filteredTotal}개는 스크리너에서`
+                  : "상위 3개 무료 공개 · 전체 목록은 로그인 후 확인 가능"}
+              </p>
             </div>
-          </div>
+            <Link
+              href={isLoggedIn ? "/screener?mincap=500" : "/login"}
+              className="shrink-0 flex items-center gap-1 text-xs font-bold text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors whitespace-nowrap"
+            >
+              전체 {preview.filteredTotal > 0 ? `${preview.filteredTotal}개` : ""} 보기
+              <ChevronRight size={13} />
+            </Link>
+          </motion.div>
 
-          {preview.loading ? (
-            <div className="flex items-center justify-center py-14 gap-2 text-zinc-400">
-              <Loader2 size={16} className="animate-spin" />
-              <span className="text-sm">불러오는 중...</span>
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ delay: 0.06 }}
+            className="rounded-2xl border border-zinc-200 dark:border-zinc-800 overflow-hidden bg-white dark:bg-zinc-900 shadow-md"
+          >
+            {/* 컬럼 헤더 */}
+            <div className="px-5 py-2.5 bg-zinc-50 dark:bg-zinc-800/70 border-b border-zinc-200 dark:border-zinc-800 flex items-center justify-between">
+              <span className="text-[10px] font-extrabold text-zinc-400 uppercase tracking-wider">종목</span>
+              <div className="flex items-center gap-5">
+                <span className="text-[10px] font-extrabold text-zinc-400 uppercase tracking-wider hidden sm:block">PBR</span>
+                <span className="text-[10px] font-extrabold text-zinc-400 uppercase tracking-wider hidden sm:block">PER</span>
+                <span className="text-[10px] font-extrabold text-zinc-400 uppercase tracking-wider">NCAV 비율</span>
+              </div>
             </div>
-          ) : preview.items.length === 0 ? (
-            <div className="py-12 text-center text-zinc-400 text-sm">스캔 데이터가 없습니다.</div>
-          ) : (
-            <>
-              {/* 공개 항목 (항상 표시) */}
-              {publicItems.map(item => (
-                <StockPreviewRow key={item.ticker} item={item} />
-              ))}
 
-              {/* 잠긴 항목 */}
-              {lockedItems.length > 0 && (
-                <div className="relative">
-                  {lockedItems.map(item => (
-                    <div
-                      key={item.ticker}
-                      className={cn(
-                        "transition-all duration-300",
-                        !isLoggedIn && "blur-sm select-none pointer-events-none"
-                      )}
-                    >
-                      <StockPreviewRow item={item} />
-                    </div>
-                  ))}
-                  {/* 비로그인 시 오버레이 */}
-                  {!isLoggedIn && (
-                    <div className="absolute inset-0 flex items-center justify-center bg-white/75 dark:bg-zinc-900/75 backdrop-blur-[2px]">
-                      <Link
-                        href="/login"
-                        className="group flex items-center gap-2 px-5 py-2.5 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-extrabold shadow-lg shadow-blue-600/20 transition-all"
+            {preview.loading ? (
+              <div className="flex items-center justify-center py-16 gap-2.5 text-zinc-400">
+                <Loader2 size={18} className="animate-spin" />
+                <span className="text-sm font-medium">종목 불러오는 중...</span>
+              </div>
+            ) : preview.items.length === 0 ? (
+              <div className="py-14 text-center">
+                <BarChart3 size={28} className="text-zinc-300 dark:text-zinc-600 mx-auto mb-3" />
+                <p className="text-sm text-zinc-400">스캔 데이터가 없습니다.</p>
+              </div>
+            ) : (
+              <>
+                {/* 공개 항목 */}
+                {publicItems.map((item, i) => (
+                  <StockPreviewRow key={item.ticker} item={item} index={i} />
+                ))}
+
+                {/* 잠긴 항목 */}
+                {lockedItems.length > 0 && (
+                  <div className="relative">
+                    {lockedItems.map((item, i) => (
+                      <div
+                        key={item.ticker}
+                        className={cn(
+                          "transition-all duration-300",
+                          !isLoggedIn && "blur-sm select-none pointer-events-none"
+                        )}
                       >
-                        <Lock size={13} />
-                        로그인하여 전체 {preview.total}개 보기
-                        <ArrowRight size={13} className="group-hover:translate-x-0.5 transition-transform" />
-                      </Link>
-                    </div>
-                  )}
-                </div>
-              )}
+                        <StockPreviewRow item={item} index={publicItems.length + i} />
+                      </div>
+                    ))}
 
-              {/* 로그인 후 스크리너 바로가기 CTA */}
-              {isLoggedIn && (
-                <div className="px-5 py-3 bg-blue-50 dark:bg-blue-950/20 border-t border-blue-100 dark:border-blue-900/40 flex items-center justify-between gap-4">
-                  <p className="text-xs text-blue-700 dark:text-blue-400 font-medium">
-                    시가총액 500억+ 기준 <span className="font-black">{preview.filteredTotal}개</span> 종목을 전략 필터와 함께 확인하세요.
-                  </p>
-                  <Link
-                    href="/screener?mincap=500"
-                    className="shrink-0 flex items-center gap-1 text-xs font-bold text-blue-700 dark:text-blue-400 hover:underline"
-                  >
-                    스크리너 열기 <ChevronRight size={11} />
-                  </Link>
-                </div>
-              )}
-            </>
-          )}
-        </motion.div>
+                    {!isLoggedIn && (
+                      <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-b from-white/60 to-white/90 dark:from-zinc-900/60 dark:to-zinc-900/90">
+                        <Link
+                          href="/login"
+                          className="group flex items-center gap-2.5 px-6 py-3 rounded-full bg-blue-600 hover:bg-blue-700 text-white text-sm font-extrabold shadow-xl shadow-blue-600/25 transition-all"
+                        >
+                          <Lock size={14} />
+                          로그인하여 전체 종목 확인
+                          <ArrowRight size={14} className="group-hover:translate-x-0.5 transition-transform" />
+                        </Link>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* 로그인 후 CTA */}
+                {isLoggedIn && (
+                  <div className="px-5 py-3.5 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/20 dark:to-indigo-950/20 border-t border-blue-100 dark:border-blue-900/40 flex items-center justify-between gap-4">
+                    <p className="text-xs text-blue-700 dark:text-blue-400 font-medium">
+                      시가총액 500억+ 기준 <span className="font-black">{preview.filteredTotal}개</span> 종목 · 전략 필터·정렬로 더 정밀하게 탐색하세요.
+                    </p>
+                    <Link
+                      href="/screener?mincap=500"
+                      className="shrink-0 flex items-center gap-1.5 px-3.5 py-1.5 rounded-lg bg-blue-600 text-white text-xs font-bold hover:bg-blue-700 transition-colors whitespace-nowrap"
+                    >
+                      스크리너 열기 <ChevronRight size={11} />
+                    </Link>
+                  </div>
+                )}
+              </>
+            )}
+          </motion.div>
+        </div>
       </section>
 
-      {/* ── 사용 방법 ── */}
-      <section className="border-t border-zinc-100 dark:border-zinc-800/60 bg-zinc-50 dark:bg-zinc-900/40 py-16 px-6">
-        <div className="max-w-3xl mx-auto">
-          <motion.p
+      {/* ── 기능 카드 ── */}
+      <section className="py-16 px-6 bg-zinc-50 dark:bg-zinc-900/40 border-t border-zinc-100 dark:border-zinc-800/60">
+        <div className="max-w-4xl mx-auto">
+          <motion.div
             initial={{ opacity: 0, y: 10 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            className="text-center text-[11px] font-extrabold text-blue-500 uppercase tracking-[0.2em] mb-10"
+            className="text-center mb-10"
           >
-            How it works
-          </motion.p>
+            <p className="text-[11px] font-extrabold text-blue-500 uppercase tracking-[0.2em] mb-3">Features</p>
+            <h2 className="text-2xl font-black text-zinc-900 dark:text-white mb-2">투자 결정을 위한 3단계</h2>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">발굴 → 분석 → 계산, 투자 판단에 필요한 모든 도구.</p>
+          </motion.div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-8 relative">
-            <div className="hidden md:block absolute top-7 left-[calc(16.66%+1rem)] right-[calc(16.66%+1rem)] h-px bg-gradient-to-r from-zinc-200 via-blue-300/50 to-zinc-200 dark:from-zinc-800 dark:via-blue-700/30 dark:to-zinc-800" />
-
-            {HOW_IT_WORKS.map((item, i) => {
-              const Icon = item.icon;
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {FEATURES.map((f, i) => {
+              const Icon = f.icon;
               return (
                 <motion.div
                   key={i}
                   initial={{ opacity: 0, y: 16 }}
                   whileInView={{ opacity: 1, y: 0 }}
                   viewport={{ once: true }}
-                  transition={{ delay: i * 0.12 }}
-                  className="flex flex-col items-center text-center"
+                  transition={{ delay: i * 0.1 }}
+                  className="group bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 p-6 hover:border-blue-300 dark:hover:border-blue-700 hover:shadow-md transition-all"
                 >
-                  <Link href={item.link} className="group relative w-14 h-14 rounded-2xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 hover:border-blue-400 dark:hover:border-blue-600 flex items-center justify-center mb-4 z-10 transition-all shadow-sm">
-                    <Icon size={22} className="text-blue-600 dark:text-blue-400" strokeWidth={1.8} />
-                    <span className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-blue-600 text-white text-[9px] font-black flex items-center justify-center">
-                      {item.step}
-                    </span>
+                  <div className={cn("w-10 h-10 rounded-xl flex items-center justify-center mb-4", f.bg)}>
+                    <Icon size={20} className={f.color} strokeWidth={1.8} />
+                  </div>
+                  <h3 className="text-base font-black mb-2 text-zinc-900 dark:text-white">{f.title}</h3>
+                  <p className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed mb-4 break-keep">{f.desc}</p>
+                  <Link href={f.link}
+                    className="inline-flex items-center gap-1 text-xs font-bold text-blue-600 dark:text-blue-400 hover:gap-1.5 transition-all group-hover:text-blue-700 dark:group-hover:text-blue-300"
+                  >
+                    {f.linkLabel} <ChevronRight size={12} />
                   </Link>
-                  <h3 className="text-base font-black mb-1.5">{item.title}</h3>
-                  <p className="text-xs text-zinc-500 dark:text-zinc-400 leading-relaxed break-keep">{item.desc}</p>
                 </motion.div>
               );
             })}
@@ -393,18 +497,71 @@ export default function HomePage() {
         </div>
       </section>
 
+      {/* ── 보증 스트립 ── */}
+      <section className="py-12 px-6 bg-white dark:bg-zinc-950 border-t border-zinc-100 dark:border-zinc-800/60">
+        <div className="max-w-4xl mx-auto">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {[
+              { icon: Zap, color: "text-amber-500", bg: "bg-amber-50 dark:bg-amber-950/30", title: "5분마다 자동 업데이트", desc: "KIS(한국투자증권) API로 실시간 재무 데이터와 시세를 반영해 전 종목을 롤링 스캔합니다." },
+              { icon: ShieldCheck, color: "text-emerald-600", bg: "bg-emerald-50 dark:bg-emerald-950/30", title: "검증된 퀀트 전략", desc: "벤자민 그레이엄·그린블라트·워렌 버핏의 투자 철학을 알고리즘으로 구현한 9가지 전략을 제공합니다." },
+              { icon: Activity, color: "text-blue-600", bg: "bg-blue-50 dark:bg-blue-950/30", title: "국내 전 종목 커버", desc: "KOSPI·KOSDAQ 상장 2,000여 종목을 매일 스캔하여 오늘 기준 저평가 후보 종목 목록을 제공합니다." },
+            ].map((item, i) => {
+              const Icon = item.icon;
+              return (
+                <motion.div
+                  key={i}
+                  initial={{ opacity: 0, y: 10 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: i * 0.08 }}
+                  className="flex gap-4 p-5 rounded-2xl bg-zinc-50 dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800"
+                >
+                  <div className={cn("w-9 h-9 rounded-xl flex items-center justify-center shrink-0", item.bg)}>
+                    <Icon size={17} className={item.color} strokeWidth={2} />
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-extrabold mb-1 text-zinc-900 dark:text-white">{item.title}</h3>
+                    <p className="text-[11px] text-zinc-500 dark:text-zinc-400 leading-relaxed break-keep">{item.desc}</p>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {/* ── 최종 CTA ── */}
+      {!isLoggedIn && !sessionLoading && (
+        <section className="py-16 px-6 bg-gradient-to-br from-blue-600 via-blue-700 to-indigo-700 dark:from-blue-700 dark:via-blue-800 dark:to-indigo-800">
+          <motion.div
+            initial={{ opacity: 0, y: 12 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="max-w-xl mx-auto text-center"
+          >
+            <h2 className="text-2xl font-black text-white mb-3">지금 바로 시작하세요</h2>
+            <p className="text-sm text-blue-200 mb-7 leading-relaxed">
+              카카오 로그인 30초 · 무료 · 신용카드 불필요
+            </p>
+            <Link href="/login"
+              className="inline-flex items-center gap-2.5 px-8 py-3.5 rounded-full bg-white text-blue-700 text-sm font-extrabold shadow-lg hover:bg-blue-50 transition-all"
+            >
+              카카오로 무료 시작
+              <ArrowRight size={15} />
+            </Link>
+          </motion.div>
+        </section>
+      )}
+
       {/* ── 푸터 ── */}
       <footer className="border-t border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-950">
-        <div className="max-w-3xl mx-auto px-6 py-8 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-          <div className="flex items-center gap-2">
+        <div className="max-w-4xl mx-auto px-6 py-8 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+          <div className="flex items-center gap-2.5">
             <TrendingUp size={16} className="text-blue-600" strokeWidth={2.5} />
             <span className="text-sm font-black tracking-tight">IDIOT QUANT</span>
-            <span className="text-xs text-zinc-400 font-medium ml-1">
-              KOSPI·KOSDAQ 퀀트 스크리너
-            </span>
+            <span className="text-xs text-zinc-400 font-medium">KOSPI · KOSDAQ 퀀트 스크리너</span>
           </div>
-
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-5">
             {[
               { label: "종목 발굴", href: isLoggedIn ? "/screener" : "/login" },
               { label: "종목 분석", href: "/analyze" },
@@ -419,7 +576,7 @@ export default function HomePage() {
           </div>
         </div>
         <div className="border-t border-zinc-100 dark:border-zinc-800/60">
-          <div className="max-w-3xl mx-auto px-6 py-3 flex flex-col sm:flex-row justify-between items-center gap-1">
+          <div className="max-w-4xl mx-auto px-6 py-3 flex flex-col sm:flex-row justify-between items-center gap-1">
             <p className="text-[10px] text-zinc-400 dark:text-zinc-500">© 2026 IDIOT QUANT · Powered by 한국투자증권 API</p>
             <p className="text-[10px] text-zinc-400 dark:text-zinc-500 text-center sm:text-right">
               본 서비스는 투자 참고 목적으로 제공되며, 투자 결과에 대한 책임을 지지 않습니다.
@@ -428,6 +585,15 @@ export default function HomePage() {
         </div>
       </footer>
 
+    </div>
+  );
+}
+
+function Stat({ value, label, color }: { value: number; label: string; color: string }) {
+  return (
+    <div className="text-center">
+      <p className={cn("text-2xl font-black tabular-nums", color)}>{value.toLocaleString()}</p>
+      <p className="text-[11px] font-medium text-zinc-400 mt-0.5">{label}</p>
     </div>
   );
 }

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -17,7 +17,10 @@ interface PreviewStock {
   pbr: number;
   per: number;
   strategies: string[];
+  market_cap?: number;
 }
+
+const HOME_MKTCAP_MIN = 500; // 억원
 
 const STRATEGY_LABEL: Record<string, string> = {
   ncav: "NCAV", low_pbr: "저PBR", low_per: "저PER", s_rim: "S-RIM",
@@ -111,16 +114,26 @@ export default function HomePage() {
   const [preview, setPreview] = useState<{
     items: PreviewStock[];
     total: number;
+    filteredTotal: number;
     scanDate: string | null;
     loading: boolean;
-  }>({ items: [], total: 0, scanDate: null, loading: true });
+  }>({ items: [], total: 0, filteredTotal: 0, scanDate: null, loading: true });
 
   useEffect(() => {
-    fetch("/api/proxy/scan/daily?strategy=all&limit=5&sort=ncav_ratio&order=desc")
+    fetch("/api/proxy/scan/daily?strategy=all&limit=200&sort=ncav_ratio&order=desc")
       .then(r => r.json())
       .then((data: any) => {
         if (data.success) {
-          setPreview({ items: data.data, total: data.meta.total, scanDate: data.meta.scanDate, loading: false });
+          const all: PreviewStock[] = data.data;
+          // 시가총액 500억+ 필터 (단위: 억원)
+          const filtered = all.filter(item => (item.market_cap ?? 0) >= HOME_MKTCAP_MIN);
+          setPreview({
+            items: filtered.slice(0, 5),
+            total: data.meta.total,
+            filteredTotal: filtered.length,
+            scanDate: data.meta.scanDate,
+            loading: false,
+          });
         } else {
           setPreview(p => ({ ...p, loading: false }));
         }
@@ -240,16 +253,21 @@ export default function HomePage() {
           className="mb-4 flex items-end justify-between gap-4"
         >
           <div>
-            <h2 className="text-lg font-black tracking-tight">오늘의 발굴 종목</h2>
+            <div className="flex items-center gap-2 flex-wrap">
+              <h2 className="text-lg font-black tracking-tight">오늘의 발굴 종목</h2>
+              <span className="text-[10px] font-extrabold px-2 py-0.5 rounded-full bg-blue-50 dark:bg-blue-950/30 text-blue-600 dark:text-blue-400 border border-blue-200/60 dark:border-blue-800/40">
+                시가총액 500억+
+              </span>
+            </div>
             <p className="text-xs text-zinc-400 mt-0.5">
               {isLoggedIn ? "로그인 중 · 전체 목록은 스크리너에서 확인하세요" : "상위 3개 무료 공개 · 전체 목록은 로그인 후 확인 가능"}
             </p>
           </div>
           <Link
-            href={isLoggedIn ? "/screener" : "/login"}
+            href={isLoggedIn ? "/screener?mincap=500" : "/login"}
             className="shrink-0 flex items-center gap-1 text-xs font-bold text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors whitespace-nowrap"
           >
-            전체 {preview.total > 0 ? `${preview.total}개` : ""} 보기
+            전체 {preview.filteredTotal > 0 ? `${preview.filteredTotal}개` : ""} 보기
             <ChevronRight size={12} />
           </Link>
         </motion.div>
@@ -319,10 +337,10 @@ export default function HomePage() {
               {isLoggedIn && (
                 <div className="px-5 py-3 bg-blue-50 dark:bg-blue-950/20 border-t border-blue-100 dark:border-blue-900/40 flex items-center justify-between gap-4">
                   <p className="text-xs text-blue-700 dark:text-blue-400 font-medium">
-                    전체 <span className="font-black">{preview.total}개</span> 종목을 전략 필터와 함께 확인하세요.
+                    시가총액 500억+ 기준 <span className="font-black">{preview.filteredTotal}개</span> 종목을 전략 필터와 함께 확인하세요.
                   </p>
                   <Link
-                    href="/screener"
+                    href="/screener?mincap=500"
                     className="shrink-0 flex items-center gap-1 text-xs font-bold text-blue-700 dark:text-blue-400 hover:underline"
                   >
                     스크리너 열기 <ChevronRight size={11} />

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -129,6 +129,14 @@ function resolveStrategies(item: Record<string, any>): string[] {
     return Array.from(base);
 }
 
+// 시가총액 프리셋 (단위: 억원)
+const MKTCAP_PRESETS: { label: string; value: number }[] = [
+    { label: "전체", value: 0 },
+    { label: "500억+", value: 500 },
+    { label: "1000억+", value: 1000 },
+    { label: "5000억+", value: 5000 },
+];
+
 const TOOLTIP_CLS =
     "z-50 max-w-64 rounded-xl px-3.5 py-3 text-xs bg-zinc-900 dark:bg-zinc-800 border border-zinc-700/60 shadow-xl text-zinc-200 leading-relaxed " +
     "data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 " +
@@ -333,6 +341,11 @@ function ScreenerContent() {
         searchParams.get('exclude')?.split(',').includes('deficit') ?? false
     );
     const [filterOpen, setFilterOpen] = useState(false);
+    // 시가총액 필터 (단위: 억원, URL param: mincap)
+    const [minMarketCap, setMinMarketCap] = useState<number>(() => {
+        const mc = Number(searchParams.get('mincap') ?? 0);
+        return MKTCAP_PRESETS.some(p => p.value === mc) ? mc : 0;
+    });
 
     const hasDiscovered = useRef(false);
 
@@ -369,10 +382,11 @@ function ScreenerContent() {
             excludeDeficit ? 'deficit' : null,
         ].filter(Boolean).join(',');
         if (excludeList) params.set('exclude', excludeList);
+        if (minMarketCap > 0) params.set('mincap', String(minMarketCap));
 
         const qs = params.toString();
         router.replace(qs ? `/screener?${qs}` : '/screener', { scroll: false });
-    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, router]);
+    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, minMarketCap, router]);
 
     const handleRefresh = useCallback(() => {
         dispatch(reqGetNcavDailyList("latest"));
@@ -412,6 +426,7 @@ function ScreenerContent() {
         setSearchQuery('');
         setExcludeHoldings(false);
         setExcludeDeficit(false);
+        setMinMarketCap(0);
         setDisplayCount(DAILY_PAGE_SIZE);
     }, []);
 
@@ -450,6 +465,7 @@ function ScreenerContent() {
 
         if (excludeHoldings) list = list.filter(item => !item.name?.includes("홀딩스"));
         if (excludeDeficit)  list = list.filter(item => safeNum(item.eps) > 0);
+        if (minMarketCap > 0) list = list.filter(item => safeNum(item.market_cap) >= minMarketCap);
 
         list.sort((a, b) => {
             if (sortKey === "ticker") {
@@ -468,7 +484,7 @@ function ScreenerContent() {
         });
 
         return list;
-    }, [ncavDailyList.list, activeStrategyIds, filterMode, searchQuery, excludeHoldings, excludeDeficit, sortKey, sortOrder]);
+    }, [ncavDailyList.list, activeStrategyIds, filterMode, searchQuery, excludeHoldings, excludeDeficit, minMarketCap, sortKey, sortOrder]);
 
     const visibleList = filteredList.slice(0, displayCount);
     const hasMore = filteredList.length > displayCount;
@@ -483,9 +499,9 @@ function ScreenerContent() {
         ? `${scanDate.slice(0, 4)}.${scanDate.slice(4, 6)}.${scanDate.slice(6, 8)}`
         : null;
 
-    const activeFilterCount = [excludeHoldings, excludeDeficit].filter(Boolean).length;
+    const activeFilterCount = [excludeHoldings, excludeDeficit, minMarketCap > 0].filter(Boolean).length;
     const isAllActive = activeStrategyIds.size === 0;
-    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || sortKey !== 'ncav_ratio' || sortOrder !== 'desc';
+    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || minMarketCap > 0 || sortKey !== 'ncav_ratio' || sortOrder !== 'desc';
 
     return (
         <Tooltip.Provider delayDuration={300}>
@@ -597,7 +613,7 @@ function ScreenerContent() {
                             <span className="hidden sm:inline">전략 안내</span>
                         </button>
 
-                        {/* 필터 초기화 버튼 */}
+                        {/* 전체 필터 초기화 */}
                         {hasActiveFilters && (
                             <button
                                 onClick={resetAllFilters}
@@ -746,25 +762,51 @@ function ScreenerContent() {
                 </button>
 
                 {filterOpen && (
-                    <div className="w-full flex flex-wrap items-center gap-4 px-1 py-2">
-                        <label className="flex items-center gap-2 cursor-pointer select-none">
-                            <input
-                                type="checkbox"
-                                checked={excludeHoldings}
-                                onChange={e => setExcludeHoldings(e.target.checked)}
-                                className="rounded accent-blue-600"
-                            />
-                            <span className="text-xs font-bold text-zinc-600 dark:text-zinc-400">홀딩스 제외</span>
-                        </label>
-                        <label className="flex items-center gap-2 cursor-pointer select-none">
-                            <input
-                                type="checkbox"
-                                checked={excludeDeficit}
-                                onChange={e => setExcludeDeficit(e.target.checked)}
-                                className="rounded accent-blue-600"
-                            />
-                            <span className="text-xs font-bold text-zinc-600 dark:text-zinc-400">적자 기업 제외</span>
-                        </label>
+                    <div className="w-full flex flex-wrap items-center gap-x-5 gap-y-3 px-1 py-2">
+                        {/* 시가총액 필터 */}
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <span className="text-[10px] font-extrabold text-zinc-400 uppercase tracking-wider">시가총액</span>
+                            {MKTCAP_PRESETS.map(p => (
+                                <button
+                                    key={p.value}
+                                    onClick={() => { setMinMarketCap(p.value); setDisplayCount(DAILY_PAGE_SIZE); }}
+                                    className={cn(
+                                        "px-2.5 py-1 rounded-lg border text-xs font-bold transition-all",
+                                        minMarketCap === p.value
+                                            ? "bg-blue-600 border-blue-600 text-white shadow-sm"
+                                            : "bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-600"
+                                    )}
+                                >
+                                    {p.label}
+                                </button>
+                            ))}
+                        </div>
+
+                        {/* 구분선 */}
+                        <div className="w-px h-4 bg-zinc-200 dark:bg-zinc-700 hidden sm:block" />
+
+                        {/* 제외 조건 */}
+                        <div className="flex items-center gap-4 flex-wrap">
+                            <span className="text-[10px] font-extrabold text-zinc-400 uppercase tracking-wider">제외</span>
+                            <label className="flex items-center gap-2 cursor-pointer select-none">
+                                <input
+                                    type="checkbox"
+                                    checked={excludeHoldings}
+                                    onChange={e => setExcludeHoldings(e.target.checked)}
+                                    className="rounded accent-blue-600"
+                                />
+                                <span className="text-xs font-bold text-zinc-600 dark:text-zinc-400">홀딩스</span>
+                            </label>
+                            <label className="flex items-center gap-2 cursor-pointer select-none">
+                                <input
+                                    type="checkbox"
+                                    checked={excludeDeficit}
+                                    onChange={e => setExcludeDeficit(e.target.checked)}
+                                    className="rounded accent-blue-600"
+                                />
+                                <span className="text-xs font-bold text-zinc-600 dark:text-zinc-400">적자 기업</span>
+                            </label>
+                        </div>
                     </div>
                 )}
             </div>


### PR DESCRIPTION
## Summary

- 스크리너에 시가총액 프리셋 필터 추가 (전체 / 500억+ / 1000억+ / 5000억+)
- 홈 온보딩 페이지 UI를 상용 SaaS 제품 수준으로 전면 재설계
- main 리베이스 후 모든 필터 URL 파라미터 단일 `useEffect`로 통합

---

## 변경 내용

### `app/(screener)/screener/page.tsx`

#### 시가총액 프리셋 필터
필터 버튼 클릭 시 펼쳐지는 필터 바에 시가총액 섹션 추가:

| 버튼 | 기준 (억원) |
|---|---|
| 전체 | 제한 없음 |
| 500억+ | ≥ 500억 |
| 1000억+ | ≥ 1,000억 |
| 5000억+ | ≥ 5,000억 |

- URL param `mincap` 으로 동기화 → `/screener?mincap=500`
- 기존 URL 동기화 `useEffect`에 `mincap` 통합 (main PR #377 리베이스)
- 뒤로가기·새로고침·공유 링크에서 필터 복원
- `resetAllFilters`에 `setMinMarketCap(0)` 포함

### `app/(home)/page.tsx` — 상용 제품 수준 UI 재설계

#### 히어로 섹션
- 그라데이션 배경 (파란/보라 blurred blob)
- 실시간 Pulse 배지 (Live 신호 도트)
- 큰 그라데이션 헤드라인 타이포그래피
- 로그인 상태별 CTA 분기 (카카오 무료 시작 / 종목 발굴하기)
- 신뢰 지표 4개 (카카오 로그인 30초, 무료 영구, KIS API, 9가지 전략)

#### 라이브 스탯 스트립 (히어로 하단)
- 오늘 발굴된 저평가 종목 수
- 시가총액 500억+ 종목 수
- 마지막 스캔 날짜
- 스캔 전략 수 (9가지)

#### 오늘의 발굴 종목 미리보기
- NCAV 비율 미니 progress bar 추가
- 순위 번호 표시
- 전략 배지 컬러 풀셋 (9가지)
- 비로그인: 상위 3개 공개, 나머지 blur + 오버레이 CTA
- 로그인: 하단 스크리너 열기 CTA 배너

#### 기능 카드 3개
- 종목 발굴 / 상세 분석 / 수익 계산기 각 카드
- hover 효과, 각 페이지 링크

#### 보증 스트립
- 5분마다 자동 업데이트 / 검증된 퀀트 전략 / 국내 전 종목 커버

#### 비로그인 최종 CTA 섹션
- 파란 그라데이션 배경의 풀-블리드 CTA 섹션

---

## 참고

`market_cap` 필드 단위는 KIS API 기준 **억원**으로 가정합니다.

https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA