### PR TITLE
feat: Claude.ai-style UI 리디자인 — 사이드바 네비 + 중립 컬러 팔레트

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -388,10 +388,10 @@ function AnalyzeContent() {
     }
   }, [isLoaded, krOrUs, data]);
 
-  if (!hasMounted) return <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950" />;
+  if (!hasMounted) return <div className="min-h-screen bg-stone-100 dark:bg-[#0d0d0d]" />;
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 antialiased">
+    <div className="min-h-screen bg-stone-100 dark:bg-[#0d0d0d] text-neutral-900 dark:text-neutral-100 antialiased">
 
       {/* ── Toast ── */}
       <div className="fixed top-4 right-4 z-[100] space-y-2 max-w-sm w-full pointer-events-none px-4 sm:px-0">
@@ -401,7 +401,7 @@ function AnalyzeContent() {
       </div>
 
       {/* ── 헤더 ── */}
-      <header className="sticky top-0 z-30 bg-white dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800 shadow-sm">
+      <header className="sticky top-0 z-30 bg-white dark:bg-[#111111] border-b border-neutral-200 dark:border-[#222222]">
         {fromScreener && (
           <div className="border-b border-zinc-100 dark:border-zinc-800/60">
             <div className="max-w-4xl mx-auto px-4 py-2">
@@ -797,7 +797,7 @@ function AnalyzeContent() {
 export default function AnalyzePage() {
   return (
     <Suspense fallback={
-      <div className="flex flex-col items-center justify-center py-40 gap-5 bg-zinc-50 dark:bg-zinc-950 min-h-screen">
+      <div className="flex flex-col items-center justify-center py-40 gap-5 bg-stone-100 dark:bg-[#0d0d0d] min-h-screen">
         <div className="p-4 bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm">
           <Loader2 className="animate-spin text-blue-600 dark:text-blue-400" size={24} />
         </div>

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -3,10 +3,9 @@
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { motion } from "framer-motion";
 import {
-  Search, Calculator, BarChart3, Lock, ArrowRight,
-  TrendingUp, ChevronRight, Loader2, LayoutGrid,
+  Search, Calculator, Filter, Lock, ArrowRight,
+  TrendingUp, ChevronRight, Loader2, BarChart3,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -42,76 +41,72 @@ const STRATEGY_BADGE_CLS: Record<string, string> = {
 
 const FEATURES = [
   {
-    icon: LayoutGrid,
-    color: "text-blue-600 dark:text-blue-400",
-    bg: "bg-blue-50 dark:bg-blue-950/30",
+    icon: Filter,
+    iconCls: "text-blue-600 dark:text-blue-400",
+    bgCls: "bg-blue-50 dark:bg-blue-950/30",
     title: "종목 발굴",
-    desc: "9가지 퀀트 전략으로 KOSPI·KOSDAQ 전 종목을 매일 자동 스캔.",
+    desc: "9가지 퀀트 전략으로 KOSPI·KOSDAQ 전 종목을 매일 자동 스캔합니다.",
     link: "/screener",
     linkLabel: "스크리너 열기",
   },
   {
     icon: Search,
-    color: "text-violet-600 dark:text-violet-400",
-    bg: "bg-violet-50 dark:bg-violet-950/30",
+    iconCls: "text-violet-600 dark:text-violet-400",
+    bgCls: "bg-violet-50 dark:bg-violet-950/30",
     title: "적정주가 분석",
-    desc: "NCAV·S-RIM·PBR·PER 4개 모델로 적정 주가와 괴리율 즉시 계산.",
+    desc: "NCAV·S-RIM·PBR·PER 4개 모델로 적정 주가와 괴리율을 즉시 계산합니다.",
     link: "/analyze",
     linkLabel: "종목 분석하기",
   },
   {
     icon: Calculator,
-    color: "text-emerald-600 dark:text-emerald-400",
-    bg: "bg-emerald-50 dark:bg-emerald-950/30",
+    iconCls: "text-emerald-600 dark:text-emerald-400",
+    bgCls: "bg-emerald-50 dark:bg-emerald-950/30",
     title: "수익 계산기",
-    desc: "거래세·수수료 포함 세후 순수익과 연환산 수익률을 즉시 산출.",
+    desc: "거래세·수수료 포함 세후 순수익과 연환산 수익률을 즉시 산출합니다.",
     link: "/calculator",
     linkLabel: "계산해보기",
   },
 ];
 
-function StockPreviewRow({ item, index }: { item: PreviewStock; index: number }) {
+function StockRow({ item, index }: { item: PreviewStock; index: number }) {
   const ncav = item.ncav_ratio;
   const strategies = item.strategies?.slice(0, 2) ?? [];
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 6 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true }}
-      transition={{ delay: 0.04 * index }}
-      className="flex items-center gap-3 px-4 py-3.5 border-b border-zinc-100 dark:border-zinc-800/60 last:border-0 active:bg-zinc-50 dark:active:bg-zinc-800/30 transition-colors"
-    >
-      <span className="w-4 text-[10px] font-black text-zinc-300 dark:text-zinc-600 tabular-nums shrink-0">{index + 1}</span>
+    <div className="flex items-center gap-3 px-4 py-3.5 border-b border-neutral-100 dark:border-[#2a2a2a] last:border-0 transition-colors">
+      <span className="w-4 text-[10px] font-black text-neutral-300 dark:text-neutral-600 tabular-nums shrink-0">
+        {index + 1}
+      </span>
 
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5 mb-0.5 flex-wrap">
-          <p className="font-bold text-sm text-zinc-900 dark:text-white truncate leading-tight">{item.name}</p>
+          <p className="font-semibold text-sm text-neutral-900 dark:text-neutral-50 truncate leading-tight">
+            {item.name}
+          </p>
           {strategies.map(s => (
             <span key={s} className={cn(
               "text-[9px] font-extrabold px-1.5 py-0.5 rounded border leading-none",
-              STRATEGY_BADGE_CLS[s] ?? "bg-zinc-100 text-zinc-500 border-zinc-200"
+              STRATEGY_BADGE_CLS[s] ?? "bg-neutral-100 text-neutral-500 border-neutral-200"
             )}>
               {STRATEGY_LABEL[s] ?? s}
             </span>
           ))}
         </div>
-        <p className="text-[10px] text-zinc-400 font-mono">{item.ticker}</p>
+        <p className="text-[10px] text-neutral-400 font-mono">{item.ticker}</p>
       </div>
 
-      <div className={cn(
-        "shrink-0 text-right min-w-[52px]",
-      )}>
+      <div className="shrink-0 text-right min-w-[52px]">
         <p className={cn(
           "text-sm font-black font-mono tabular-nums",
           ncav >= 1 ? "text-emerald-600 dark:text-emerald-400" :
-          ncav >= 0.7 ? "text-amber-600 dark:text-amber-400" : "text-zinc-400"
+          ncav >= 0.7 ? "text-amber-600 dark:text-amber-400" : "text-neutral-400"
         )}>
           {ncav > 0 ? `${ncav.toFixed(2)}x` : "—"}
         </p>
-        <p className="text-[9px] text-zinc-400 font-bold uppercase tracking-wider">NCAV</p>
+        <p className="text-[9px] text-neutral-400 font-bold uppercase tracking-wider">NCAV</p>
       </div>
-    </motion.div>
+    </div>
   );
 }
 
@@ -156,134 +151,109 @@ export default function HomePage() {
     : null;
 
   return (
-    <div className="min-h-screen bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-50">
+    <div className="min-h-screen">
 
-      {/* ── 히어로 ── */}
-      <header className="relative overflow-hidden">
-        <div className="absolute inset-0 -z-10">
-          <div className="absolute inset-0 bg-gradient-to-b from-blue-50/70 via-white to-white dark:from-blue-950/20 dark:via-zinc-950 dark:to-zinc-950" />
-          <div className="absolute top-0 left-1/4 w-[500px] h-[400px] bg-blue-400/8 dark:bg-blue-600/8 blur-[90px] rounded-full" />
-        </div>
+      {/* ── HERO ─────────────────────────────────────────────────── */}
+      <section className="bg-white dark:bg-[#111111] border-b border-neutral-200/70 dark:border-[#222222]">
+        <div className="max-w-lg mx-auto px-5 pt-10 pb-8 sm:pt-14 sm:pb-10">
 
-        <div className="max-w-lg mx-auto px-5 pt-10 pb-8 sm:pt-16 sm:pb-12 text-center">
-          {/* Live 뱃지 */}
-          <motion.div
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.4 }}
-            className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 shadow-sm mb-5"
-          >
+          {/* Live badge */}
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-stone-100 dark:bg-[#1a1a1a] border border-neutral-200 dark:border-[#2a2a2a] mb-5 text-[11px] font-medium text-neutral-500 dark:text-neutral-400">
             <span className="relative flex h-1.5 w-1.5 shrink-0">
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
               <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
             </span>
-            <span className="text-[11px] font-semibold text-zinc-500 dark:text-zinc-400">
-              매일 자동 스캔 · KOSPI · KOSDAQ
-            </span>
-          </motion.div>
+            매일 자동 스캔 · KOSPI · KOSDAQ
+          </div>
 
-          {/* 헤드라인 */}
-          <motion.h1
-            initial={{ opacity: 0, y: 14 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.55, delay: 0.07 }}
-            className="text-[2.2rem] sm:text-[3.2rem] font-black leading-[1.06] tracking-tight mb-4"
-          >
-            <span className="block text-zinc-900 dark:text-white">저평가 국내 주식,</span>
-            <span className="block text-transparent bg-clip-text bg-gradient-to-r from-blue-500 via-blue-600 to-violet-600">
-              데이터가 찾아드립니다.
-            </span>
-          </motion.h1>
+          {/* Headline */}
+          <h1 className="text-[2.1rem] sm:text-[3rem] font-black leading-[1.08] tracking-tight mb-4 text-neutral-900 dark:text-neutral-50">
+            저평가 국내 주식,<br />
+            <span className="text-blue-600 dark:text-blue-400">데이터가 찾아드립니다.</span>
+          </h1>
 
-          <motion.p
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.13 }}
-            className="text-sm sm:text-base text-zinc-500 dark:text-zinc-400 font-medium leading-relaxed mb-7"
-          >
+          <p className="text-sm sm:text-[15px] text-neutral-500 dark:text-neutral-400 font-medium leading-relaxed mb-7">
             9가지 퀀트 전략으로 매일 저평가 종목을 발굴하고<br className="hidden sm:block" />
             적정 주가까지 즉시 확인하세요.
-          </motion.p>
+          </p>
 
-          {/* CTA 버튼 */}
-          <motion.div
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.45, delay: 0.2 }}
-            className="flex flex-col sm:flex-row justify-center gap-2.5"
-          >
+          {/* CTA buttons */}
+          <div className="flex flex-col sm:flex-row gap-2.5">
             {!sessionLoading && (isLoggedIn ? (
               <Link href="/screener"
-                className="group inline-flex items-center justify-center gap-2 w-full sm:w-auto px-6 py-3.5 rounded-2xl bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white text-sm font-bold shadow-lg shadow-blue-600/25 transition-all"
+                className="inline-flex items-center justify-center gap-2 w-full sm:w-auto px-6 py-3 rounded-xl bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white text-sm font-bold shadow-md shadow-blue-600/20 transition-all"
               >
                 <TrendingUp size={15} strokeWidth={2.5} />
                 종목 발굴하기
-                <ArrowRight size={14} className="group-hover:translate-x-0.5 transition-transform" />
+                <ArrowRight size={14} />
               </Link>
             ) : (
               <Link href="/login"
-                className="group inline-flex items-center justify-center gap-2 w-full sm:w-auto px-6 py-3.5 rounded-2xl bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white text-sm font-bold shadow-lg shadow-blue-600/25 transition-all"
+                className="inline-flex items-center justify-center gap-2 w-full sm:w-auto px-6 py-3 rounded-xl bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white text-sm font-bold shadow-md shadow-blue-600/20 transition-all"
               >
                 카카오로 무료 시작
-                <ArrowRight size={14} className="group-hover:translate-x-0.5 transition-transform" />
+                <ArrowRight size={14} />
               </Link>
             ))}
             <Link href="/analyze"
-              className="inline-flex items-center justify-center gap-2 w-full sm:w-auto px-6 py-3.5 rounded-2xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 hover:border-zinc-400 dark:hover:border-zinc-500 text-zinc-700 dark:text-zinc-300 text-sm font-bold transition-all"
+              className="inline-flex items-center justify-center gap-2 w-full sm:w-auto px-6 py-3 rounded-xl bg-stone-100 dark:bg-[#1a1a1a] border border-neutral-200 dark:border-[#2a2a2a] hover:border-neutral-400 dark:hover:border-[#3a3a3a] text-neutral-700 dark:text-neutral-300 text-sm font-bold transition-all"
             >
               종목 직접 분석하기
             </Link>
-          </motion.div>
-        </div>
-
-        {/* 스탯 스트립 */}
-        <div className="border-t border-zinc-100 dark:border-zinc-800/60 bg-white/80 dark:bg-zinc-900/50 backdrop-blur-sm">
-          <div className="max-w-lg mx-auto px-5 py-3">
-            {preview.loading ? (
-              <div className="flex items-center justify-center gap-2 text-zinc-400 py-2">
-                <Loader2 size={12} className="animate-spin" />
-                <span className="text-xs">집계 중...</span>
-              </div>
-            ) : preview.total > 0 ? (
-              <div className="grid grid-cols-3 gap-0">
-                <div className="text-center py-1">
-                  <p className="text-xl font-black text-blue-600 dark:text-blue-400 tabular-nums leading-none">
-                    {preview.total.toLocaleString()}
-                  </p>
-                  <p className="text-[10px] text-zinc-400 font-medium mt-1">오늘 발굴 종목</p>
-                </div>
-                <div className="text-center py-1 border-x border-zinc-100 dark:border-zinc-800">
-                  <p className="text-xl font-black text-emerald-600 dark:text-emerald-400 tabular-nums leading-none">
-                    {preview.filteredTotal.toLocaleString()}
-                  </p>
-                  <p className="text-[10px] text-zinc-400 font-medium mt-1">시총 500억+</p>
-                </div>
-                <div className="text-center py-1">
-                  <p className="text-xl font-black text-zinc-700 dark:text-zinc-200 tabular-nums leading-none">
-                    {formattedDate ?? "—"}
-                  </p>
-                  <p className="text-[10px] text-zinc-400 font-medium mt-1">업데이트</p>
-                </div>
-              </div>
-            ) : null}
           </div>
         </div>
-      </header>
 
-      {/* ── 오늘의 발굴 종목 ── */}
-      <section className="py-8 px-5 bg-white dark:bg-zinc-950">
+        {/* Stats strip */}
+        {!preview.loading && preview.total > 0 && (
+          <div className="border-t border-neutral-100 dark:border-[#1f1f1f]">
+            <div className="max-w-lg mx-auto px-5 py-3 grid grid-cols-3 gap-0">
+              <div className="text-center py-1">
+                <p className="text-xl font-black text-blue-600 dark:text-blue-400 tabular-nums leading-none">
+                  {preview.total.toLocaleString()}
+                </p>
+                <p className="text-[10px] text-neutral-400 font-medium mt-1">오늘 발굴 종목</p>
+              </div>
+              <div className="text-center py-1 border-x border-neutral-100 dark:border-[#1f1f1f]">
+                <p className="text-xl font-black text-emerald-600 dark:text-emerald-400 tabular-nums leading-none">
+                  {preview.filteredTotal.toLocaleString()}
+                </p>
+                <p className="text-[10px] text-neutral-400 font-medium mt-1">시총 500억+</p>
+              </div>
+              <div className="text-center py-1">
+                <p className="text-xl font-black text-neutral-700 dark:text-neutral-200 tabular-nums leading-none">
+                  {formattedDate ?? "—"}
+                </p>
+                <p className="text-[10px] text-neutral-400 font-medium mt-1">업데이트</p>
+              </div>
+            </div>
+          </div>
+        )}
+        {preview.loading && (
+          <div className="border-t border-neutral-100 dark:border-[#1f1f1f] flex items-center justify-center gap-2 py-3 text-neutral-400">
+            <Loader2 size={11} className="animate-spin" />
+            <span className="text-xs">집계 중...</span>
+          </div>
+        )}
+      </section>
+
+      {/* ── TODAY'S PICKS ─────────────────────────────────────────── */}
+      <section className="py-6 px-5">
         <div className="max-w-lg mx-auto">
-          {/* 섹션 헤더 */}
-          <div className="flex items-center justify-between mb-4">
+
+          <div className="flex items-center justify-between mb-3">
             <div>
               <div className="flex items-center gap-2">
-                <h2 className="text-base font-black tracking-tight text-zinc-900 dark:text-white">오늘의 발굴 종목</h2>
+                <h2 className="text-base font-black tracking-tight text-neutral-900 dark:text-neutral-50">
+                  오늘의 발굴 종목
+                </h2>
                 <span className="text-[9px] font-extrabold px-2 py-0.5 rounded-full bg-blue-600 text-white">
                   500억+
                 </span>
               </div>
-              <p className="text-[11px] text-zinc-400 mt-0.5">
-                {isLoggedIn ? `NCAV 비율 순 · 전체 ${preview.filteredTotal}개` : "상위 3개 공개 · 전체는 로그인 후"}
+              <p className="text-[11px] text-neutral-400 mt-0.5">
+                {isLoggedIn
+                  ? `NCAV 비율 순 · 전체 ${preview.filteredTotal}개`
+                  : "상위 3개 공개 · 전체는 로그인 후"}
               </p>
             </div>
             <Link
@@ -294,31 +264,31 @@ export default function HomePage() {
             </Link>
           </div>
 
-          {/* 종목 리스트 카드 */}
-          <div className="rounded-2xl border border-zinc-200 dark:border-zinc-800 overflow-hidden bg-white dark:bg-zinc-900 shadow-sm">
-            {/* 헤더 */}
-            <div className="px-4 py-2 bg-zinc-50 dark:bg-zinc-800/70 border-b border-zinc-100 dark:border-zinc-800 flex items-center justify-between">
-              <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider">종목</span>
-              <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider">NCAV 비율</span>
+          {/* Stock list card */}
+          <div className="rounded-2xl border border-neutral-200 dark:border-[#2a2a2a] overflow-hidden bg-white dark:bg-[#1a1a1a] shadow-sm">
+            {/* Column headers */}
+            <div className="px-4 py-2 bg-stone-50 dark:bg-[#111111] border-b border-neutral-100 dark:border-[#2a2a2a] flex items-center justify-between">
+              <span className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider">종목</span>
+              <span className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider">NCAV 비율</span>
             </div>
 
             {preview.loading ? (
-              <div className="flex items-center justify-center py-12 gap-2 text-zinc-400">
+              <div className="flex items-center justify-center py-12 gap-2 text-neutral-400">
                 <Loader2 size={16} className="animate-spin" />
                 <span className="text-sm">불러오는 중...</span>
               </div>
             ) : preview.items.length === 0 ? (
               <div className="py-10 text-center">
-                <BarChart3 size={24} className="text-zinc-300 dark:text-zinc-600 mx-auto mb-2" />
-                <p className="text-xs text-zinc-400">스캔 데이터가 없습니다.</p>
+                <BarChart3 size={24} className="text-neutral-300 dark:text-neutral-600 mx-auto mb-2" />
+                <p className="text-xs text-neutral-400">스캔 데이터가 없습니다.</p>
               </div>
             ) : (
               <>
                 {publicItems.map((item, i) => (
-                  <StockPreviewRow key={item.ticker} item={item} index={i} />
+                  <StockRow key={item.ticker} item={item} index={i} />
                 ))}
 
-                {/* 잠긴 항목 */}
+                {/* Locked rows */}
                 {lockedItems.length > 0 && (
                   <div className="relative">
                     {lockedItems.map((item, i) => (
@@ -326,15 +296,15 @@ export default function HomePage() {
                         key={item.ticker}
                         className={cn(!isLoggedIn && "blur-sm select-none pointer-events-none")}
                       >
-                        <StockPreviewRow item={item} index={publicItems.length + i} />
+                        <StockRow item={item} index={publicItems.length + i} />
                       </div>
                     ))}
 
                     {!isLoggedIn && (
-                      <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-b from-white/50 to-white/95 dark:from-zinc-900/50 dark:to-zinc-900/95">
+                      <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-b from-white/40 to-white/90 dark:from-[#1a1a1a]/40 dark:to-[#1a1a1a]/95">
                         <Link
                           href="/login"
-                          className="flex items-center gap-2 px-5 py-2.5 rounded-2xl bg-blue-600 hover:bg-blue-700 text-white text-sm font-bold shadow-lg shadow-blue-600/20 transition-all"
+                          className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-blue-600 hover:bg-blue-700 text-white text-sm font-bold shadow-md shadow-blue-600/20 transition-all"
                         >
                           <Lock size={13} />
                           로그인하여 전체 확인
@@ -364,52 +334,52 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ── 기능 카드 (수평 스크롤) ── */}
-      <section className="py-8 bg-zinc-50 dark:bg-zinc-900/40 border-t border-zinc-100 dark:border-zinc-800/60">
+      {/* ── FEATURES ─────────────────────────────────────────────── */}
+      <section className="py-6 px-5 border-t border-neutral-100 dark:border-[#222222]">
         <div className="max-w-lg mx-auto">
-          <div className="px-5 mb-4">
-            <h2 className="text-base font-black text-zinc-900 dark:text-white">주요 기능</h2>
-            <p className="text-[11px] text-zinc-400 mt-0.5">발굴 → 분석 → 계산</p>
+          <div className="mb-4">
+            <h2 className="text-base font-black text-neutral-900 dark:text-neutral-50">주요 기능</h2>
+            <p className="text-[11px] text-neutral-400 mt-0.5">발굴 → 분석 → 계산</p>
           </div>
 
-          {/* 모바일: 수평 스크롤, 데스크탑: 3열 */}
-          <div className="flex gap-3 overflow-x-auto no-scrollbar px-5 pb-1 sm:grid sm:grid-cols-3 sm:overflow-visible">
+          {/* Mobile: horizontal scroll, Desktop: 3-col grid */}
+          <div className="flex gap-3 overflow-x-auto no-scrollbar pb-1 sm:grid sm:grid-cols-3 sm:overflow-visible">
             {FEATURES.map((f, i) => {
               const Icon = f.icon;
               return (
-                <motion.div
+                <div
                   key={i}
-                  initial={{ opacity: 0, y: 12 }}
-                  whileInView={{ opacity: 1, y: 0 }}
-                  viewport={{ once: true }}
-                  transition={{ delay: i * 0.08 }}
-                  className="shrink-0 w-52 sm:w-auto bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 p-4 flex flex-col gap-3"
+                  className="shrink-0 w-52 sm:w-auto bg-white dark:bg-[#1a1a1a] rounded-2xl border border-neutral-200 dark:border-[#2a2a2a] p-4 flex flex-col gap-3"
                 >
-                  <div className={cn("w-8 h-8 rounded-xl flex items-center justify-center", f.bg)}>
-                    <Icon size={16} className={f.color} strokeWidth={2} />
+                  <div className={cn("w-8 h-8 rounded-xl flex items-center justify-center", f.bgCls)}>
+                    <Icon size={16} className={f.iconCls} strokeWidth={2} />
                   </div>
                   <div className="flex-1">
-                    <p className="text-sm font-black text-zinc-900 dark:text-white mb-1">{f.title}</p>
-                    <p className="text-[11px] text-zinc-500 dark:text-zinc-400 leading-relaxed break-keep">{f.desc}</p>
+                    <p className="text-sm font-black text-neutral-900 dark:text-neutral-50 mb-1">{f.title}</p>
+                    <p className="text-[11px] text-neutral-500 dark:text-neutral-400 leading-relaxed break-keep">
+                      {f.desc}
+                    </p>
                   </div>
                   <Link href={f.link}
                     className="inline-flex items-center gap-1 text-xs font-bold text-blue-600 dark:text-blue-400"
                   >
                     {f.linkLabel} <ChevronRight size={11} />
                   </Link>
-                </motion.div>
+                </div>
               );
             })}
           </div>
         </div>
       </section>
 
-      {/* ── 푸터 ── */}
-      <footer className="border-t border-zinc-100 dark:border-zinc-800/60 bg-white dark:bg-zinc-950">
-        <div className="max-w-lg mx-auto px-5 py-6 flex items-center justify-between gap-4">
+      {/* ── FOOTER ───────────────────────────────────────────────── */}
+      <footer className="border-t border-neutral-100 dark:border-[#222222] bg-white dark:bg-[#111111]">
+        <div className="max-w-lg mx-auto px-5 py-5 flex items-center justify-between gap-4">
           <div className="flex items-center gap-2">
             <TrendingUp size={14} className="text-blue-600 shrink-0" strokeWidth={2.5} />
-            <span className="text-xs font-black tracking-tight text-zinc-700 dark:text-zinc-200">IDIOT QUANT</span>
+            <span className="text-xs font-black tracking-tight text-neutral-700 dark:text-neutral-200">
+              IDIOT QUANT
+            </span>
           </div>
           <div className="flex items-center gap-4">
             {[
@@ -418,15 +388,15 @@ export default function HomePage() {
               { label: "계산기", href: "/calculator" },
             ].map(l => (
               <Link key={l.label} href={l.href}
-                className="text-xs text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-200 transition-colors font-medium"
+                className="text-xs text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors font-medium"
               >
                 {l.label}
               </Link>
             ))}
           </div>
         </div>
-        <div className="border-t border-zinc-100 dark:border-zinc-800/40">
-          <p className="px-5 py-2.5 text-[10px] text-zinc-400 dark:text-zinc-600 text-center">
+        <div className="border-t border-neutral-100 dark:border-[#1f1f1f]">
+          <p className="px-5 py-2.5 text-[10px] text-neutral-400 dark:text-neutral-600 text-center">
             본 서비스는 투자 참고 목적이며 투자 결과에 대한 책임을 지지 않습니다. © 2026 IDIOT QUANT
           </p>
         </div>

--- a/cf-idiotquant/app/(login)/login/page.tsx
+++ b/cf-idiotquant/app/(login)/login/page.tsx
@@ -9,13 +9,7 @@ const BENEFITS = [
 
 export default function LoginPage() {
     return (
-        <div className="min-h-[calc(100vh-3.5rem)] flex flex-col items-center justify-center px-4 py-12 bg-gradient-to-b from-zinc-50 to-white dark:from-zinc-950 dark:to-zinc-900 relative overflow-hidden">
-
-            {/* Background blobs */}
-            <div className="pointer-events-none absolute inset-0 overflow-hidden">
-                <div className="absolute -top-40 -right-40 w-96 h-96 rounded-full bg-blue-500/6 blur-3xl" />
-                <div className="absolute -bottom-40 -left-40 w-96 h-96 rounded-full bg-indigo-500/6 blur-3xl" />
-            </div>
+        <div className="min-h-screen flex flex-col items-center justify-center px-4 py-12 bg-stone-100 dark:bg-[#0d0d0d]">
 
             <div className="relative w-full max-w-sm flex flex-col gap-8">
 
@@ -32,10 +26,10 @@ export default function LoginPage() {
                 </div>
 
                 {/* Card */}
-                <div className="bg-white dark:bg-zinc-900 rounded-3xl border border-zinc-200/80 dark:border-zinc-800 shadow-xl shadow-zinc-900/6 dark:shadow-black/40 overflow-hidden">
+                <div className="bg-white dark:bg-[#1a1a1a] rounded-3xl border border-neutral-200 dark:border-[#2a2a2a] shadow-xl shadow-neutral-900/6 dark:shadow-black/40 overflow-hidden">
 
                     {/* Card header */}
-                    <div className="px-8 pt-8 pb-6 text-center border-b border-zinc-100 dark:border-zinc-800">
+                    <div className="px-8 pt-8 pb-6 text-center border-b border-neutral-100 dark:border-[#2a2a2a]">
                         <h1 className="text-[1.6rem] font-black leading-tight text-zinc-900 dark:text-white">
                             저평가 종목을<br />매일 발굴해드립니다
                         </h1>
@@ -45,7 +39,7 @@ export default function LoginPage() {
                     </div>
 
                     {/* Benefits */}
-                    <div className="px-8 py-6 space-y-4 border-b border-zinc-100 dark:border-zinc-800">
+                    <div className="px-8 py-6 space-y-4 border-b border-neutral-100 dark:border-[#2a2a2a]">
                         {BENEFITS.map((b) => (
                             <div key={b.label} className="flex items-start gap-3">
                                 <div className="mt-0.5 w-5 h-5 rounded-full bg-blue-100 dark:bg-blue-950/60 flex items-center justify-center shrink-0">

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -505,10 +505,10 @@ function ScreenerContent() {
 
     return (
         <Tooltip.Provider delayDuration={300}>
-        <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100">
+        <div className="min-h-screen bg-stone-100 dark:bg-[#0d0d0d] text-neutral-900 dark:text-neutral-100">
 
             {/* ── 헤더 ── */}
-            <div className="bg-white dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800">
+            <div className="bg-white dark:bg-[#111111] border-b border-neutral-200 dark:border-[#222222]">
                 <div className="max-w-7xl mx-auto px-4 sm:px-6 py-5">
                     <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
                         <div>
@@ -549,7 +549,7 @@ function ScreenerContent() {
             </div>
 
             {/* ── 전략 탭 (sticky, 멀티셀렉트) ── */}
-            <div className="sticky top-14 z-30 bg-white/95 dark:bg-zinc-900/95 backdrop-blur-md border-b border-zinc-200 dark:border-zinc-800">
+            <div className="sticky top-0 z-30 bg-white/95 dark:bg-[#111111]/95 backdrop-blur-md border-b border-neutral-200 dark:border-[#222222]">
                 <div className="max-w-7xl mx-auto px-4 sm:px-6">
                     <div className="flex items-center gap-1.5 py-3">
                         {/* 전체 탭 */}
@@ -845,8 +845,8 @@ function ScreenerContent() {
                     <>
                         {/* 데스크탑 테이블 */}
                         <div className="hidden md:block">
-                            <div className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 overflow-hidden shadow-sm">
-                                <div className="grid grid-cols-[minmax(160px,2.5fr)_minmax(110px,1fr)_88px_68px_68px_68px_88px] gap-4 items-center px-5 py-3.5 bg-zinc-50 dark:bg-zinc-800/60 border-b border-zinc-200 dark:border-zinc-700/60">
+                            <div className="bg-white dark:bg-[#1a1a1a] rounded-2xl border border-neutral-200 dark:border-[#2a2a2a] overflow-hidden shadow-sm">
+                                <div className="grid grid-cols-[minmax(160px,2.5fr)_minmax(110px,1fr)_88px_68px_68px_68px_88px] gap-4 items-center px-5 py-3.5 bg-stone-50 dark:bg-[#111111] border-b border-neutral-200 dark:border-[#2a2a2a]">
                                     <SortableHeader label="종목명" sortKey="ticker" currentKey={sortKey} order={sortOrder} onToggle={toggleSort} />
                                     <div className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider">전략</div>
                                     <SortableHeader label="NCAV 비율" sortKey="ncav_ratio" currentKey={sortKey} order={sortOrder} onToggle={toggleSort} />
@@ -874,7 +874,7 @@ function ScreenerContent() {
                             <div className="flex justify-center mt-8">
                                 <button
                                     onClick={() => setDisplayCount(c => c + DAILY_PAGE_SIZE)}
-                                    className="px-6 py-2.5 rounded-xl border border-zinc-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 text-sm font-bold text-zinc-600 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-600 hover:text-zinc-900 dark:hover:text-white transition-all"
+                                    className="px-6 py-2.5 rounded-xl border border-neutral-200 dark:border-[#2a2a2a] bg-white dark:bg-[#1a1a1a] text-sm font-bold text-neutral-600 dark:text-neutral-400 hover:border-neutral-300 dark:hover:border-[#3a3a3a] hover:text-neutral-900 dark:hover:text-white transition-all"
                                 >
                                     더 보기 ({filteredList.length - displayCount}개 남음)
                                 </button>
@@ -894,7 +894,7 @@ function ScreenerContent() {
 export default function ScreenerPage() {
     return (
         <Suspense fallback={
-            <div className="flex items-center justify-center min-h-screen bg-zinc-50 dark:bg-zinc-950">
+            <div className="flex items-center justify-center min-h-screen bg-stone-100 dark:bg-[#0d0d0d]">
                 <Loader2 className="animate-spin text-blue-600" size={24} />
             </div>
         }>

--- a/cf-idiotquant/app/global.css
+++ b/cf-idiotquant/app/global.css
@@ -1,3 +1,28 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ── Layout tokens ── */
+:root {
+  --sidebar-w: 220px;
+  --topbar-h: 48px;
+  --bottombar-h: 64px;
+}
+
+/* ── Slim custom scrollbar (Claude.ai style) ── */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #d4d4d4 transparent;
+}
+*::-webkit-scrollbar { width: 4px; height: 4px; }
+*::-webkit-scrollbar-track { background: transparent; }
+*::-webkit-scrollbar-thumb { background: #d4d4d4; border-radius: 99px; }
+*::-webkit-scrollbar-thumb:hover { background: #a3a3a3; }
+
+.dark * { scrollbar-color: #3a3a3a transparent; }
+.dark *::-webkit-scrollbar-thumb { background: #3a3a3a; }
+.dark *::-webkit-scrollbar-thumb:hover { background: #525252; }
+
+/* ── No scrollbar utility ── */
+.no-scrollbar { scrollbar-width: none; -ms-overflow-style: none; }
+.no-scrollbar::-webkit-scrollbar { display: none; }

--- a/cf-idiotquant/app/layout.tsx
+++ b/cf-idiotquant/app/layout.tsx
@@ -51,14 +51,12 @@ export default function RootLayout({
   return (
     <html lang="ko" suppressHydrationWarning>
       <head>
-        {/* 1. 구조화 데이터 주입 */}
         <Script
           id="structured-data"
           type="application/ld+json"
           strategy="afterInteractive"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
-        {/* 2. 애드센스 코드 스니펫 */}
         <script
           async
           src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6995198721227228"
@@ -67,20 +65,21 @@ export default function RootLayout({
         <meta name="google-adsense-account" content="ca-pub-6995198721227228" />
       </head>
       <body className={cn(
-        "min-h-screen font-sans antialiased bg-white dark:bg-black text-zinc-900 dark:text-zinc-50",
-        "flex flex-col md:flex-row" // 모바일은 세로, 데스크탑은 가로 레이아웃
+        "min-h-screen font-sans antialiased",
+        "bg-stone-100 dark:bg-[#0d0d0d] text-neutral-900 dark:text-neutral-50"
       )}>
         <StoreProvider>
           <ThemeProviderClient>
             <AuthProvider>
-              {/* 사이드바/네비게이션 */}
               <NavbarWithSimpleLinks />
-              
-              {/* 메인 콘텐츠 영역 */}
-              <main className="flex-1 w-full min-h-screen overflow-y-auto overflow-x-hidden">
-                <div className="mx-auto w-full">
-                  {children}
-                </div>
+              {/* offset: mobile top header + bottom tab bar; desktop: sidebar left margin */}
+              <main className={cn(
+                "md:ml-[220px]",
+                "pt-[48px] md:pt-0",
+                "pb-[64px] md:pb-0",
+                "min-h-screen overflow-x-hidden"
+              )}>
+                {children}
               </main>
             </AuthProvider>
           </ThemeProviderClient>

--- a/cf-idiotquant/components/navigation.tsx
+++ b/cf-idiotquant/components/navigation.tsx
@@ -1,299 +1,152 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useEffect } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import {
-  MagnifyingGlassIcon,
-  CalculatorIcon,
-  FunnelIcon,
-  Bars3Icon,
-  XMarkIcon,
-  ChevronRightIcon,
-  CurrencyDollarIcon,
-  ChartBarIcon,
-  GlobeAltIcon,
-  LockClosedIcon,
-  LockOpenIcon,
-  UserIcon,
-  ChevronDownIcon,
-  ArrowRightOnRectangleIcon,
-} from "@heroicons/react/24/outline";
 import { useSession, signOut } from "next-auth/react";
 import ThemeChanger from "@/components/theme_changer";
 import { cn } from "@/lib/utils";
-import { EyeIcon, TrendingUp, TrendingDown, Activity } from "lucide-react";
+import {
+  Home,
+  Filter,
+  Search,
+  Calculator,
+  LogOut,
+  LogIn,
+  Eye,
+  DollarSign,
+} from "lucide-react";
 
-/* ──────────────────────────────────────────
-   NAV ITEMS CONFIG
-────────────────────────────────────────── */
-const NAV_ITEMS = [
-  {
-    label: "종목 발굴",
-    href: "/screener",
-    icon: FunnelIcon,
-    desc: "NCAV·저PBR·저PER 기준 저평가 종목 매일 자동 스캔",
-    badge: "Pro",
-  },
-  {
-    label: "적정 주가",
-    href: "/analyze",
-    icon: MagnifyingGlassIcon,
-    desc: "7가지 밸류에이션 모델 기반 적정 주가 산출",
-    badge: null,
-  },
-  {
-    label: "수익률 계산",
-    href: "/calculator",
-    icon: CalculatorIcon,
-    desc: "세후 순수익·복리·연환산 시뮬레이션",
-    badge: null,
-  },
+/* ─── NAV CONFIG ──────────────────────────────────────────────────── */
+const MAIN_NAV = [
+  { label: "홈",        href: "/",           icon: Home,       exact: true  },
+  { label: "종목 발굴", href: "/screener",    icon: Filter,     badge: "Pro" },
+  { label: "적정 주가", href: "/analyze",     icon: Search                  },
+  { label: "수익 계산", href: "/calculator",  icon: Calculator              },
 ];
 
-/* ──────────────────────────────────────────
-   SCROLL PROGRESS BAR
-────────────────────────────────────────── */
-function ScrollProgress() {
-  const [progress, setProgress] = useState(0);
-  useEffect(() => {
-    const update = () => {
-      const el = document.documentElement;
-      const scrolled = el.scrollTop;
-      const total = el.scrollHeight - el.clientHeight;
-      setProgress(total > 0 ? (scrolled / total) * 100 : 0);
-    };
-    window.addEventListener("scroll", update, { passive: true });
-    return () => window.removeEventListener("scroll", update);
-  }, []);
-  return (
-    <div className="absolute bottom-0 left-0 right-0 h-[1.5px] bg-zinc-200/60 dark:bg-zinc-800/60">
-      <div
-        className="h-full bg-gradient-to-r from-blue-500 to-indigo-500 transition-[width] duration-100"
-        style={{ width: `${progress}%` }}
-      />
-    </div>
-  );
+const PORTFOLIO_NAV = [
+  { label: "KR 포트폴리오", href: "/balance-kr", icon: Eye         },
+  { label: "US 포트폴리오", href: "/balance-us", icon: DollarSign  },
+];
+
+/* ─── HELPERS ─────────────────────────────────────────────────────── */
+function active(pathname: string, href: string, exact = false) {
+  if (exact) return pathname === href;
+  return pathname === href || pathname.startsWith(href + "/") || (href !== "/" && pathname.startsWith(href));
 }
 
-/* ──────────────────────────────────────────
-   DROPDOWN MENU
-────────────────────────────────────────── */
-function NavDropdown({
-  session,
-  status,
-  pathname,
+/* ─── SIDEBAR NAV ITEM ────────────────────────────────────────────── */
+function SideItem({
+  href, label, icon: Icon, isActive, badge,
 }: {
-  session: any;
-  status: string;
-  pathname: string;
+  href: string; label: string; icon: any; isActive: boolean; badge?: string | null;
 }) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node))
-        setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
-
   return (
-    <div ref={ref} className="relative">
-      <button
-        onClick={() => setOpen((v) => !v)}
-        className={cn(
-          "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all",
-          open
-            ? "bg-zinc-100 dark:bg-zinc-800 text-zinc-900 dark:text-white"
-            : "text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-900 dark:hover:text-white"
-        )}
-      >
-        서비스
-        <ChevronDownIcon
-          className={cn(
-            "w-3 h-3 transition-transform duration-200",
-            open && "rotate-180"
-          )}
-        />
-      </button>
-
-      {open && (
-        <div className="absolute top-[calc(100%+10px)] left-1/2 -translate-x-1/2 w-[340px] bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700/80 rounded-2xl shadow-2xl shadow-zinc-900/10 dark:shadow-black/40 overflow-hidden z-50">
-          {/* Header */}
-          <div className="px-5 py-3.5 border-b border-zinc-100 dark:border-zinc-800 bg-zinc-50/70 dark:bg-zinc-800/50">
-            <p className="text-[10px] font-extrabold text-zinc-400 dark:text-zinc-500 uppercase tracking-[0.2em]">
-              Core Tools
-            </p>
-          </div>
-
-          {/* Items */}
-          <div className="p-2">
-            {NAV_ITEMS.map((item) => {
-              const Icon = item.icon;
-              const active = pathname === item.href;
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  onClick={() => setOpen(false)}
-                  className={cn(
-                    "group flex items-center gap-4 px-4 py-3 rounded-xl transition-all",
-                    active
-                      ? "bg-blue-600 text-white"
-                      : "hover:bg-zinc-50 dark:hover:bg-zinc-800"
-                  )}
-                >
-                  <div
-                    className={cn(
-                      "w-9 h-9 rounded-lg flex items-center justify-center shrink-0 transition-colors",
-                      active
-                        ? "bg-white/20"
-                        : "bg-zinc-100 dark:bg-zinc-800 group-hover:bg-zinc-200 dark:group-hover:bg-zinc-700"
-                    )}
-                  >
-                    <Icon
-                      className={cn(
-                        "w-4 h-4",
-                        active
-                          ? "text-white"
-                          : "text-zinc-600 dark:text-zinc-400"
-                      )}
-                    />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span
-                        className={cn(
-                          "text-sm font-bold",
-                          active
-                            ? "text-white"
-                            : "text-zinc-800 dark:text-zinc-200"
-                        )}
-                      >
-                        {item.label}
-                      </span>
-                      {item.badge && (
-                        <span
-                          className={cn(
-                            "text-[9px] font-extrabold px-1.5 py-0.5 rounded-full uppercase tracking-tight",
-                            active
-                              ? "bg-white/20 text-white"
-                              : "bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400"
-                          )}
-                        >
-                          {item.badge}
-                        </span>
-                      )}
-                    </div>
-                    <p
-                      className={cn(
-                        "text-[11px] mt-0.5 truncate",
-                        active
-                          ? "text-blue-100"
-                          : "text-zinc-400 dark:text-zinc-500"
-                      )}
-                    >
-                      {item.desc}
-                    </p>
-                  </div>
-                  <ChevronRightIcon
-                    className={cn(
-                      "w-3.5 h-3.5 shrink-0 transition-all",
-                      active
-                        ? "text-white opacity-60"
-                        : "text-zinc-300 dark:text-zinc-600 group-hover:text-zinc-500 group-hover:translate-x-0.5"
-                    )}
-                  />
-                </Link>
-              );
-            })}
-          </div>
-
-          {/* Footer CTA */}
-          <div className="px-3 pb-3">
-            <Link
-              href="/screener"
-              onClick={() => setOpen(false)}
-              className="flex items-center justify-between w-full px-4 py-3 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 text-white text-xs font-bold hover:from-blue-700 hover:to-indigo-700 transition-all"
-            >
-              <span>종목 발굴 시작하기</span>
-              <ChevronRightIcon className="w-3.5 h-3.5" />
-            </Link>
-          </div>
-        </div>
+    <Link
+      href={href}
+      className={cn(
+        "group flex items-center gap-3 w-full px-3 py-2.5 rounded-xl text-sm transition-all duration-150",
+        isActive
+          ? "bg-stone-200/80 dark:bg-[#2a2a2a] text-neutral-900 dark:text-neutral-50 font-semibold"
+          : "font-medium text-neutral-500 dark:text-neutral-400 hover:bg-stone-100 dark:hover:bg-[#1f1f1f] hover:text-neutral-900 dark:hover:text-neutral-100"
       )}
-    </div>
+    >
+      <Icon
+        size={16}
+        strokeWidth={isActive ? 2.2 : 1.8}
+        className={cn("shrink-0 transition-colors", isActive ? "text-blue-600 dark:text-blue-400" : "")}
+      />
+      <span className="flex-1 truncate">{label}</span>
+      {badge && (
+        <span className={cn(
+          "text-[9px] font-extrabold px-1.5 py-0.5 rounded-full uppercase tracking-tight",
+          isActive
+            ? "bg-blue-600 text-white"
+            : "bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400"
+        )}>
+          {badge}
+        </span>
+      )}
+    </Link>
   );
 }
 
-/* ──────────────────────────────────────────
-   SESSION BUTTON (desktop)
-────────────────────────────────────────── */
-function SessionButton({
-  session,
-  status,
+/* ─── BOTTOM TAB ITEM (mobile) ────────────────────────────────────── */
+function TabItem({
+  href, label, icon: Icon, isActive,
 }: {
-  session: any;
-  status: string;
+  href: string; label: string; icon: any; isActive: boolean;
 }) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "flex flex-1 flex-col items-center justify-center gap-[3px] py-2 rounded-xl transition-colors",
+        isActive
+          ? "text-blue-600 dark:text-blue-400"
+          : "text-neutral-400 dark:text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300"
+      )}
+    >
+      <Icon size={20} strokeWidth={isActive ? 2.2 : 1.6} />
+      <span className="text-[10px] font-semibold leading-none">{label}</span>
+    </Link>
+  );
+}
 
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, []);
-
+/* ─── SIDEBAR USER SECTION ────────────────────────────────────────── */
+function SidebarUser({ session, status }: { session: any; status: string }) {
   if (status === "loading") {
     return (
-      <div className="w-20 h-7 rounded-lg bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+      <div className="mx-3 mb-4 h-10 bg-stone-100 dark:bg-[#1a1a1a] rounded-xl animate-pulse" />
     );
   }
 
   if (status === "authenticated") {
     return (
-      <div ref={ref} className="relative">
-        <button
-          onClick={() => setOpen((v) => !v)}
-          className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 transition-colors"
-        >
-          <div className="w-5 h-5 rounded-full bg-gradient-to-br from-blue-400 to-indigo-500 flex items-center justify-center text-white text-[9px] font-black">
+      <div className="px-3 pb-4">
+        <div className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl bg-stone-100 dark:bg-[#1f1f1f]">
+          <div className="w-7 h-7 rounded-full bg-gradient-to-br from-blue-400 to-indigo-500 flex items-center justify-center text-white text-[10px] font-black shrink-0">
             {session?.user?.name?.[0] ?? "U"}
           </div>
-          <span className="text-xs font-bold text-zinc-700 dark:text-zinc-300 max-w-[80px] truncate">
+          <span className="flex-1 text-xs font-semibold text-neutral-700 dark:text-neutral-300 truncate min-w-0">
             {session?.user?.name}
           </span>
-          <div className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
-        </button>
+          <button
+            onClick={() => signOut({ callbackUrl: "/" })}
+            className="p-1.5 rounded-lg text-neutral-400 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/20 transition-colors shrink-0"
+            title="로그아웃"
+          >
+            <LogOut size={14} />
+          </button>
+        </div>
+      </div>
+    );
+  }
 
-        {open && (
-          <div className="absolute right-0 top-[calc(100%+8px)] w-48 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700/80 rounded-xl shadow-xl overflow-hidden z-50">
-            <div className="px-4 py-3 border-b border-zinc-100 dark:border-zinc-800">
-              <p className="text-xs font-black text-zinc-900 dark:text-white truncate">
-                {session?.user?.name}
-              </p>
-              <p className="text-[10px] text-emerald-600 dark:text-emerald-400 mt-0.5 flex items-center gap-1">
-                <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 inline-block" />
-                로그인 중
-              </p>
-            </div>
-            <div className="p-1">
-              <button
-                onClick={() => { setOpen(false); signOut({ callbackUrl: "/" }); }}
-                className="w-full flex items-center gap-2.5 px-3 py-2.5 rounded-lg text-xs font-bold text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 transition-colors"
-              >
-                <ArrowRightOnRectangleIcon className="w-4 h-4" />
-                로그아웃
-              </button>
-            </div>
-          </div>
-        )}
+  return (
+    <div className="px-3 pb-4">
+      <Link
+        href="/login"
+        className="flex items-center justify-center gap-2 w-full py-2.5 rounded-xl bg-blue-600 hover:bg-blue-700 text-white text-xs font-bold transition-colors shadow-sm"
+      >
+        <LogIn size={14} />
+        카카오 로그인
+      </Link>
+    </div>
+  );
+}
+
+/* ─── MOBILE MINI SESSION ─────────────────────────────────────────── */
+function MiniSession({ session, status }: { session: any; status: string }) {
+  if (status === "loading") {
+    return <div className="w-7 h-7 rounded-full bg-stone-200 dark:bg-neutral-800 animate-pulse" />;
+  }
+
+  if (status === "authenticated") {
+    return (
+      <div className="w-7 h-7 rounded-full bg-gradient-to-br from-blue-400 to-indigo-500 flex items-center justify-center text-white text-[10px] font-black shrink-0">
+        {session?.user?.name?.[0] ?? "U"}
       </div>
     );
   }
@@ -301,429 +154,121 @@ function SessionButton({
   return (
     <Link
       href="/login"
-      className="flex items-center gap-1.5 px-3.5 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-xs font-extrabold tracking-wide transition-all shadow-md shadow-blue-600/25"
+      className="px-3 py-1.5 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-xs font-bold transition-colors"
     >
-      <LockClosedIcon className="w-3 h-3" />
-      <div className="w-10">로그인</div>
+      로그인
     </Link>
   );
 }
 
-/* ──────────────────────────────────────────
-   MAIN NAVBAR
-────────────────────────────────────────── */
+/* ─── MAIN EXPORT ─────────────────────────────────────────────────── */
 export function NavbarWithSimpleLinks() {
   const { data: session, status } = useSession();
   const pathname = usePathname();
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const [visible, setVisible] = useState(true);
-  const [scrolled, setScrolled] = useState(false);
-  const lastScrollY = useRef(0);
+  const isMasterUser = session?.user?.name === process.env.NEXT_PUBLIC_MASTER;
 
-  // Theme sync
+  /* Theme sync: persist choice in localStorage, hydrate on mount */
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const syncInitialTheme = () => {
-      const savedTheme = localStorage.getItem("theme");
-      const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-      if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
-        document.documentElement.classList.add("dark");
-      } else {
-        document.documentElement.classList.remove("dark");
-      }
-    };
-    syncInitialTheme();
-    const observer = new MutationObserver((mutations) => {
-      mutations.forEach((m) => {
-        if (m.attributeName === "class") {
-          const isDark = document.documentElement.classList.contains("dark");
-          localStorage.setItem("theme", isDark ? "dark" : "light");
-        }
-      });
+    const savedTheme = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    if (savedTheme === "dark" || (!savedTheme && prefersDark)) {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+    const observer = new MutationObserver(() => {
+      const isDark = document.documentElement.classList.contains("dark");
+      localStorage.setItem("theme", isDark ? "dark" : "light");
     });
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
     return () => observer.disconnect();
   }, []);
 
-  // Scroll behavior
-  useEffect(() => {
-    const handleScroll = () => {
-      const currentScrollY = window.scrollY;
-      setScrolled(currentScrollY > 8);
-      if (currentScrollY > lastScrollY.current && currentScrollY > 80) {
-        setVisible(false);
-      } else {
-        setVisible(true);
-      }
-      lastScrollY.current = currentScrollY;
-    };
-    window.addEventListener("scroll", handleScroll, { passive: true });
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
-  // Body lock
-  useEffect(() => {
-    document.body.style.overflow = isDrawerOpen ? "hidden" : "auto";
-  }, [isDrawerOpen]);
-
-  const closeDrawer = () => setIsDrawerOpen(false);
-  const isMasterUser = session?.user?.name === process.env.NEXT_PUBLIC_MASTER;
-
   return (
     <>
-      <nav
-        className={cn(
-          "fixed top-0 left-0 right-0 z-40 h-14 transition-all duration-300 ease-in-out transform-gpu",
-          // visible ? "translate-y-0" : "-translate-y-full",
-          scrolled
-            ? "bg-white/90 dark:bg-zinc-950/90 backdrop-blur-xl border-b border-zinc-200/80 dark:border-zinc-800/80 shadow-sm"
-            : "bg-white/70 dark:bg-zinc-950/70 backdrop-blur-md border-b border-zinc-200/40 dark:border-zinc-800/40"
-        )}
-      >
-        <div className="h-full max-w-7xl mx-auto px-4 md:px-6 flex items-center gap-4">
-          {/* ── Logo ── */}
-          <Link
-            href="/"
-            className="flex items-center gap-2.5 shrink-0 group"
-          >
-            <div className="relative w-7 h-7 bg-blue-600 rounded-lg flex items-center justify-center shadow-lg shadow-blue-600/30 group-hover:shadow-blue-600/50 transition-shadow">
-              <span className="text-white text-[10px] font-black italic leading-none">
-                IQ
-              </span>
-              <div className="absolute inset-0 rounded-lg bg-gradient-to-br from-white/20 to-transparent" />
+      {/* ══ DESKTOP SIDEBAR ══════════════════════════════════════════ */}
+      <aside className="hidden md:flex flex-col fixed left-0 top-0 h-full w-[220px] z-40 bg-white dark:bg-[#111111] border-r border-neutral-200/70 dark:border-[#222222]">
+
+        {/* Logo */}
+        <div className="h-14 flex items-center px-4 border-b border-neutral-100 dark:border-[#1f1f1f] shrink-0">
+          <Link href="/" className="flex items-center gap-2.5">
+            <div className="w-7 h-7 bg-blue-600 rounded-lg flex items-center justify-center shadow-md shadow-blue-600/25 shrink-0">
+              <span className="text-white text-[10px] font-black italic leading-none">IQ</span>
             </div>
-            <span className="font-black tracking-tighter text-sm text-zinc-900 dark:text-white">
+            <span className="font-black tracking-tighter text-sm text-neutral-900 dark:text-white">
               IDIOT<span className="text-blue-600">QUANT</span>
             </span>
           </Link>
-
-          {/* ── Divider ── */}
-          <div className="hidden md:block w-px h-4 bg-zinc-200 dark:bg-zinc-800" />
-
-          {/* ── Spacer ── */}
-          <div className="flex-1" />
-
-          {/* ── Desktop Nav ── */}
-          <div className="hidden md:flex items-center gap-1">
-            <NavDropdown session={session} status={status} pathname={pathname} />
-
-            {/* Direct links */}
-            <NavLink href="/screener" active={pathname === "/screener"}>
-              <FunnelIcon className="w-3.5 h-3.5" />
-              종목 발굴
-            </NavLink>
-            <NavLink href="/analyze" active={pathname === "/analyze"}>
-              <MagnifyingGlassIcon className="w-3.5 h-3.5" />
-              적정 주가
-            </NavLink>
-            <NavLink href="/calculator" active={pathname === "/calculator"}>
-              <CalculatorIcon className="w-3.5 h-3.5" />
-              계산기
-            </NavLink>
-
-            {/* Master-only links */}
-            {isMasterUser && (
-              <>
-                <div className="w-px h-4 bg-zinc-200 dark:bg-zinc-800 mx-1" />
-                <NavLink href="/balance-kr" active={pathname === "/balance-kr"}>
-                  <EyeIcon className="w-3.5 h-3.5" />
-                  KR
-                </NavLink>
-                <NavLink href="/balance-us" active={pathname === "/balance-us"}>
-                  <CurrencyDollarIcon className="w-3.5 h-3.5" />
-                  US
-                </NavLink>
-              </>
-            )}
-          </div>
-
-          {/* ── Right cluster ── */}
-          <div className="hidden md:flex items-center gap-2 pl-3 border-l border-zinc-200 dark:border-zinc-800">
-            <ThemeChanger />
-            <SessionButton session={session} status={status} />
-          </div>
-
-          {/* ── Mobile burger ── */}
-          <button
-            onClick={() => setIsDrawerOpen(true)}
-            className="md:hidden p-2 text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-xl transition-colors"
-            aria-label="메뉴 열기"
-          >
-            <Bars3Icon className="w-5 h-5" />
-          </button>
         </div>
 
-        <ScrollProgress />
-      </nav>
+        {/* Navigation */}
+        <nav className="flex-1 px-3 py-4 space-y-0.5 overflow-y-auto">
+          {MAIN_NAV.map(item => (
+            <SideItem
+              key={item.href}
+              href={item.href}
+              label={item.label}
+              icon={item.icon}
+              isActive={active(pathname, item.href, item.exact)}
+              badge={item.badge}
+            />
+          ))}
 
-      {/* ──────────────────────────────────
-          MOBILE DRAWER
-      ────────────────────────────────── */}
-      <div
-        className={cn(
-          "fixed inset-0 z-50 transition-all duration-300",
-          isDrawerOpen ? "visible" : "invisible"
-        )}
-      >
-        {/* Backdrop */}
-        <div
-          className={cn(
-            "absolute inset-0 bg-zinc-900/50 dark:bg-black/70 backdrop-blur-sm transition-opacity duration-300",
-            isDrawerOpen ? "opacity-100" : "opacity-0"
+          {isMasterUser && (
+            <>
+              <div className="pt-4 pb-1.5 px-1">
+                <div className="h-px bg-neutral-100 dark:bg-[#222222] mb-3" />
+                <span className="text-[10px] font-bold text-neutral-400 dark:text-neutral-500 uppercase tracking-widest">
+                  Portfolio
+                </span>
+              </div>
+              {PORTFOLIO_NAV.map(item => (
+                <SideItem
+                  key={item.href}
+                  href={item.href}
+                  label={item.label}
+                  icon={item.icon}
+                  isActive={active(pathname, item.href)}
+                />
+              ))}
+            </>
           )}
-          onClick={closeDrawer}
-        />
+        </nav>
 
-        {/* Panel */}
-        <aside
-          className={cn(
-            "absolute right-0 top-0 h-full w-[88%] max-w-[340px] bg-white dark:bg-[#0e0e10] shadow-2xl transition-transform duration-300 ease-out flex flex-col border-l border-zinc-200 dark:border-zinc-800",
-            isDrawerOpen ? "translate-x-0" : "translate-x-full"
-          )}
-        >
-          {/* Panel header */}
-          <div className="flex items-center justify-between px-5 py-4 border-b border-zinc-100 dark:border-zinc-800/80">
-            <Link href="/" onClick={closeDrawer} className="flex items-center gap-2">
-              <div className="w-6 h-6 bg-blue-600 rounded-md flex items-center justify-center">
-                <span className="text-white text-[9px] font-black italic">IQ</span>
-              </div>
-              <span className="font-black tracking-tighter text-sm text-zinc-900 dark:text-white">
-                IDIOT<span className="text-blue-600">QUANT</span>
-              </span>
-            </Link>
-            <button
-              onClick={closeDrawer}
-              className="p-1.5 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-full transition-colors text-zinc-500"
-            >
-              <XMarkIcon className="w-4 h-4" />
-            </button>
-          </div>
-
-          {/* Scrollable content */}
-          <div className="flex-1 overflow-y-auto px-4 py-5 space-y-6">
-
-            {/* Account card */}
-            <div className={cn(
-              "rounded-2xl p-4 border",
-              status === "authenticated"
-                ? "bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-900/60"
-                : "bg-blue-50 dark:bg-blue-950/30 border-blue-200 dark:border-blue-900/60"
-            )}>
-              <div className="flex items-center gap-3">
-                <div className={cn(
-                  "w-10 h-10 rounded-xl flex items-center justify-center",
-                  status === "authenticated"
-                    ? "bg-emerald-500/20"
-                    : "bg-blue-500/20"
-                )}>
-                  {status === "authenticated"
-                    ? <div className="w-6 h-6 rounded-full bg-gradient-to-br from-blue-400 to-indigo-500 flex items-center justify-center text-white text-[10px] font-black">
-                        {session?.user?.name?.[0] ?? "U"}
-                      </div>
-                    : <LockClosedIcon className="w-5 h-5 text-blue-600 dark:text-blue-400" />
-                  }
-                </div>
-                <div className="flex-1 min-w-0">
-                  {status === "authenticated" ? (
-                    <>
-                      <p className="text-sm font-black text-zinc-900 dark:text-zinc-100 truncate">
-                        {session?.user?.name}
-                      </p>
-                      <p className="text-[11px] text-emerald-600 dark:text-emerald-400 font-semibold flex items-center gap-1">
-                        <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 inline-block" />
-                        Connected
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <p className="text-sm font-black text-zinc-900 dark:text-zinc-100">로그인하세요</p>
-                      <p className="text-[11px] text-zinc-500 dark:text-zinc-400">Pro 기능을 사용하려면 로그인이 필요합니다.</p>
-                    </>
-                  )}
-                </div>
-                {status !== "authenticated" && (
-                  <Link
-                    href="/login"
-                    onClick={closeDrawer}
-                    className="shrink-0 px-3.5 py-2 rounded-xl bg-blue-600 text-white text-xs font-extrabold hover:bg-blue-700 transition-colors"
-                  >
-                    시작하기
-                  </Link>
-                )}
-              </div>
-
-              {status === "authenticated" && (
-                <div className="mt-3 pt-3 border-t border-emerald-200/60 dark:border-emerald-900/40">
-                  <button
-                    onClick={() => { closeDrawer(); signOut({ callbackUrl: "/" }); }}
-                    className="w-full flex items-center justify-center gap-2 py-2 rounded-xl text-xs font-bold text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 border border-red-200/50 dark:border-red-900/30 transition-colors"
-                  >
-                    <ArrowRightOnRectangleIcon className="w-3.5 h-3.5" />
-                    로그아웃
-                  </button>
-                </div>
-              )}
-            </div>
-
-            {/* Strategy links */}
-            <section>
-              <SectionLabel>Strategy</SectionLabel>
-              <div className="space-y-1.5 mt-2.5">
-                {NAV_ITEMS.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <MobileLink
-                      key={item.href}
-                      href={item.href}
-                      active={pathname === item.href}
-                      onClick={closeDrawer}
-                      icon={<Icon className="w-4 h-4" />}
-                      badge={item.badge}
-                    >
-                      {item.label}
-                    </MobileLink>
-                  );
-                })}
-              </div>
-            </section>
-
-            {/* Master-only section */}
-            {isMasterUser && (
-              <section>
-                <SectionLabel>Portfolio</SectionLabel>
-                <div className="space-y-1.5 mt-2.5">
-                  <MobileLink
-                    href="/balance-kr"
-                    active={pathname === "/balance-kr"}
-                    onClick={closeDrawer}
-                    icon={<ChartBarIcon className="w-4 h-4" />}
-                  >
-                    Korea Balance
-                  </MobileLink>
-                  <MobileLink
-                    href="/balance-us"
-                    active={pathname === "/balance-us"}
-                    onClick={closeDrawer}
-                    icon={<GlobeAltIcon className="w-4 h-4" />}
-                  >
-                    US Balance
-                  </MobileLink>
-                </div>
-              </section>
-            )}
-          </div>
-
-          {/* Panel footer */}
-          <div className="px-5 py-4 border-t border-zinc-100 dark:border-zinc-800 bg-zinc-50/80 dark:bg-zinc-900/80 flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <UserIcon className="w-3.5 h-3.5 text-zinc-400" />
-              <span className="text-xs font-bold text-zinc-500 dark:text-zinc-400">
-                Display Mode
-              </span>
-            </div>
+        {/* Theme toggle + User */}
+        <div className="border-t border-neutral-100 dark:border-[#1f1f1f] shrink-0">
+          <div className="flex items-center justify-end px-4 py-2.5">
             <ThemeChanger />
           </div>
-        </aside>
-      </div>
+          <SidebarUser session={session} status={status} />
+        </div>
+      </aside>
 
-      {/* Spacer */}
-      <div className="h-14" />
+      {/* ══ MOBILE TOP HEADER ════════════════════════════════════════ */}
+      <header className="md:hidden fixed top-0 left-0 right-0 h-[48px] z-40 bg-white/95 dark:bg-[#111111]/95 backdrop-blur-xl border-b border-neutral-200/70 dark:border-[#222222] flex items-center justify-between px-4">
+        <Link href="/" className="flex items-center gap-2">
+          <div className="w-6 h-6 bg-blue-600 rounded-md flex items-center justify-center shadow-sm shadow-blue-600/25 shrink-0">
+            <span className="text-white text-[9px] font-black italic leading-none">IQ</span>
+          </div>
+          <span className="font-black tracking-tighter text-sm text-neutral-900 dark:text-white">
+            IDIOT<span className="text-blue-600">QUANT</span>
+          </span>
+        </Link>
+        <div className="flex items-center gap-2">
+          <ThemeChanger />
+          <MiniSession session={session} status={status} />
+        </div>
+      </header>
+
+      {/* ══ MOBILE BOTTOM TAB BAR ════════════════════════════════════ */}
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 h-[64px] z-40 bg-white/95 dark:bg-[#111111]/95 backdrop-blur-xl border-t border-neutral-200/70 dark:border-[#222222] flex items-center px-3">
+        <TabItem href="/"           label="홈"     icon={Home}       isActive={pathname === "/"} />
+        <TabItem href="/screener"   label="발굴"   icon={Filter}     isActive={pathname.startsWith("/screener")} />
+        <TabItem href="/analyze"    label="분석"   icon={Search}     isActive={pathname.startsWith("/analyze")} />
+        <TabItem href="/calculator" label="계산기" icon={Calculator} isActive={pathname.startsWith("/calculator")} />
+      </nav>
     </>
-  );
-}
-
-/* ──────────────────────────────────────────
-   SUB-COMPONENTS
-────────────────────────────────────────── */
-function NavLink({
-  href,
-  active,
-  children,
-}: {
-  href: string;
-  active: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <Link
-      href={href}
-      className={cn(
-        "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all",
-        active
-          ? "bg-blue-600 text-white shadow-md shadow-blue-600/25"
-          : "text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-900 dark:hover:text-white"
-      )}
-    >
-      {children}
-    </Link>
-  );
-}
-
-function MobileLink({
-  href,
-  active,
-  onClick,
-  icon,
-  children,
-  badge,
-}: {
-  href: string;
-  active: boolean;
-  onClick: () => void;
-  icon: React.ReactNode;
-  children: React.ReactNode;
-  badge?: string | null;
-}) {
-  return (
-    <Link
-      href={href}
-      onClick={onClick}
-      className={cn(
-        "group flex items-center gap-3 w-full px-4 py-3 rounded-xl border transition-all",
-        active
-          ? "bg-blue-600 border-blue-600 shadow-lg shadow-blue-600/20"
-          : "bg-white dark:bg-zinc-900 border-zinc-100 dark:border-zinc-800 hover:border-zinc-200 dark:hover:border-zinc-700"
-      )}
-    >
-      <div className={cn(
-        "w-8 h-8 rounded-lg flex items-center justify-center shrink-0 transition-colors",
-        active
-          ? "bg-white/20 text-white"
-          : "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 group-hover:bg-zinc-200 dark:group-hover:bg-zinc-700"
-      )}>
-        {icon}
-      </div>
-      <span className={cn(
-        "flex-1 text-sm font-bold",
-        active ? "text-white" : "text-zinc-800 dark:text-zinc-200"
-      )}>
-        {children}
-      </span>
-      {badge && (
-        <span className={cn(
-          "text-[9px] font-extrabold px-2 py-0.5 rounded-full uppercase tracking-tight",
-          active
-            ? "bg-white/20 text-white"
-            : "bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400"
-        )}>
-          {badge}
-        </span>
-      )}
-      <ChevronRightIcon className={cn(
-        "w-3.5 h-3.5 shrink-0 transition-all",
-        active
-          ? "text-white opacity-50"
-          : "text-zinc-300 dark:text-zinc-600 group-hover:translate-x-0.5 group-hover:text-zinc-400"
-      )} />
-    </Link>
-  );
-}
-
-function SectionLabel({ children }: { children: React.ReactNode }) {
-  return (
-    <span className="text-[10px] font-extrabold text-zinc-400 dark:text-zinc-500 uppercase tracking-[0.22em] px-1">
-      {children}
-    </span>
   );
 }
 


### PR DESCRIPTION
## 변경 내용

### Navigation (가장 큰 변화)
- **데스크탑**: 기존 상단 fixed 네비바 → 220px 좌측 고정 사이드바 (로고 · 아이콘+라벨 네비 · 하단 유저 섹션)
- **모바일**: 기존 우측 드로어 → 상단 48px 헤더(로고+테마+미니세션) + 하단 64px 탭바(홈/발굴/분석/계산기)
- 기존 우측 드로어, 스크롤 프로그레스 바 제거

### Claude.ai 색상 톤
| 역할 | Light | Dark |
|---|---|---|
| 페이지 배경 | `stone-100` | `#0d0d0d` |
| 사이드바/헤더 | `white` | `#111111` |
| 카드 | `white` | `#1a1a1a` |
| 보더 | `neutral-200` | `#2a2a2a` |

- `global.css`: CSS 변수, 슬림 4px 커스텀 스크롤바, `.no-scrollbar` 유틸리티

### 페이지별 업데이트
- **Layout**: `md:ml-[220px] pt-[48px] md:pt-0 pb-[64px] md:pb-0` 오프셋 적용
- **홈**: Framer Motion 제거, 그래디언트 블롭 제거, 클린 미니멀 레이아웃
- **스크리너**: `sticky top-14` → `top-0` (사이드바 레이아웃 기준), 배경/보더 업데이트
- **분석**: 헤더·배경 색상 업데이트
- **로그인**: 그래디언트 배경 제거, 중립 카드 스타일

## 검증
- [ ] 데스크탑(≥768px): 좌측 사이드바 표시, 활성 링크 하이라이트
- [ ] 모바일(<768px): 상단 헤더 + 하단 탭바, 드로어 없음
- [ ] 다크모드 토글 동작
- [ ] 로그인/비로그인 유저 상태 표시
- [ ] 스크리너 sticky 탭바가 콘텐츠 가릴 때 정상 동작

https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA)_