### PR TITLE
style: claude.ai 색상 시스템 잔여 zinc 패턴 전체 교체

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -106,7 +106,7 @@ const GRADE_PILL: Record<string, string> = {
   SS:  "bg-amber-500 text-white",
   S:   "bg-emerald-500 text-white",
   A:   "bg-slate-500 text-white",
-  B:   "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-200",
+  B:   "bg-zinc-200 text-zinc-700 dark:bg-[#3a3a3a] dark:text-zinc-200",
   F:   "bg-red-500 text-white",
 };
 
@@ -125,29 +125,29 @@ import {
 // 스켈레톤 컴포넌트
 // =========================================================================
 const StockCardSkeleton = memo(() => (
-  <div className="w-full h-[380px] bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 animate-pulse p-6">
+  <div className="w-full h-[380px] bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] animate-pulse p-6">
     <div className="flex items-center gap-3 mb-6">
-      <div className="w-12 h-12 bg-zinc-200 dark:bg-zinc-800 rounded-xl" />
+      <div className="w-12 h-12 bg-zinc-200 dark:bg-[#1a1a1a] rounded-xl" />
       <div className="flex-1 space-y-2">
-        <div className="h-5 bg-zinc-200 dark:bg-zinc-800 rounded w-3/4" />
-        <div className="h-4 bg-zinc-200 dark:bg-zinc-800 rounded w-1/2" />
+        <div className="h-5 bg-zinc-200 dark:bg-[#1a1a1a] rounded w-3/4" />
+        <div className="h-4 bg-zinc-200 dark:bg-[#1a1a1a] rounded w-1/2" />
       </div>
     </div>
     <div className="space-y-3">
-      {[...Array(4)].map((_, i) => <div key={i} className="h-14 bg-zinc-200 dark:bg-zinc-800 rounded-xl" />)}
+      {[...Array(4)].map((_, i) => <div key={i} className="h-14 bg-zinc-200 dark:bg-[#1a1a1a] rounded-xl" />)}
     </div>
   </div>
 ));
 StockCardSkeleton.displayName = 'StockCardSkeleton';
 
 const MetricsSkeleton = memo(() => (
-  <div className="w-full h-[380px] bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 animate-pulse p-6">
-    <div className="h-5 bg-zinc-200 dark:bg-zinc-800 rounded w-1/3 mb-5" />
+  <div className="w-full h-[380px] bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] animate-pulse p-6">
+    <div className="h-5 bg-zinc-200 dark:bg-[#1a1a1a] rounded w-1/3 mb-5" />
     <div className="grid grid-cols-2 gap-3">
       {[...Array(6)].map((_, i) => (
-        <div key={i} className="p-4 bg-zinc-50 dark:bg-zinc-800/50 rounded-xl space-y-2">
-          <div className="h-3 bg-zinc-200 dark:bg-zinc-700 rounded w-1/2" />
-          <div className="h-5 bg-zinc-200 dark:bg-zinc-700 rounded w-3/4" />
+        <div key={i} className="p-4 bg-stone-100 dark:bg-[#1a1a1a]/50 rounded-xl space-y-2">
+          <div className="h-3 bg-zinc-200 dark:bg-[#3a3a3a] rounded w-1/2" />
+          <div className="h-5 bg-zinc-200 dark:bg-[#3a3a3a] rounded w-3/4" />
         </div>
       ))}
     </div>
@@ -156,27 +156,27 @@ const MetricsSkeleton = memo(() => (
 MetricsSkeleton.displayName = 'MetricsSkeleton';
 
 const ValuationSkeleton = memo(() => (
-  <div className="w-full h-[280px] bg-white dark:bg-zinc-900 rounded-2xl animate-pulse p-6">
-    <div className="h-5 bg-zinc-200 dark:bg-zinc-800 rounded w-1/3 mb-5" />
+  <div className="w-full h-[280px] bg-white dark:bg-[#1a1a1a] rounded-2xl animate-pulse p-6">
+    <div className="h-5 bg-zinc-200 dark:bg-[#1a1a1a] rounded w-1/3 mb-5" />
     <div className="space-y-3">
-      {[...Array(3)].map((_, i) => <div key={i} className="h-14 bg-zinc-200 dark:bg-zinc-800 rounded-xl" />)}
+      {[...Array(3)].map((_, i) => <div key={i} className="h-14 bg-zinc-200 dark:bg-[#1a1a1a] rounded-xl" />)}
     </div>
   </div>
 ));
 ValuationSkeleton.displayName = 'ValuationSkeleton';
 
 const SearchSkeleton = memo(() => (
-  <div className="w-full h-11 bg-zinc-100 dark:bg-zinc-800 rounded-xl animate-pulse" />
+  <div className="w-full h-11 bg-stone-100 dark:bg-[#1a1a1a] rounded-xl animate-pulse" />
 ));
 SearchSkeleton.displayName = 'SearchSkeleton';
 
 const ResultSkeleton = memo(() => (
   <div className="space-y-4 animate-in fade-in duration-300">
-    <div className="h-[88px] bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 animate-pulse" />
+    <div className="h-[88px] bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] animate-pulse" />
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-      {[...Array(4)].map((_, i) => <div key={i} className="h-20 bg-white dark:bg-zinc-900 rounded-xl border border-zinc-200 dark:border-zinc-800 animate-pulse" />)}
+      {[...Array(4)].map((_, i) => <div key={i} className="h-20 bg-white dark:bg-[#1a1a1a] rounded-xl border border-zinc-200 dark:border-[#2a2a2a] animate-pulse" />)}
     </div>
-    <div className="h-[420px] bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 animate-pulse" />
+    <div className="h-[420px] bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] animate-pulse" />
   </div>
 ));
 ResultSkeleton.displayName = 'ResultSkeleton';
@@ -403,7 +403,7 @@ function AnalyzeContent() {
       {/* ── 헤더 ── */}
       <header className="sticky top-0 z-30 bg-white dark:bg-[#111111] border-b border-neutral-200 dark:border-[#222222]">
         {fromScreener && (
-          <div className="border-b border-zinc-100 dark:border-zinc-800/60">
+          <div className="border-b border-zinc-100 dark:border-[#2a2a2a]/60">
             <div className="max-w-4xl mx-auto px-4 py-2">
               <Link href="/screener"
                 className="inline-flex items-center gap-1.5 text-xs font-bold text-blue-600 dark:text-blue-400 hover:opacity-80 transition-opacity">
@@ -432,7 +432,7 @@ function AnalyzeContent() {
                   "flex items-center gap-1.5 px-2.5 py-2 rounded-xl border text-xs font-bold transition-all",
                   isInWatchlist
                     ? "text-amber-600 bg-amber-50 border-amber-200 dark:bg-amber-950/20 dark:border-amber-800/50 dark:text-amber-400"
-                    : "text-zinc-500 bg-zinc-50 border-zinc-200 hover:text-zinc-800 dark:bg-zinc-800/40 dark:border-zinc-700"
+                    : "text-zinc-500 bg-stone-100 border-zinc-200 hover:text-zinc-800 dark:bg-[#1a1a1a]/40 dark:border-[#222222]"
                 )}
               >
                 <Star size={13} className={isInWatchlist ? "fill-amber-500" : ""} />
@@ -453,7 +453,7 @@ function AnalyzeContent() {
 
         {/* 인기 종목 + 최근 검색 */}
         {!isLoaded && (
-          <div className="border-t border-zinc-100 dark:border-zinc-800/50 bg-zinc-50/50 dark:bg-zinc-900/30">
+          <div className="border-t border-zinc-100 dark:border-[#2a2a2a]/50 bg-stone-100/50 dark:bg-[#1a1a1a]/30">
             {popularStocks.length > 0 && (
               <div className="max-w-4xl mx-auto px-4 py-2 flex items-center gap-3">
                 <div className="flex items-center gap-1.5 shrink-0">
@@ -463,7 +463,7 @@ function AnalyzeContent() {
                 <div className="flex items-center gap-1.5 overflow-x-auto no-scrollbar">
                   {popularStocks.slice(0, 8).map((s: any, i: number) => (
                     <button key={i} onClick={() => handleSearch(s.ticker)}
-                      className="shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-white dark:bg-zinc-900 text-xs font-bold text-zinc-600 dark:text-zinc-300 border border-zinc-200/60 dark:border-zinc-800 hover:border-blue-400/70 hover:text-blue-600 dark:hover:text-blue-400 transition-all whitespace-nowrap"
+                      className="shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg bg-white dark:bg-[#1a1a1a] text-xs font-bold text-zinc-600 dark:text-zinc-300 border border-zinc-200/60 dark:border-[#2a2a2a] hover:border-blue-400/70 hover:text-blue-600 dark:hover:text-blue-400 transition-all whitespace-nowrap"
                     >
                       <span className="w-3.5 h-3.5 flex items-center justify-center rounded-full bg-blue-500 text-white font-black text-[8px] shrink-0">{i + 1}</span>
                       {s.name}
@@ -473,12 +473,12 @@ function AnalyzeContent() {
               </div>
             )}
             {krMarketHistory.length > 0 && (
-              <div className="max-w-4xl mx-auto px-4 py-2 flex items-center gap-3 border-t border-zinc-100 dark:border-zinc-800/40">
+              <div className="max-w-4xl mx-auto px-4 py-2 flex items-center gap-3 border-t border-zinc-100 dark:border-[#2a2a2a]/40">
                 <span className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider shrink-0">최근 검색</span>
                 <div className="flex items-center gap-1.5 overflow-x-auto no-scrollbar">
                   {krMarketHistory.slice().reverse().slice(0, 8).map((s, i) => (
                     <button key={i} onClick={() => handleSearch(s)}
-                      className="shrink-0 px-2.5 py-1.5 text-xs font-bold text-zinc-500 hover:text-blue-600 dark:text-zinc-400 dark:hover:text-blue-400 hover:bg-white dark:hover:bg-zinc-800/40 rounded-lg border border-zinc-200/60 dark:border-zinc-800 transition-all whitespace-nowrap"
+                      className="shrink-0 px-2.5 py-1.5 text-xs font-bold text-zinc-500 hover:text-blue-600 dark:text-zinc-400 dark:hover:text-blue-400 hover:bg-white dark:hover:bg-[#1a1a1a]/40 rounded-lg border border-zinc-200/60 dark:border-[#2a2a2a] transition-all whitespace-nowrap"
                     >
                       {s}
                     </button>
@@ -502,7 +502,7 @@ function AnalyzeContent() {
             <div className={cn(!isLoaded ? 'hidden' : 'animate-in fade-in duration-400')}>
 
               {/* 종목 헤더 카드 */}
-              <div className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 p-4 mb-4 shadow-sm relative overflow-hidden">
+              <div className="bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] p-4 mb-4 shadow-sm relative overflow-hidden">
                 <div className={cn("absolute top-0 left-0 right-0 h-0.5",
                   krOrUs === 'US' ? "bg-gradient-to-r from-blue-500 to-sky-400" : "bg-gradient-to-r from-indigo-500 to-purple-400"
                 )} />
@@ -523,7 +523,7 @@ function AnalyzeContent() {
                         {gradeDisplay && (
                           <span className={cn(
                             "px-2 py-0.5 rounded text-xs font-black font-mono shrink-0",
-                            GRADE_PILL[gradeDisplay] ?? "bg-zinc-200 text-zinc-700 dark:bg-zinc-700 dark:text-zinc-200"
+                            GRADE_PILL[gradeDisplay] ?? "bg-zinc-200 text-zinc-700 dark:bg-[#3a3a3a] dark:text-zinc-200"
                           )}>
                             {gradeDisplay}
                           </span>
@@ -547,7 +547,7 @@ function AnalyzeContent() {
                         "flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-bold border transition-all",
                         isInWatchlist
                           ? "text-amber-600 bg-amber-50 border-amber-200 dark:bg-amber-950/20 dark:border-amber-800/50 dark:text-amber-400"
-                          : "text-zinc-600 bg-zinc-50 border-zinc-200 hover:border-zinc-300 dark:bg-zinc-800/30 dark:border-zinc-700"
+                          : "text-zinc-600 bg-stone-100 border-zinc-200 hover:border-zinc-300 dark:bg-[#1a1a1a]/30 dark:border-[#222222]"
                       )}
                     >
                       <Star size={13} className={isInWatchlist ? "fill-amber-500" : ""} />
@@ -616,7 +616,7 @@ function AnalyzeContent() {
                         : "text-zinc-400",
                     },
                   ].map(m => (
-                    <div key={m.label} className="bg-white dark:bg-zinc-900 rounded-xl border border-zinc-200 dark:border-zinc-800 p-4 shadow-sm">
+                    <div key={m.label} className="bg-white dark:bg-[#1a1a1a] rounded-xl border border-zinc-200 dark:border-[#2a2a2a] p-4 shadow-sm">
                       <p className="text-[10px] font-bold text-zinc-400 uppercase tracking-wider mb-1.5">{m.label}</p>
                       <p className={cn("text-2xl font-black font-mono tabular-nums leading-none", m.color)}>{m.value}</p>
                       <p className="text-[10px] text-zinc-400 mt-1.5">{m.desc}</p>
@@ -630,7 +630,7 @@ function AnalyzeContent() {
                 <div className="space-y-5">
                   <div className="flex items-center gap-3">
                     <p className="text-[11px] font-bold text-zinc-400 uppercase tracking-widest font-mono shrink-0">Detail Analysis</p>
-                    <div className="flex-1 h-px bg-zinc-100 dark:bg-zinc-800/70" />
+                    <div className="flex-1 h-px bg-stone-100 dark:bg-[#1a1a1a]/70" />
                   </div>
 
                   {/* 차트 + 지표 */}
@@ -672,13 +672,13 @@ function AnalyzeContent() {
                   </div>
 
                   {/* 밸류에이션 */}
-                  <div className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 p-1 shadow-sm">
+                  <div className="bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] p-1 shadow-sm">
                     <ValuationSection data={data} isUs={krOrUs === 'US'} />
                   </div>
 
                   {/* 재무제표 */}
-                  <div className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm overflow-hidden">
-                    <div className="px-5 py-4 border-b border-zinc-100 dark:border-zinc-800">
+                  <div className="bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] shadow-sm overflow-hidden">
+                    <div className="px-5 py-4 border-b border-zinc-100 dark:border-[#2a2a2a]">
                       <h3 className="text-sm font-extrabold text-zinc-800 dark:text-zinc-200">재무제표</h3>
                       <p className="text-[10px] text-zinc-400 mt-0.5">
                         {krOrUs === 'KR' ? 'DART 공시 기준 (억 원)' : 'US-GAAP 기준 (USD)'}
@@ -698,8 +698,8 @@ function AnalyzeContent() {
                   {/* 잠긴 섹션 레이블 */}
                   <div className="flex items-center gap-3">
                     <p className="text-[11px] font-bold text-zinc-400 uppercase tracking-widest font-mono shrink-0">Detail Analysis</p>
-                    <div className="flex-1 h-px bg-zinc-100 dark:bg-zinc-800/70" />
-                    <span className="flex items-center gap-1 text-[10px] font-bold text-zinc-400 bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-full">
+                    <div className="flex-1 h-px bg-stone-100 dark:bg-[#1a1a1a]/70" />
+                    <span className="flex items-center gap-1 text-[10px] font-bold text-zinc-400 bg-stone-100 dark:bg-[#1a1a1a] px-2 py-0.5 rounded-full">
                       <Lock size={9} />
                       로그인 필요
                     </span>
@@ -730,13 +730,13 @@ function AnalyzeContent() {
                       },
                     ].map(item => (
                       <div key={item.title}
-                        className="relative flex items-start gap-3 p-4 bg-white dark:bg-zinc-900 rounded-xl border border-zinc-200 dark:border-zinc-800 overflow-hidden"
+                        className="relative flex items-start gap-3 p-4 bg-white dark:bg-[#1a1a1a] rounded-xl border border-zinc-200 dark:border-[#2a2a2a] overflow-hidden"
                       >
                         {/* 흐릿한 내용 배경 */}
                         <div className="absolute inset-0 opacity-30 pointer-events-none">
-                          <div className="absolute top-8 left-4 right-4 h-2 bg-zinc-200 dark:bg-zinc-700 rounded" />
-                          <div className="absolute top-13 left-4 right-8 h-2 bg-zinc-200 dark:bg-zinc-700 rounded" />
-                          <div className="absolute top-18 left-4 right-12 h-2 bg-zinc-200 dark:bg-zinc-700 rounded" />
+                          <div className="absolute top-8 left-4 right-4 h-2 bg-zinc-200 dark:bg-[#3a3a3a] rounded" />
+                          <div className="absolute top-13 left-4 right-8 h-2 bg-zinc-200 dark:bg-[#3a3a3a] rounded" />
+                          <div className="absolute top-18 left-4 right-12 h-2 bg-zinc-200 dark:bg-[#3a3a3a] rounded" />
                         </div>
                         <span className="text-xl shrink-0">{item.icon}</span>
                         <div className="min-w-0">
@@ -774,7 +774,7 @@ function AnalyzeContent() {
       </main>
 
       {/* ── 푸터 ── */}
-      <footer className="max-w-4xl mx-auto px-4 pt-8 pb-12 mt-12 border-t border-zinc-200 dark:border-zinc-800">
+      <footer className="max-w-4xl mx-auto px-4 pt-8 pb-12 mt-12 border-t border-zinc-200 dark:border-[#2a2a2a]">
         <div className="flex flex-col items-center gap-3">
           <div className="flex items-center gap-2">
             <TrendingUp size={13} className="text-blue-500" strokeWidth={2.5} />
@@ -798,7 +798,7 @@ export default function AnalyzePage() {
   return (
     <Suspense fallback={
       <div className="flex flex-col items-center justify-center py-40 gap-5 bg-stone-100 dark:bg-[#0d0d0d] min-h-screen">
-        <div className="p-4 bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm">
+        <div className="p-4 bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] shadow-sm">
           <Loader2 className="animate-spin text-blue-600 dark:text-blue-400" size={24} />
         </div>
         <p className="text-[11px] font-bold text-zinc-400 dark:text-zinc-500 tracking-widest font-mono uppercase">

--- a/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
+++ b/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
@@ -89,7 +89,7 @@ function MetricChip({ label, value, valueClass = "text-zinc-900 dark:text-zinc-1
   label: string; value: string; valueClass?: string;
 }) {
   return (
-    <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl px-4 py-2.5 flex flex-col gap-0.5 shrink-0">
+    <div className="bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] rounded-xl px-4 py-2.5 flex flex-col gap-0.5 shrink-0">
       <span className="text-[9px] font-black text-zinc-400 dark:text-zinc-500 uppercase tracking-widest whitespace-nowrap">{label}</span>
       <span className={cn("text-xs font-mono font-black whitespace-nowrap", valueClass)}>{value}</span>
     </div>
@@ -102,7 +102,7 @@ function MetricChip({ label, value, valueClass = "text-zinc-900 dark:text-zinc-1
 function OrderRow({ item, isNccs }: { item: any; isNccs: boolean }) {
   const isBuy = item.ord_dvsn_name?.includes("매수") || item.sll_buy_dvsn_cd === "02";
   return (
-    <tr className="hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors group">
+    <tr className="hover:bg-stone-100 dark:hover:bg-[#1a1a1a]/40 transition-colors group">
       <td className="py-3.5 px-4">
         <span className="block text-xs font-semibold text-zinc-700 dark:text-zinc-300">
           {isNccs ? "대기 중" : formatTime(item.ccld_time)}
@@ -314,7 +314,7 @@ function BalanceKr() {
   ];
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 transition-colors duration-300">
+    <div className="min-h-screen bg-stone-100 dark:bg-[#0d0d0d] transition-colors duration-300">
 
       <ToastContainer toasts={toasts} onRemove={removeToast} />
 
@@ -336,7 +336,7 @@ function BalanceKr() {
               {currentKakaoUser && (
                 <>
                   <ChevronRight size={11} className="text-zinc-300 dark:text-zinc-600" />
-                  <span className="flex items-center gap-1 text-zinc-600 dark:text-zinc-300 bg-zinc-200/60 dark:bg-zinc-800 px-2 py-0.5 rounded-md">
+                  <span className="flex items-center gap-1 text-zinc-600 dark:text-zinc-300 bg-zinc-200/60 dark:bg-[#1a1a1a] px-2 py-0.5 rounded-md">
                     <User size={10} />
                     {currentKakaoUser.name || balanceKey}
                   </span>
@@ -351,7 +351,7 @@ function BalanceKr() {
               </h1>
               <span className="text-2xl select-none" aria-hidden>🇰🇷</span>
               {!isLoading && totalEvalAmt > 0 && (
-                <span className="text-sm font-mono font-black text-zinc-400 dark:text-zinc-500 bg-zinc-100 dark:bg-zinc-800 px-2.5 py-1 rounded-lg border border-zinc-200 dark:border-zinc-700">
+                <span className="text-sm font-mono font-black text-zinc-400 dark:text-zinc-500 bg-stone-100 dark:bg-[#1a1a1a] px-2.5 py-1 rounded-lg border border-zinc-200 dark:border-[#222222]">
                   {totalEvalAmt.toLocaleString()}원
                 </span>
               )}
@@ -364,7 +364,7 @@ function BalanceKr() {
                 {lastUpdated.toLocaleTimeString("ko-KR")} 기준
               </p>
             ) : (
-              <div className="h-4 w-40 rounded bg-zinc-200 dark:bg-zinc-800 animate-pulse" />
+              <div className="h-4 w-40 rounded bg-zinc-200 dark:bg-[#1a1a1a] animate-pulse" />
             )}
           </div>
 
@@ -375,7 +375,7 @@ function BalanceKr() {
               isLoading={isLoading}
               onRefresh={handleRefresh}
             />
-            <span className="text-[10px] font-mono text-zinc-400 bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 px-2.5 py-1 rounded-lg">
+            <span className="text-[10px] font-mono text-zinc-400 bg-stone-100 dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] px-2.5 py-1 rounded-lg">
               ID: {String(balanceKey).slice(0, 8) || "N/A"}
             </span>
           </div>
@@ -418,7 +418,7 @@ function BalanceKr() {
             value={isLoading ? null : `${isPnlPositive ? "▲ +" : "▼ "}${pnlRate.toFixed(2)}%`}
             sub={isLoading ? "" : `당일 증감 ${isDailyPositive ? "+" : ""}${asstIcdcErngRt.toFixed(2)}%`}
             icon={<Percent size={15} />}
-            iconBg="bg-zinc-100 dark:bg-zinc-800 text-zinc-500"
+            iconBg="bg-stone-100 dark:bg-[#1a1a1a] text-zinc-500"
             valueColor={pnlValueColor(isPnlPositive)}
             accentColor={pnlAccentColor(isPnlPositive)}
           />
@@ -507,7 +507,7 @@ function BalanceKr() {
                 krCapital.state === "pending"
                   ? <span className="text-[10px] font-mono text-amber-500 bg-amber-50 dark:bg-amber-950/20 px-2 py-0.5 rounded-full border border-amber-200 dark:border-amber-800 animate-pulse">로딩 중</span>
                   : krCapital.stock_list?.length > 0
-                  ? <span className="text-[10px] font-mono text-zinc-500 dark:text-zinc-400 bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-full">{krCapital.stock_list.length}종목</span>
+                  ? <span className="text-[10px] font-mono text-zinc-500 dark:text-zinc-400 bg-stone-100 dark:bg-[#1a1a1a] px-2 py-0.5 rounded-full">{krCapital.stock_list.length}종목</span>
                   : null
               }
             />
@@ -541,7 +541,7 @@ function BalanceKr() {
             }
           />
 
-          <div className="overflow-x-auto rounded-xl border border-zinc-100 dark:border-zinc-800">
+          <div className="overflow-x-auto rounded-xl border border-zinc-100 dark:border-[#2a2a2a]">
             <table className="w-full text-sm text-left min-w-[600px]">
               <TableHeader headers={[
                 { label: "주문시간 / 번호" },
@@ -551,7 +551,7 @@ function BalanceKr() {
                 { label: "체결가 / 수량", align: "text-right" },
                 { label: "미체결", align: "text-right" },
               ]} />
-              <tbody className="divide-y divide-zinc-50 dark:divide-zinc-800/40">
+              <tbody className="divide-y divide-zinc-50 dark:divide-[#2a2a2a]/40">
                 {viewerTab === "ccnl" ? (
                   krCcnl.output?.length > 0
                     ? krCcnl.output.map((item, i) => (

--- a/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
+++ b/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
@@ -58,7 +58,7 @@ function MetricChip({ label, value, valueClass = "text-zinc-900 dark:text-zinc-1
   label: string; value: string; valueClass?: string;
 }) {
   return (
-    <div className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl px-4 py-2.5 flex flex-col gap-0.5 shrink-0">
+    <div className="bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] rounded-xl px-4 py-2.5 flex flex-col gap-0.5 shrink-0">
       <span className="text-[9px] font-black text-zinc-400 dark:text-zinc-500 uppercase tracking-widest whitespace-nowrap">{label}</span>
       <span className={cn("text-xs font-mono font-black whitespace-nowrap", valueClass)}>{value}</span>
     </div>
@@ -73,7 +73,7 @@ function OverseasOrderRow({ item, isNccs }: { item: any; isNccs: boolean }) {
   const hasPartialFill = Number(item.ft_ccld_qty || 0) > 0;
 
   return (
-    <tr className="hover:bg-zinc-50 dark:hover:bg-zinc-800/40 transition-colors group">
+    <tr className="hover:bg-stone-100 dark:hover:bg-[#1a1a1a]/40 transition-colors group">
       <td className="py-3.5 px-4">
         <span className="block text-xs font-semibold text-zinc-700 dark:text-zinc-300">
           {formatTime(item.ord_tmd)}
@@ -127,7 +127,7 @@ function OverseasOrderRow({ item, isNccs }: { item: any; isNccs: boolean }) {
             ? "bg-emerald-50 text-emerald-600 dark:bg-emerald-950/30 dark:text-emerald-400"
             : isNccs
             ? "bg-amber-50 text-amber-600 dark:bg-amber-950/30 dark:text-amber-400"
-            : "bg-zinc-100 text-zinc-500 dark:bg-zinc-800"
+            : "bg-stone-100 text-zinc-500 dark:bg-[#1a1a1a]"
         )}>
           {item.prcs_stat_name || (isNccs ? "대기" : "-")}
         </span>
@@ -309,7 +309,7 @@ function BalanceUs() {
   ];
 
   return (
-    <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 transition-colors duration-300">
+    <div className="min-h-screen bg-stone-100 dark:bg-[#0d0d0d] transition-colors duration-300">
 
       <ToastContainer toasts={toasts} onRemove={removeToast} />
 
@@ -339,7 +339,7 @@ function BalanceUs() {
                 <DollarSign size={11} /> USD Account
               </span>
               {!isLoading && totalAssetUsd > 0 && (
-                <span className="text-sm font-mono font-black text-zinc-400 dark:text-zinc-500 bg-zinc-100 dark:bg-zinc-800 px-2.5 py-1 rounded-lg border border-zinc-200 dark:border-zinc-700">
+                <span className="text-sm font-mono font-black text-zinc-400 dark:text-zinc-500 bg-stone-100 dark:bg-[#1a1a1a] px-2.5 py-1 rounded-lg border border-zinc-200 dark:border-[#222222]">
                   {fmtUsd(totalAssetUsd)}
                 </span>
               )}
@@ -352,7 +352,7 @@ function BalanceUs() {
                 {lastUpdated.toLocaleTimeString("ko-KR")} 기준
               </p>
             ) : (
-              <div className="h-4 w-40 rounded bg-zinc-200 dark:bg-zinc-800 animate-pulse" />
+              <div className="h-4 w-40 rounded bg-zinc-200 dark:bg-[#1a1a1a] animate-pulse" />
             )}
           </div>
 
@@ -364,7 +364,7 @@ function BalanceUs() {
               onRefresh={handleRefresh}
               extra={
                 exRate > 0 ? (
-                  <div className="flex items-center gap-2 bg-white dark:bg-zinc-900 px-3 py-2 rounded-xl border border-zinc-200 dark:border-zinc-800 shadow-sm">
+                  <div className="flex items-center gap-2 bg-white dark:bg-[#1a1a1a] px-3 py-2 rounded-xl border border-zinc-200 dark:border-[#2a2a2a] shadow-sm">
                     <span className="text-[10px] font-black text-zinc-400 uppercase tracking-wider">고시환율</span>
                     <span className="text-sm font-mono font-black text-blue-600 dark:text-blue-400">
                       {exRate.toLocaleString()}원
@@ -432,7 +432,7 @@ function BalanceUs() {
             subLabel="원화 환산액"
             subValue={isLoading ? null : fmtKrw(pchsAmtKrw)}
             icon={<DollarSign size={15} />}
-            iconBg="bg-zinc-100 dark:bg-zinc-800 text-zinc-500"
+            iconBg="bg-stone-100 dark:bg-[#1a1a1a] text-zinc-500"
             accentColor="bg-zinc-400 dark:bg-zinc-600"
             loading={isLoading}
           />
@@ -533,7 +533,7 @@ function BalanceUs() {
                 usCapital.state === "pending"
                   ? <span className="text-[10px] font-mono text-amber-500 bg-amber-50 dark:bg-amber-950/20 px-2 py-0.5 rounded-full border border-amber-200 dark:border-amber-800 animate-pulse">로딩 중</span>
                   : usCapital.stock_list?.length > 0
-                  ? <span className="text-[10px] font-mono text-zinc-500 dark:text-zinc-400 bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-full">{usCapital.stock_list.length}종목</span>
+                  ? <span className="text-[10px] font-mono text-zinc-500 dark:text-zinc-400 bg-stone-100 dark:bg-[#1a1a1a] px-2 py-0.5 rounded-full">{usCapital.stock_list.length}종목</span>
                   : null
               }
             />
@@ -570,7 +570,7 @@ function BalanceUs() {
             }
           />
 
-          <div className="overflow-x-auto rounded-xl border border-zinc-100 dark:border-zinc-800">
+          <div className="overflow-x-auto rounded-xl border border-zinc-100 dark:border-[#2a2a2a]">
             <table className="w-full text-sm text-left min-w-[860px]">
               <TableHeader headers={[
                 { label: "주문시각 / 번호" },
@@ -583,7 +583,7 @@ function BalanceUs() {
                 { label: "처리상태", align: "text-center" },
                 { label: "미체결", align: "text-right" },
               ]} />
-              <tbody className="divide-y divide-zinc-50 dark:divide-zinc-800/40">
+              <tbody className="divide-y divide-zinc-50 dark:divide-[#2a2a2a]/40">
                 {viewerTab === "ccnl" ? (
                   kiCcnl.output?.length > 0
                     ? kiCcnl.output.map((item, i) => (

--- a/cf-idiotquant/app/(calculator)/calculator/ResultChart.tsx
+++ b/cf-idiotquant/app/(calculator)/calculator/ResultChart.tsx
@@ -51,7 +51,7 @@ interface ResultChartProps {
 const CustomTooltip = ({ active, payload }: any) => {
     if (active && payload && payload.length) {
         return (
-            <div className="bg-zinc-950/95 dark:bg-zinc-900/95 backdrop-blur-md border border-zinc-800 p-4 rounded-xl shadow-xl space-y-2 z-50">
+            <div className="bg-zinc-950/95 dark:bg-[#111111]/95 backdrop-blur-md border border-zinc-800 p-4 rounded-xl shadow-xl space-y-2 z-50">
                 <p className="text-[10px] font-black text-zinc-400 dark:text-zinc-500 font-mono tracking-wider">
                     {payload[0].payload.year}세 예상 진단
                 </p>
@@ -89,7 +89,7 @@ const ResultChart: FC<ResultChartProps> = ({ data, height }) => {
     }
 
     return (
-        <div className="w-full bg-white dark:bg-zinc-900/10 border border-zinc-200/50 dark:border-zinc-800/50 rounded-2xl p-3 sm:p-5 backdrop-blur-md relative overflow-hidden group shadow-xs">
+        <div className="w-full bg-white dark:bg-[#1a1a1a]/10 border border-zinc-200/50 dark:border-[#2a2a2a]/50 rounded-2xl p-3 sm:p-5 backdrop-blur-md relative overflow-hidden group shadow-xs">
             <div className="absolute top-0 left-0 w-full h-[2px] bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-500 opacity-70" />
             
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-8">

--- a/cf-idiotquant/app/(calculator)/calculator/page.tsx
+++ b/cf-idiotquant/app/(calculator)/calculator/page.tsx
@@ -201,7 +201,7 @@ const createNextInputs = <K extends keyof CalcInputs>(previousInputs: CalcInputs
 export default function AssetLifetimeCalculator() {
     return (
         <Suspense fallback={
-            <div className="min-h-screen bg-zinc-50 dark:bg-zinc-950 flex flex-col gap-3 items-center justify-center text-zinc-500 dark:text-zinc-400 font-sans text-sm font-medium">
+            <div className="min-h-screen bg-stone-100 dark:bg-[#0d0d0d] flex flex-col gap-3 items-center justify-center text-zinc-500 dark:text-zinc-400 font-sans text-sm font-medium">
                 <div className="w-6 h-6 border-2 border-blue-600 border-t-transparent rounded-full animate-spin" />
                 <span>시뮬레이터 데이터를 로드하고 있습니다...</span>
             </div>
@@ -343,7 +343,7 @@ function CalculatorContent() {
 
         let level = 1;
         let label = "초심자";
-        let color = "text-zinc-700 bg-zinc-100 border-zinc-200 dark:text-zinc-300 dark:bg-zinc-800/80 dark:border-zinc-700";
+        let color = "text-zinc-700 bg-stone-100 border-zinc-200 dark:text-zinc-300 dark:bg-[#1a1a1a]/80 dark:border-[#222222]";
         let iconColor = "text-zinc-500 dark:text-zinc-400";
         let desc = "기본적인 수익률만 계산하는 단계입니다. 실전처럼 물가상승이나 건보료, 절세 옵션을 켜서 정밀도를 높여보세요.";
 
@@ -497,9 +497,9 @@ function CalculatorContent() {
     };
 
     return (
-        <div className="bg-zinc-50 dark:bg-zinc-950 min-h-screen p-3 sm:p-6 md:p-10 pb-24 md:pb-10 font-sans text-zinc-900 dark:text-zinc-50 selection:bg-blue-500/20">
+        <div className="bg-stone-100 dark:bg-[#0d0d0d] min-h-screen p-3 sm:p-6 md:p-10 pb-24 md:pb-10 font-sans text-zinc-900 dark:text-zinc-50 selection:bg-blue-500/20">
             <div className="max-w-6xl mx-auto space-y-5 sm:space-y-10">
-                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-zinc-200 dark:border-zinc-800 pb-4 sm:pb-6">
+                <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-zinc-200 dark:border-[#2a2a2a] pb-4 sm:pb-6">
                     <div className="flex items-center gap-2 sm:gap-3">
                         <div className="p-2 sm:p-2.5 bg-blue-600 rounded-xl sm:rounded-2xl text-white shadow-lg shadow-blue-600/20 shrink-0">
                             <CalculatorIcon className="w-5 h-5 sm:w-6" />
@@ -539,7 +539,7 @@ function CalculatorContent() {
                                 "flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-1.5 px-2 py-2 sm:px-3 rounded-lg font-bold text-[10px] sm:text-[11px] transition-all border shadow-xs text-center leading-tight sm:leading-none",
                                 isReorderEnabled
                                     ? "bg-blue-600 border-blue-600 text-white"
-                                    : "bg-white dark:bg-zinc-900 border-zinc-300 dark:border-zinc-700 text-zinc-900 dark:text-zinc-50"
+                                    : "bg-white dark:bg-[#1a1a1a] border-zinc-300 dark:border-[#222222] text-zinc-900 dark:text-zinc-50"
                             )}
                         >
                             <Bars3Icon className="w-3.5 h-3.5 shrink-0" />
@@ -548,7 +548,7 @@ function CalculatorContent() {
 
                         <button
                             onClick={resetLayout}
-                            className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-1 px-2 py-2 sm:px-3 rounded-lg font-bold text-[10px] sm:text-[11px] bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 text-zinc-700 dark:text-zinc-300 transition-colors border border-zinc-200 dark:border-zinc-700/60 shadow-xs text-center leading-tight sm:leading-none"
+                            className="flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-1 px-2 py-2 sm:px-3 rounded-lg font-bold text-[10px] sm:text-[11px] bg-stone-100 dark:bg-[#1a1a1a] hover:bg-zinc-200 dark:hover:bg-[#1a1a1a] text-zinc-700 dark:text-zinc-300 transition-colors border border-zinc-200 dark:border-[#222222]/60 shadow-xs text-center leading-tight sm:leading-none"
                         >
                             <ArrowPathIcon className="w-3.5 h-3.5 shrink-0" />
                             <span>위치 초기화</span>
@@ -560,7 +560,7 @@ function CalculatorContent() {
                                 "flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-1.5 px-2 py-2 sm:px-3 rounded-lg font-bold text-[10px] sm:text-[11px] transition-all shadow-xs border shrink-0 text-center leading-tight sm:leading-none",
                                 copied
                                     ? "bg-emerald-600 border-emerald-600 text-white"
-                                    : "bg-white dark:bg-zinc-900 border-zinc-300 dark:border-zinc-700 text-zinc-900 dark:text-zinc-50 hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                                    : "bg-white dark:bg-[#1a1a1a] border-zinc-300 dark:border-[#222222] text-zinc-900 dark:text-zinc-50 hover:bg-stone-100 dark:hover:bg-[#1a1a1a]"
                             )}
                         >
                             {copied ? <CheckIcon className="w-3.5 h-3.5 shrink-0" /> : <ShareIcon className="w-3.5 h-3.5 shrink-0" />}
@@ -587,7 +587,7 @@ function CalculatorContent() {
                                     >
                                         <DragIndicatorOverlay desktopType="입력 섹션 내 상하 이동" isEnabled={isReorderEnabled && activeDraggingId === "core-investment"} />
                                         <SectionWrapper title="핵심 자산 및 기대 수익률" icon={<ArrowTrendingUpIcon className="w-4 h-4 text-zinc-500 dark:text-zinc-400" />}>
-                                            <div className="space-y-4 sm:space-y-6 bg-white dark:bg-zinc-900 p-3.5 xs:p-4 sm:p-6 rounded-2xl sm:rounded-[2rem] border border-zinc-200 dark:border-zinc-800 shadow-xs relative group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10 transition-all duration-200">
+                                            <div className="space-y-4 sm:space-y-6 bg-white dark:bg-[#1a1a1a] p-3.5 xs:p-4 sm:p-6 rounded-2xl sm:rounded-[2rem] border border-zinc-200 dark:border-[#2a2a2a] shadow-xs relative group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10 transition-all duration-200">
 
                                                 {/* 모바일 터치 피드백을 위한 touch-action: none 및 넉넉한 터치 패딩 공간 확보 */}
                                                 <div className="absolute right-3 top-3 w-24 h-8 flex items-center justify-end z-30">
@@ -603,7 +603,7 @@ function CalculatorContent() {
                                                             "px-2 py-1.5 rounded text-[10px] font-black select-none flex items-center gap-1 border transition-all",
                                                             isReorderEnabled
                                                                 ? "cursor-grab active:cursor-grabbing bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-800/80 shadow-xs"
-                                                                : "opacity-25 bg-zinc-100 dark:bg-zinc-800 text-zinc-400 border-transparent cursor-not-allowed"
+                                                                : "opacity-25 bg-stone-100 dark:bg-[#1a1a1a] text-zinc-400 border-transparent cursor-not-allowed"
                                                         )}
                                                     >
                                                         <Bars3Icon className="w-3.5 h-3.5" />
@@ -615,7 +615,7 @@ function CalculatorContent() {
                                                     <InputGroup label="초기 투자 시드" tooltip="현재 투입 가능한 순수 자산 및 투자 예치금 총액입니다." value={formatKrw(inputs.investmentAmount)} color="text-blue-600 dark:text-blue-400">
                                                         <div className="flex gap-2">
                                                             <div className="relative flex-1">
-                                                                <input type="number" inputMode="numeric" pattern="[0-9]*" value={inputs.investmentAmount} onChange={(e) => updateInput("investmentAmount", Number(e.target.value))} className="w-full bg-zinc-50 dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-700 rounded-xl pl-3 pr-10 py-2 sm:py-2.5 font-black text-xs sm:text-sm text-zinc-900 dark:text-zinc-50 focus:ring-2 focus:ring-blue-500 outline-none transition-shadow" />
+                                                                <input type="number" inputMode="numeric" pattern="[0-9]*" value={inputs.investmentAmount} onChange={(e) => updateInput("investmentAmount", Number(e.target.value))} className="w-full bg-stone-100 dark:bg-[#1a1a1a] border border-zinc-300 dark:border-[#222222] rounded-xl pl-3 pr-10 py-2 sm:py-2.5 font-black text-xs sm:text-sm text-zinc-900 dark:text-zinc-50 focus:ring-2 focus:ring-blue-500 outline-none transition-shadow" />
                                                                 <div className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-400 dark:text-zinc-500 text-[11px] sm:text-xs font-bold">만원</div>
                                                             </div>
                                                             <StepButtons value={inputs.investmentAmount} step={500} min={0} max={100000000} onChange={(v) => updateInput("investmentAmount", v)} />
@@ -635,7 +635,7 @@ function CalculatorContent() {
                                                     showQuickButtons={true}
                                                 />
 
-                                                <div className="p-3 sm:p-4 bg-zinc-50 dark:bg-zinc-800/30 rounded-xl sm:rounded-2xl border border-zinc-200 dark:border-zinc-800 space-y-2 sm:space-y-3">
+                                                <div className="p-3 sm:p-4 bg-stone-100 dark:bg-[#1a1a1a]/30 rounded-xl sm:rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] space-y-2 sm:space-y-3">
                                                     <span className="text-[11px] sm:text-xs font-black text-zinc-800 dark:text-zinc-200 block px-1">과세 및 헷지 변수</span>
                                                     <div className="flex flex-col gap-0.5">
                                                         <ToggleButton checked={inputs.applyTax} onChange={(v) => updateInput("applyTax", v)} label="이자소득세 과세 (15.4%)" tooltip="매년 투자 수익에 배당소득세를 차감한 세후 복리를 계산합니다." />
@@ -670,7 +670,7 @@ function CalculatorContent() {
                                     >
                                         <DragIndicatorOverlay desktopType="입력 섹션 내 상하 이동" isEnabled={isReorderEnabled && activeDraggingId === "life-cycle"} />
                                         <SectionWrapper title="생애 주기 임계값" icon={<UserIcon className="w-4 h-4 text-zinc-500 dark:text-zinc-400" />}>
-                                            <div className="space-y-4 sm:space-y-5 bg-white dark:bg-zinc-900 p-3.5 xs:p-4 sm:p-6 rounded-2xl sm:rounded-[2rem] border border-zinc-200 dark:border-zinc-800 shadow-xs relative group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10 transition-all duration-200">
+                                            <div className="space-y-4 sm:space-y-5 bg-white dark:bg-[#1a1a1a] p-3.5 xs:p-4 sm:p-6 rounded-2xl sm:rounded-[2rem] border border-zinc-200 dark:border-[#2a2a2a] shadow-xs relative group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10 transition-all duration-200">
 
                                                 <div className="absolute right-3 top-3 w-24 h-8 flex items-center justify-end z-30">
                                                     <div
@@ -685,7 +685,7 @@ function CalculatorContent() {
                                                             "px-2 py-1.5 rounded text-[10px] font-black select-none flex items-center gap-1 border transition-all",
                                                             isReorderEnabled
                                                                 ? "cursor-grab active:cursor-grabbing bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-800/80 shadow-xs"
-                                                                : "opacity-25 bg-zinc-100 dark:bg-zinc-800 text-zinc-400 border-transparent cursor-not-allowed"
+                                                                : "opacity-25 bg-stone-100 dark:bg-[#1a1a1a] text-zinc-400 border-transparent cursor-not-allowed"
                                                         )}
                                                     >
                                                         <Bars3Icon className="w-3.5 h-3.5" />
@@ -717,7 +717,7 @@ function CalculatorContent() {
                                     >
                                         <DragIndicatorOverlay desktopType="입력 섹션 내 상하 이동" isEnabled={isReorderEnabled && activeDraggingId === "incremental-flows"} />
                                         <SectionWrapper title="점증형 현금 가감 데이터" icon={<ArrowsRightLeftIcon className="w-4 h-4 text-zinc-500 dark:text-zinc-400" />}>
-                                            <div className="space-y-4 sm:space-y-6 bg-white dark:bg-zinc-900 p-3.5 xs:p-4 sm:p-6 rounded-2xl sm:rounded-[2rem] border border-zinc-200 dark:border-zinc-800 shadow-xs relative group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10 transition-all duration-200">
+                                            <div className="space-y-4 sm:space-y-6 bg-white dark:bg-[#1a1a1a] p-3.5 xs:p-4 sm:p-6 rounded-2xl sm:rounded-[2rem] border border-zinc-200 dark:border-[#2a2a2a] shadow-xs relative group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10 transition-all duration-200">
 
                                                 <div className="absolute right-3 top-3 w-24 h-8 flex items-center justify-end z-30">
                                                     <div
@@ -732,7 +732,7 @@ function CalculatorContent() {
                                                             "px-2 py-1.5 rounded text-[10px] font-black select-none flex items-center gap-1 border transition-all",
                                                             isReorderEnabled
                                                                 ? "cursor-grab active:cursor-grabbing bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-800/80 shadow-xs"
-                                                                : "opacity-25 bg-zinc-100 dark:bg-zinc-800 text-zinc-400 border-transparent cursor-not-allowed"
+                                                                : "opacity-25 bg-stone-100 dark:bg-[#1a1a1a] text-zinc-400 border-transparent cursor-not-allowed"
                                                         )}
                                                     >
                                                         <Bars3Icon className="w-3.5 h-3.5" />
@@ -743,17 +743,17 @@ function CalculatorContent() {
                                                 <div className="space-y-3 sm:space-y-4 pt-6">
                                                     <InputGroup label="초기 매월 저축액" tooltip="은퇴 전 근로 기간 동안 매달 투자 계좌에 적립할 원금입니다." value={formatKrw(inputs.contributions)}>
                                                         <div className="flex gap-2">
-                                                            <input type="number" inputMode="numeric" pattern="[0-9]*" value={inputs.contributions} onChange={(e) => updateInput("contributions", Number(e.target.value))} className="flex-1 bg-zinc-50 dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-700 rounded-xl px-3 py-2 sm:py-2.5 font-black text-xs sm:text-sm text-zinc-900 dark:text-zinc-50 outline-none focus:ring-2 focus:ring-blue-500 transition-shadow" />
+                                                            <input type="number" inputMode="numeric" pattern="[0-9]*" value={inputs.contributions} onChange={(e) => updateInput("contributions", Number(e.target.value))} className="flex-1 bg-stone-100 dark:bg-[#1a1a1a] border border-zinc-300 dark:border-[#222222] rounded-xl px-3 py-2 sm:py-2.5 font-black text-xs sm:text-sm text-zinc-900 dark:text-zinc-50 outline-none focus:ring-2 focus:ring-blue-500 transition-shadow" />
                                                             <StepButtons value={inputs.contributions} step={50} min={0} max={5000} onChange={(v) => updateInput("contributions", v)} />
                                                         </div>
                                                     </InputGroup>
                                                     <PercentRateSlider label="복리 저축 매년 증액률" tooltip="연봉 상승을 반영해 매년 월 적립액을 복리로 늘려나가는 엔진입니다." value={inputs.contributionGrowthRate} min={0} max={15} step={0.1} onChange={(v) => updateInput("contributionGrowthRate", v)} accentColor="blue" />
                                                 </div>
-                                                <div className="h-px bg-zinc-100 dark:bg-zinc-800" />
+                                                <div className="h-px bg-stone-100 dark:bg-[#1a1a1a]" />
                                                 <div className="space-y-3 sm:space-y-4">
                                                     <InputGroup label="기본 목표 초기 월 생활비" tooltip="은퇴 후 매달 삶을 유지하기 위해 인출하여 사용할 고정 비용입니다." value={formatKrw(inputs.monthlyExpense)} color="text-rose-600 dark:text-rose-400">
                                                         <div className="flex gap-2">
-                                                            <input type="number" inputMode="numeric" pattern="[0-9]*" value={inputs.monthlyExpense} onChange={(e) => updateInput("monthlyExpense", Number(e.target.value))} className="flex-1 bg-zinc-50 dark:bg-zinc-800 border border-zinc-300 dark:border-zinc-700 rounded-xl px-3 py-2 sm:py-2.5 font-black text-xs sm:text-sm text-zinc-900 dark:text-zinc-50 outline-none focus:ring-2 focus:ring-rose-500 transition-shadow" />
+                                                            <input type="number" inputMode="numeric" pattern="[0-9]*" value={inputs.monthlyExpense} onChange={(e) => updateInput("monthlyExpense", Number(e.target.value))} className="flex-1 bg-stone-100 dark:bg-[#1a1a1a] border border-zinc-300 dark:border-[#222222] rounded-xl px-3 py-2 sm:py-2.5 font-black text-xs sm:text-sm text-zinc-900 dark:text-zinc-50 outline-none focus:ring-2 focus:ring-rose-500 transition-shadow" />
                                                             <StepButtons value={inputs.monthlyExpense} step={50} min={0} max={5000} onChange={(v) => updateInput("monthlyExpense", v)} />
                                                         </div>
                                                     </InputGroup>
@@ -784,7 +784,7 @@ function CalculatorContent() {
                                         className="bg-transparent select-none outline-none relative group/item rounded-2xl"
                                     >
                                         <DragIndicatorOverlay desktopType="리포트 섹션 내 상하 이동" isEnabled={isReorderEnabled && activeDraggingId === "summary-card"} />
-                                        <div className={cn("p-4 sm:p-8 md:p-10 rounded-2xl sm:rounded-[2.5rem] shadow-xl relative overflow-hidden transition-all duration-300 border bg-zinc-950 border-zinc-800 dark:bg-zinc-900 dark:border-zinc-800/80 text-white group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10", results.finalValue < 0 && "border-rose-900/50 bg-gradient-to-br from-zinc-950 to-rose-950/30")}>
+                                        <div className={cn("p-4 sm:p-8 md:p-10 rounded-2xl sm:rounded-[2.5rem] shadow-xl relative overflow-hidden transition-all duration-300 border bg-zinc-950 border-zinc-800 dark:bg-[#1a1a1a] dark:border-[#2a2a2a]/80 text-white group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10", results.finalValue < 0 && "border-rose-900/50 bg-gradient-to-br from-zinc-950 to-rose-950/30")}>
 
                                             <div className="absolute right-4 top-4 w-24 h-8 flex items-center justify-end z-30">
                                                 <div
@@ -870,7 +870,7 @@ function CalculatorContent() {
                                                     className={cn(
                                                         "px-2 py-1.5 rounded text-[10px] font-black select-none flex items-center gap-1 border transition-all",
                                                         isReorderEnabled
-                                                            ? "cursor-grab active:cursor-grabbing bg-white dark:bg-zinc-900 text-blue-600 dark:text-blue-400 border-zinc-200 dark:border-zinc-800 shadow-xs ring-1 ring-blue-500/30"
+                                                            ? "cursor-grab active:cursor-grabbing bg-white dark:bg-[#1a1a1a] text-blue-600 dark:text-blue-400 border-zinc-200 dark:border-[#2a2a2a] shadow-xs ring-1 ring-blue-500/30"
                                                             : "opacity-0 pointer-events-none"
                                                     )}
                                                 >
@@ -904,7 +904,7 @@ function CalculatorContent() {
                                         className="bg-transparent select-none outline-none relative group/item rounded-2xl"
                                     >
                                         <DragIndicatorOverlay desktopType="리포트 섹션 내 상하 이동" isEnabled={isReorderEnabled && activeDraggingId === "chart-view"} />
-                                        <div className="bg-white dark:bg-zinc-900 p-3.5 sm:p-6 md:p-8 rounded-2xl sm:rounded-[2.5rem] border border-zinc-200 dark:border-zinc-800 shadow-xs relative group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10 transition-all duration-200">
+                                        <div className="bg-white dark:bg-[#1a1a1a] p-3.5 sm:p-6 md:p-8 rounded-2xl sm:rounded-[2.5rem] border border-zinc-200 dark:border-[#2a2a2a] shadow-xs relative group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10 transition-all duration-200">
 
                                             <div className="absolute right-3 top-3 w-24 h-8 flex items-center justify-end z-30">
                                                 <div
@@ -919,7 +919,7 @@ function CalculatorContent() {
                                                         "px-2 py-1.5 rounded text-[10px] font-black select-none flex items-center gap-1 border transition-all",
                                                         isReorderEnabled
                                                             ? "cursor-grab active:cursor-grabbing bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-800/80 shadow-xs"
-                                                            : "opacity-25 bg-zinc-100 dark:bg-zinc-800 text-zinc-400 border-transparent cursor-not-allowed"
+                                                            : "opacity-25 bg-stone-100 dark:bg-[#1a1a1a] text-zinc-400 border-transparent cursor-not-allowed"
                                                     )}
                                                 >
                                                     <Bars3Icon className="w-3.5 h-3.5" />
@@ -931,7 +931,7 @@ function CalculatorContent() {
                                                 <h3 className="text-sm sm:text-lg font-black tracking-tight text-zinc-900 dark:text-zinc-50">지표 연동형 자산 변동 그래프</h3>
                                                 <p className="text-[11px] sm:text-sm text-zinc-500 dark:text-zinc-400 font-semibold mt-0.5">매년 가중되는 인플레이션 누적 및 세후 배당 유출입 복리 커브</p>
                                             </div>
-                                            <div className="bg-zinc-50 dark:bg-black/20 rounded-xl overflow-hidden border border-zinc-200 dark:border-zinc-800/80 p-1 sm:p-4">
+                                            <div className="bg-stone-100 dark:bg-black/20 rounded-xl overflow-hidden border border-zinc-200 dark:border-[#2a2a2a]/80 p-1 sm:p-4">
                                                 <ResultChart data={results.chartData} height="h-[260px] sm:h-[350px]" />
                                             </div>
                                         </div>
@@ -951,7 +951,7 @@ function CalculatorContent() {
                                         className="bg-transparent select-none outline-none relative group/item rounded-2xl"
                                     >
                                         <DragIndicatorOverlay desktopType="리포트 섹션 내 상하 이동" isEnabled={isReorderEnabled && activeDraggingId === "table-report"} />
-                                        <div className="bg-white dark:bg-zinc-900 p-3.5 sm:p-6 rounded-2xl sm:rounded-[2.5rem] border border-zinc-200 dark:border-zinc-800 shadow-xs relative group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10 transition-all duration-200">
+                                        <div className="bg-white dark:bg-[#1a1a1a] p-3.5 sm:p-6 rounded-2xl sm:rounded-[2.5rem] border border-zinc-200 dark:border-[#2a2a2a] shadow-xs relative group/card border-t-4 group-active/item:border-blue-500 group-active/item:ring-4 group-active/item:ring-blue-500/20 dark:group-active/item:ring-blue-500/10 transition-all duration-200">
 
                                             <div className="absolute right-3 top-3 w-24 h-8 flex items-center justify-end z-30">
                                                 <div
@@ -966,7 +966,7 @@ function CalculatorContent() {
                                                         "px-2 py-1.5 rounded text-[10px] font-black select-none flex items-center gap-1 border transition-all",
                                                         isReorderEnabled
                                                             ? "cursor-grab active:cursor-grabbing bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-800/80 shadow-xs"
-                                                            : "opacity-25 bg-zinc-100 dark:bg-zinc-800 text-zinc-400 border-transparent cursor-not-allowed"
+                                                            : "opacity-25 bg-stone-100 dark:bg-[#1a1a1a] text-zinc-400 border-transparent cursor-not-allowed"
                                                     )}
                                                 >
                                                     <Bars3Icon className="w-3.5 h-3.5" />
@@ -980,9 +980,9 @@ function CalculatorContent() {
                                                     {inputs.realValueMode ? "인플레이션 차감 가치가 반영된 실질 가치 기준 흐름입니다." : "매년 가중 증액된 명목 화폐 기준 흐름입니다."}
                                                 </p>
                                             </div>
-                                            <div className="overflow-x-auto rounded-xl border border-zinc-200 dark:border-zinc-800 max-h-64 sm:max-h-80 overflow-y-auto">
+                                            <div className="overflow-x-auto rounded-xl border border-zinc-200 dark:border-[#2a2a2a] max-h-64 sm:max-h-80 overflow-y-auto">
                                                 <table className="w-full text-left border-collapse text-[11px] sm:text-xs">
-                                                    <thead className="bg-zinc-50 dark:bg-zinc-800 sticky top-0 font-black text-zinc-700 dark:text-zinc-300 border-b border-zinc-200 dark:border-zinc-700">
+                                                    <thead className="bg-stone-100 dark:bg-[#1a1a1a] sticky top-0 font-black text-zinc-700 dark:text-zinc-300 border-b border-zinc-200 dark:border-[#222222]">
                                                         <tr>
                                                             <th className="p-2 sm:p-3">나이</th>
                                                             <th className="p-2 sm:p-3 text-right">연간 저축</th>
@@ -992,9 +992,9 @@ function CalculatorContent() {
                                                             <th className="p-2 sm:p-3 text-right">예상 잔고</th>
                                                         </tr>
                                                     </thead>
-                                                    <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800/60 font-semibold text-zinc-800 dark:text-zinc-200 font-mono">
+                                                    <tbody className="divide-y divide-zinc-100 dark:divide-[#2a2a2a]/60 font-semibold text-zinc-800 dark:text-zinc-200 font-mono">
                                                         {results.chartData.map((row: any) => (
-                                                            <tr key={row.year} className="hover:bg-zinc-50/50 dark:hover:bg-zinc-800/30 transition-colors">
+                                                            <tr key={row.year} className="hover:bg-stone-100/50 dark:hover:bg-[#1a1a1a]/30 transition-colors">
                                                                 <td className="p-2 sm:p-3 font-bold text-zinc-500">{row.year}세</td>
                                                                 <td className="p-2 sm:p-3 text-right text-blue-600 dark:text-blue-400">
                                                                     {row.annualContribution > 0 ? formatKrw(row.annualContribution) : "-"}
@@ -1013,7 +1013,7 @@ function CalculatorContent() {
                                                                             <span className="px-1.5 py-0.5 text-[9px] bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300 rounded font-bold">은퇴기</span>
                                                                         )}
                                                                         {row.hasTaxApplied && (
-                                                                            <span className="px-1.5 py-0.5 text-[9px] bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300 rounded">
+                                                                            <span className="px-1.5 py-0.5 text-[9px] bg-stone-100 text-zinc-700 dark:bg-[#1a1a1a] dark:text-zinc-300 rounded">
                                                                                 {row.hasIsaGoldApplied ? "금투세(22%)" : "일반과세"}
                                                                             </span>
                                                                         )}
@@ -1098,11 +1098,11 @@ function InputGroup({ label, value, tooltip, color = "text-zinc-900 dark:text-zi
 
 function StepButtons({ value, step, min, max, onChange }: { value: number; step: number; min: number; max: number; onChange: (v: number) => void }) {
     return (
-        <div className="flex border border-zinc-300 dark:border-zinc-700 rounded-xl overflow-hidden bg-white dark:bg-zinc-800 shadow-xs shrink-0 h-8 sm:h-10 items-center">
-            <button type="button" disabled={value <= min} onClick={() => onChange(Math.max(min, Number((value - step).toFixed(2))))} className="px-2.5 sm:px-3 h-full text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700 disabled:opacity-20 border-r border-zinc-300 dark:border-zinc-700 transition-colors flex items-center justify-center">
+        <div className="flex border border-zinc-300 dark:border-[#222222] rounded-xl overflow-hidden bg-white dark:bg-[#1a1a1a] shadow-xs shrink-0 h-8 sm:h-10 items-center">
+            <button type="button" disabled={value <= min} onClick={() => onChange(Math.max(min, Number((value - step).toFixed(2))))} className="px-2.5 sm:px-3 h-full text-zinc-700 dark:text-zinc-300 hover:bg-stone-100 dark:hover:bg-[#1a1a1a] disabled:opacity-20 border-r border-zinc-300 dark:border-[#222222] transition-colors flex items-center justify-center">
                 <MinusIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
             </button>
-            <button type="button" disabled={value >= max} onClick={() => onChange(Math.min(max, Number((value + step).toFixed(2))))} className="px-2.5 sm:px-3 h-full text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-700 disabled:opacity-20 transition-colors flex items-center justify-center">
+            <button type="button" disabled={value >= max} onClick={() => onChange(Math.min(max, Number((value + step).toFixed(2))))} className="px-2.5 sm:px-3 h-full text-zinc-700 dark:text-zinc-300 hover:bg-stone-100 dark:hover:bg-[#1a1a1a] disabled:opacity-20 transition-colors flex items-center justify-center">
                 <PlusIcon className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
             </button>
         </div>
@@ -1111,7 +1111,7 @@ function StepButtons({ value, step, min, max, onChange }: { value: number; step:
 
 function ToggleButton({ checked, onChange, label, tooltip }: { checked: boolean; onChange: (v: boolean) => void; label: string; tooltip?: string }) {
     return (
-        <div className="flex items-center justify-between p-1.5 sm:p-2 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800/40 transition-colors min-w-0 gap-2">
+        <div className="flex items-center justify-between p-1.5 sm:p-2 rounded-lg hover:bg-stone-100 dark:hover:bg-[#1a1a1a]/40 transition-colors min-w-0 gap-2">
             <div className="flex items-center gap-1 group relative max-w-[calc(100%-2.5rem)] min-w-0">
                 <span className="text-[11px] sm:text-xs font-semibold text-zinc-700 dark:text-zinc-300 whitespace-normal break-keep">
                     {label}
@@ -1125,7 +1125,7 @@ function ToggleButton({ checked, onChange, label, tooltip }: { checked: boolean;
                     </>
                 )}
             </div>
-            <button type="button" onClick={() => onChange(!checked)} className={cn("w-8 h-4.5 sm:w-9 sm:h-5 rounded-full p-0.5 transition-colors duration-200 focus:outline-none shrink-0", checked ? "bg-blue-600" : "bg-zinc-300 dark:bg-zinc-700")}>
+            <button type="button" onClick={() => onChange(!checked)} className={cn("w-8 h-4.5 sm:w-9 sm:h-5 rounded-full p-0.5 transition-colors duration-200 focus:outline-none shrink-0", checked ? "bg-blue-600" : "bg-zinc-300 dark:bg-[#3a3a3a]")}>
                 <div className={cn("bg-white w-3.5 h-3.5 sm:w-4 sm:h-4 rounded-full shadow-xs transform transition-transform duration-200", checked ? "translate-x-3.5 sm:translate-x-4" : "translate-x-0")} />
             </button>
         </div>
@@ -1134,7 +1134,7 @@ function ToggleButton({ checked, onChange, label, tooltip }: { checked: boolean;
 
 function CalloutWrapper({ icon, title, children }: { icon: React.ReactNode; title: string; children: React.ReactNode }) {
     return (
-        <div className="bg-white dark:bg-zinc-900 p-3.5 sm:p-5 rounded-xl sm:rounded-[2rem] border border-zinc-200 dark:border-zinc-800 shadow-xs flex gap-2.5 sm:gap-3 w-full">
+        <div className="bg-white dark:bg-[#1a1a1a] p-3.5 sm:p-5 rounded-xl sm:rounded-[2rem] border border-zinc-200 dark:border-[#2a2a2a] shadow-xs flex gap-2.5 sm:gap-3 w-full">
             <div className="shrink-0 pt-0.5">{icon}</div>
             <div className="space-y-0.5 min-w-0 flex-1">
                 <h4 className="text-[10px] sm:text-xs font-black text-zinc-900 dark:text-zinc-50 uppercase tracking-wider truncate">{title}</h4>
@@ -1195,7 +1195,7 @@ function PercentRateSlider({
                         step={step}
                         value={value}
                         onChange={(e) => onChange(Number(e.target.value))}
-                        className={cn("flex-1 h-1.5 sm:h-2 bg-zinc-200 dark:bg-zinc-800 rounded-lg appearance-none cursor-pointer transition-all", accentColors[accentColor])}
+                        className={cn("flex-1 h-1.5 sm:h-2 bg-zinc-200 dark:bg-[#1a1a1a] rounded-lg appearance-none cursor-pointer transition-all", accentColors[accentColor])}
                     />
                     <StepButtons value={value} step={step} min={min} max={max} onChange={onChange} />
                 </div>
@@ -1206,7 +1206,7 @@ function PercentRateSlider({
                                 type="button"
                                 key={qr.label}
                                 onClick={() => onChange(qr.rate)}
-                                className="text-[9px] sm:text-[10px] font-bold px-2 py-0.5 sm:py-1 bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700 rounded transition-colors"
+                                className="text-[9px] sm:text-[10px] font-bold px-2 py-0.5 sm:py-1 bg-stone-100 dark:bg-[#1a1a1a] text-zinc-700 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-[#1a1a1a] rounded transition-colors"
                             >
                                 {qr.label}({qr.rate}%)
                             </button>
@@ -1242,7 +1242,7 @@ function AgeInputSlider({
                     max={max}
                     value={value}
                     onChange={(e) => onChange(Number(e.target.value))}
-                    className="flex-1 accent-zinc-800 dark:accent-zinc-200 h-1.5 sm:h-2 bg-zinc-200 dark:bg-zinc-800 rounded-lg appearance-none cursor-pointer"
+                    className="flex-1 accent-zinc-800 dark:accent-zinc-200 h-1.5 sm:h-2 bg-zinc-200 dark:bg-[#1a1a1a] rounded-lg appearance-none cursor-pointer"
                 />
                 <StepButtons value={value} step={1} min={min} max={max} onChange={onChange} />
             </div>

--- a/cf-idiotquant/app/(login)/login/page.tsx
+++ b/cf-idiotquant/app/(login)/login/page.tsx
@@ -60,9 +60,9 @@ export default function LoginPage() {
                         <AuthButton />
 
                         <div className="flex items-center gap-3 my-5">
-                            <div className="flex-1 h-px bg-zinc-100 dark:bg-zinc-800" />
+                            <div className="flex-1 h-px bg-stone-100 dark:bg-[#1a1a1a]" />
                             <span className="text-[10px] font-bold text-zinc-300 dark:text-zinc-600 uppercase tracking-widest">무료 · 1초 가입</span>
-                            <div className="flex-1 h-px bg-zinc-100 dark:bg-zinc-800" />
+                            <div className="flex-1 h-px bg-stone-100 dark:bg-[#1a1a1a]" />
                         </div>
 
                         <div className="flex justify-center gap-4 text-[11px] text-zinc-400 dark:text-zinc-500">

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -138,7 +138,7 @@ const MKTCAP_PRESETS: { label: string; value: number }[] = [
 ];
 
 const TOOLTIP_CLS =
-    "z-50 max-w-64 rounded-xl px-3.5 py-3 text-xs bg-zinc-900 dark:bg-zinc-800 border border-zinc-700/60 shadow-xl text-zinc-200 leading-relaxed " +
+    "z-50 max-w-64 rounded-xl px-3.5 py-3 text-xs bg-zinc-900 dark:bg-[#1a1a1a] border border-zinc-700/60 shadow-xl text-zinc-200 leading-relaxed " +
     "data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 " +
     "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95";
 
@@ -177,7 +177,7 @@ function TableRow({ item, onClick }: { item: any; onClick: (ticker: string, name
 
     return (
         <div
-            className="group grid grid-cols-[minmax(160px,2.5fr)_minmax(110px,1fr)_88px_68px_68px_68px_88px] gap-4 items-center px-5 py-4 hover:bg-blue-50/40 dark:hover:bg-zinc-800/50 cursor-pointer transition-colors border-b border-zinc-100 dark:border-zinc-800 last:border-0"
+            className="group grid grid-cols-[minmax(160px,2.5fr)_minmax(110px,1fr)_88px_68px_68px_68px_88px] gap-4 items-center px-5 py-4 hover:bg-blue-50/40 dark:hover:bg-[#1a1a1a]/50 cursor-pointer transition-colors border-b border-zinc-100 dark:border-[#2a2a2a] last:border-0"
             onClick={() => onClick(item.ticker, item.name)}
         >
             <div className="min-w-0">
@@ -187,12 +187,12 @@ function TableRow({ item, onClick }: { item: any; onClick: (ticker: string, name
 
             <div className="flex flex-wrap gap-1">
                 {strategies.slice(0, 2).map(s => (
-                    <span key={s} className={cn("px-1.5 py-0.5 rounded text-[10px] font-bold", STRATEGY_BADGE[s] ?? "bg-zinc-100 text-zinc-500")}>
+                    <span key={s} className={cn("px-1.5 py-0.5 rounded text-[10px] font-bold", STRATEGY_BADGE[s] ?? "bg-stone-100 text-zinc-500")}>
                         {STRATEGY_LABEL[s] ?? s}
                     </span>
                 ))}
                 {strategies.length > 2 && (
-                    <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-zinc-100 dark:bg-zinc-700 text-zinc-500">
+                    <span className="px-1.5 py-0.5 rounded text-[10px] font-bold bg-stone-100 dark:bg-[#3a3a3a] text-zinc-500">
                         +{strategies.length - 2}
                     </span>
                 )}
@@ -232,7 +232,7 @@ function TableRow({ item, onClick }: { item: any; onClick: (ticker: string, name
 
             <div className="flex justify-end">
                 <button
-                    className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-zinc-100 dark:bg-zinc-800 group-hover:bg-blue-600 group-hover:text-white text-zinc-600 dark:text-zinc-400 text-xs font-bold transition-all whitespace-nowrap"
+                    className="flex items-center gap-1 px-3 py-1.5 rounded-lg bg-stone-100 dark:bg-[#1a1a1a] group-hover:bg-blue-600 group-hover:text-white text-zinc-600 dark:text-zinc-400 text-xs font-bold transition-all whitespace-nowrap"
                     onClick={(e) => { e.stopPropagation(); onClick(item.ticker, item.name); }}
                 >
                     분석
@@ -253,7 +253,7 @@ function StockRowCard({ item, onClick }: { item: any; onClick: (ticker: string, 
 
     return (
         <div
-            className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 p-4 cursor-pointer hover:border-blue-300 dark:hover:border-blue-700/50 hover:shadow-md transition-all active:scale-[0.99]"
+            className="bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] p-4 cursor-pointer hover:border-blue-300 dark:hover:border-blue-700/50 hover:shadow-md transition-all active:scale-[0.99]"
             onClick={() => onClick(item.ticker, item.name)}
         >
             <div className="flex items-start justify-between gap-2 mb-3">
@@ -267,7 +267,7 @@ function StockRowCard({ item, onClick }: { item: any; onClick: (ticker: string, 
                         ? "bg-emerald-100 dark:bg-emerald-950/50 text-emerald-700 dark:text-emerald-400"
                         : ncav >= 0.7
                         ? "bg-amber-100 dark:bg-amber-950/50 text-amber-700 dark:text-amber-400"
-                        : "bg-zinc-100 dark:bg-zinc-800 text-zinc-500"
+                        : "bg-stone-100 dark:bg-[#1a1a1a] text-zinc-500"
                 )}>
                     {ncav > 0 ? `${ncav.toFixed(2)}x` : "—"}
                 </div>
@@ -276,7 +276,7 @@ function StockRowCard({ item, onClick }: { item: any; onClick: (ticker: string, 
             {strategies.length > 0 && (
                 <div className="flex flex-wrap gap-1 mb-3">
                     {strategies.map(s => (
-                        <span key={s} className={cn("px-1.5 py-0.5 rounded text-[10px] font-bold", STRATEGY_BADGE[s] ?? "bg-zinc-100 text-zinc-500")}>
+                        <span key={s} className={cn("px-1.5 py-0.5 rounded text-[10px] font-bold", STRATEGY_BADGE[s] ?? "bg-stone-100 text-zinc-500")}>
                             {STRATEGY_LABEL[s] ?? s}
                         </span>
                     ))}
@@ -289,14 +289,14 @@ function StockRowCard({ item, onClick }: { item: any; onClick: (ticker: string, 
                     { label: "PER", value: safeNum(item.per) > 0 ? `${safeNum(item.per).toFixed(1)}` : "—" },
                     { label: "ROE", value: roe !== null && roe > 0 ? `${roe.toFixed(1)}%` : "—" },
                 ].map(m => (
-                    <div key={m.label} className="text-center p-2.5 bg-zinc-50 dark:bg-zinc-800/60 rounded-xl">
+                    <div key={m.label} className="text-center p-2.5 bg-stone-100 dark:bg-[#1a1a1a]/60 rounded-xl">
                         <p className="text-[9px] font-bold text-zinc-400 uppercase tracking-wider">{m.label}</p>
                         <p className="text-sm font-mono font-bold text-zinc-700 dark:text-zinc-200 mt-0.5">{m.value}</p>
                     </div>
                 ))}
             </div>
 
-            <button className="w-full flex items-center justify-center gap-1.5 py-2.5 rounded-xl bg-zinc-100 dark:bg-zinc-800 hover:bg-blue-600 hover:text-white text-zinc-600 dark:text-zinc-400 text-xs font-bold transition-all">
+            <button className="w-full flex items-center justify-center gap-1.5 py-2.5 rounded-xl bg-stone-100 dark:bg-[#1a1a1a] hover:bg-blue-600 hover:text-white text-zinc-600 dark:text-zinc-400 text-xs font-bold transition-all">
                 상세 분석
                 <ChevronRight size={12} />
             </button>
@@ -539,7 +539,7 @@ function ScreenerContent() {
                         <button
                             onClick={handleRefresh}
                             disabled={isLoading}
-                            className="flex items-center gap-1.5 px-3.5 py-2 rounded-xl bg-zinc-100 dark:bg-zinc-800 hover:bg-zinc-200 dark:hover:bg-zinc-700 text-zinc-600 dark:text-zinc-400 text-xs font-bold transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0 self-start"
+                            className="flex items-center gap-1.5 px-3.5 py-2 rounded-xl bg-stone-100 dark:bg-[#1a1a1a] hover:bg-zinc-200 dark:hover:bg-[#1a1a1a] text-zinc-600 dark:text-zinc-400 text-xs font-bold transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0 self-start"
                         >
                             <RefreshCw size={13} className={isLoading ? "animate-spin" : ""} />
                             새로고침
@@ -559,13 +559,13 @@ function ScreenerContent() {
                                 "shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold border transition-all whitespace-nowrap",
                                 isAllActive
                                     ? STRATEGY_ACTIVE_CLS.all
-                                    : "border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-600 bg-white dark:bg-zinc-900"
+                                    : "border-zinc-200 dark:border-[#222222] text-zinc-600 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-600 bg-white dark:bg-[#1a1a1a]"
                             )}
                         >
                             전체
                             <span className={cn(
                                 "text-[10px] font-black px-1.5 py-0.5 rounded-full",
-                                isAllActive ? "bg-white/20 dark:bg-black/20" : "bg-zinc-100 dark:bg-zinc-700 text-zinc-500"
+                                isAllActive ? "bg-white/20 dark:bg-black/20" : "bg-stone-100 dark:bg-[#3a3a3a] text-zinc-500"
                             )}>
                                 {strategyCounts.all}
                             </span>
@@ -583,13 +583,13 @@ function ScreenerContent() {
                                             "shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold border transition-all whitespace-nowrap",
                                             isActive
                                                 ? STRATEGY_ACTIVE_CLS[preset.id]
-                                                : "border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-600 bg-white dark:bg-zinc-900"
+                                                : "border-zinc-200 dark:border-[#222222] text-zinc-600 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-600 bg-white dark:bg-[#1a1a1a]"
                                         )}
                                     >
                                         {preset.label}
                                         <span className={cn(
                                             "text-[10px] font-black px-1.5 py-0.5 rounded-full",
-                                            isActive ? "bg-white/20 dark:bg-black/20" : "bg-zinc-100 dark:bg-zinc-700 text-zinc-500"
+                                            isActive ? "bg-white/20 dark:bg-black/20" : "bg-stone-100 dark:bg-[#3a3a3a] text-zinc-500"
                                         )}>
                                             {strategyCounts[preset.id] ?? 0}
                                         </span>
@@ -605,7 +605,7 @@ function ScreenerContent() {
                                 "shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg border text-xs font-bold transition-all ml-1",
                                 showGuide
                                     ? "bg-blue-50 dark:bg-blue-950/30 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-400"
-                                    : "border-zinc-200 dark:border-zinc-700 text-zinc-500 dark:text-zinc-400 hover:border-zinc-300 bg-white dark:bg-zinc-900"
+                                    : "border-zinc-200 dark:border-[#222222] text-zinc-500 dark:text-zinc-400 hover:border-zinc-300 bg-white dark:bg-[#1a1a1a]"
                             )}
                             title="전략 설명 보기"
                         >
@@ -617,7 +617,7 @@ function ScreenerContent() {
                         {hasActiveFilters && (
                             <button
                                 onClick={resetAllFilters}
-                                className="shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-red-200 dark:border-red-800/50 text-xs font-bold text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/20 transition-all bg-white dark:bg-zinc-900"
+                                className="shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg border border-red-200 dark:border-red-800/50 text-xs font-bold text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/20 transition-all bg-white dark:bg-[#1a1a1a]"
                                 title="모든 필터 초기화"
                             >
                                 <X size={12} />
@@ -636,7 +636,7 @@ function ScreenerContent() {
                                 return (
                                     <span key={id} className={cn(
                                         "inline-flex items-center gap-1 text-[10px] font-bold px-2 py-0.5 rounded",
-                                        STRATEGY_BADGE[id] ?? "bg-zinc-100 text-zinc-500"
+                                        STRATEGY_BADGE[id] ?? "bg-stone-100 text-zinc-500"
                                     )}>
                                         {preset.label}
                                         <button onClick={() => toggleStrategy(id)} className="hover:opacity-70">
@@ -646,14 +646,14 @@ function ScreenerContent() {
                                 );
                             })}
                             {/* OR / AND 토글 */}
-                            <div className="flex items-center rounded-full border border-zinc-200 dark:border-zinc-700 overflow-hidden text-[10px] font-black">
+                            <div className="flex items-center rounded-full border border-zinc-200 dark:border-[#222222] overflow-hidden text-[10px] font-black">
                                 <button
                                     onClick={() => setFilterMode('OR')}
                                     className={cn(
                                         "px-2 py-0.5 transition-colors",
                                         filterMode === 'OR'
                                             ? "bg-blue-600 text-white"
-                                            : "text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                                            : "text-zinc-500 dark:text-zinc-400 hover:bg-stone-100 dark:hover:bg-[#1a1a1a]"
                                     )}
                                 >
                                     OR
@@ -661,10 +661,10 @@ function ScreenerContent() {
                                 <button
                                     onClick={() => setFilterMode('AND')}
                                     className={cn(
-                                        "px-2 py-0.5 transition-colors border-l border-zinc-200 dark:border-zinc-700",
+                                        "px-2 py-0.5 transition-colors border-l border-zinc-200 dark:border-[#222222]",
                                         filterMode === 'AND'
                                             ? "bg-blue-600 text-white"
-                                            : "text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                                            : "text-zinc-500 dark:text-zinc-400 hover:bg-stone-100 dark:hover:bg-[#1a1a1a]"
                                     )}
                                 >
                                     AND
@@ -680,7 +680,7 @@ function ScreenerContent() {
 
             {/* ── 전략 가이드 패널 ── */}
             {showGuide && (
-                <div className="bg-white dark:bg-zinc-900 border-b border-zinc-200 dark:border-zinc-800">
+                <div className="bg-white dark:bg-[#1a1a1a] border-b border-zinc-200 dark:border-[#2a2a2a]">
                     <div className="max-w-7xl mx-auto px-4 sm:px-6 py-5">
                         <div className="flex items-center justify-between mb-4">
                             <h2 className="text-sm font-black text-zinc-900 dark:text-white">전략 설명</h2>
@@ -700,13 +700,13 @@ function ScreenerContent() {
                                         "text-left p-3.5 rounded-xl border-2 transition-all",
                                         activeStrategyIds.has(preset.id)
                                             ? "border-blue-400 dark:border-blue-600 bg-blue-50 dark:bg-blue-950/20"
-                                            : "border-zinc-200 dark:border-zinc-700 hover:border-zinc-300 dark:hover:border-zinc-600 bg-zinc-50 dark:bg-zinc-800/50"
+                                            : "border-zinc-200 dark:border-[#222222] hover:border-zinc-300 dark:hover:border-zinc-600 bg-stone-100 dark:bg-[#1a1a1a]/50"
                                     )}
                                 >
                                     <div className="flex items-center gap-2 mb-2">
                                         <span className={cn(
                                             "text-[10px] font-extrabold px-2 py-0.5 rounded",
-                                            STRATEGY_BADGE[preset.id] ?? "bg-zinc-100 text-zinc-500"
+                                            STRATEGY_BADGE[preset.id] ?? "bg-stone-100 text-zinc-500"
                                         )}>
                                             {preset.label}
                                         </span>
@@ -739,7 +739,7 @@ function ScreenerContent() {
                         value={searchQuery}
                         onChange={e => { setSearchQuery(e.target.value); setDisplayCount(DAILY_PAGE_SIZE); }}
                         placeholder="종목명 또는 티커 검색"
-                        className="w-full pl-8 pr-3 py-2 text-xs bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 rounded-xl outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 placeholder:text-zinc-400 font-medium"
+                        className="w-full pl-8 pr-3 py-2 text-xs bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#222222] rounded-xl outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 placeholder:text-zinc-400 font-medium"
                     />
                 </div>
 
@@ -749,7 +749,7 @@ function ScreenerContent() {
                         "flex items-center gap-1.5 px-3.5 py-2 rounded-xl border text-xs font-bold transition-all",
                         filterOpen || activeFilterCount > 0
                             ? "bg-blue-50 dark:bg-blue-950/30 border-blue-300 dark:border-blue-800 text-blue-700 dark:text-blue-400"
-                            : "bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:border-zinc-300"
+                            : "bg-white dark:bg-[#1a1a1a] border-zinc-200 dark:border-[#222222] text-zinc-600 dark:text-zinc-400 hover:border-zinc-300"
                     )}
                 >
                     <SlidersHorizontal size={12} />
@@ -774,7 +774,7 @@ function ScreenerContent() {
                                         "px-2.5 py-1 rounded-lg border text-xs font-bold transition-all",
                                         minMarketCap === p.value
                                             ? "bg-blue-600 border-blue-600 text-white shadow-sm"
-                                            : "bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-700 text-zinc-600 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-600"
+                                            : "bg-white dark:bg-[#1a1a1a] border-zinc-200 dark:border-[#222222] text-zinc-600 dark:text-zinc-400 hover:border-zinc-300 dark:hover:border-zinc-600"
                                     )}
                                 >
                                     {p.label}
@@ -783,7 +783,7 @@ function ScreenerContent() {
                         </div>
 
                         {/* 구분선 */}
-                        <div className="w-px h-4 bg-zinc-200 dark:bg-zinc-700 hidden sm:block" />
+                        <div className="w-px h-4 bg-zinc-200 dark:bg-[#3a3a3a] hidden sm:block" />
 
                         {/* 제외 조건 */}
                         <div className="flex items-center gap-4 flex-wrap">
@@ -823,7 +823,7 @@ function ScreenerContent() {
 
                 {!isLoading && filteredList.length === 0 && (
                     <div className="flex flex-col items-center justify-center py-20 text-center gap-4">
-                        <div className="p-4 bg-zinc-100 dark:bg-zinc-800 rounded-2xl">
+                        <div className="p-4 bg-stone-100 dark:bg-[#1a1a1a] rounded-2xl">
                             <Search size={24} className="text-zinc-400" />
                         </div>
                         <div>

--- a/cf-idiotquant/app/(search)/search/components/ErrorFallback.tsx
+++ b/cf-idiotquant/app/(search)/search/components/ErrorFallback.tsx
@@ -44,7 +44,7 @@ export function ErrorFallback({
         
         <button
           onClick={() => window.location.reload()}
-          className="inline-flex items-center justify-center gap-2 px-8 py-3 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 text-zinc-700 dark:text-zinc-300 rounded-2xl font-bold hover:bg-zinc-50 dark:hover:bg-zinc-800 transition-all active:scale-95"
+          className="inline-flex items-center justify-center gap-2 px-8 py-3 bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] text-zinc-700 dark:text-zinc-300 rounded-2xl font-bold hover:bg-stone-50 dark:hover:bg-[#2a2a2a] transition-all active:scale-95"
         >
           <RotateCw size={18} />
           페이지 새로고침
@@ -53,7 +53,7 @@ export function ErrorFallback({
 
       {/* 에러 코드 푸터 */}
       <div className="mt-16 flex flex-col items-center gap-2">
-        <div className="h-px w-12 bg-zinc-200 dark:bg-zinc-800" />
+        <div className="h-px w-12 bg-zinc-200 dark:bg-[#2a2a2a]" />
         <span className="text-[10px] text-zinc-400 uppercase tracking-[0.3em] font-black">
           Error Code: ERR_STOCK_FETCH_FAILURE
         </span>

--- a/cf-idiotquant/app/(search)/search/components/FinancialTables.tsx
+++ b/cf-idiotquant/app/(search)/search/components/FinancialTables.tsx
@@ -154,8 +154,8 @@ function FinancialTable({ sections, data }: { sections: SectionDef[]; data: any 
         <div className="overflow-x-auto">
             <table className="w-full border-collapse text-sm">
                 <thead>
-                    <tr className="border-b border-zinc-200 dark:border-zinc-800">
-                        <th className="sticky left-0 z-10 bg-white dark:bg-zinc-900 px-5 py-3 text-left min-w-[11rem] w-44">
+                    <tr className="border-b border-zinc-200 dark:border-[#2a2a2a]">
+                        <th className="sticky left-0 z-10 bg-white dark:bg-[#1a1a1a] px-5 py-3 text-left min-w-[11rem] w-44">
                             <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-400 dark:text-zinc-500 font-mono select-none">
                                 계정과목
                             </span>
@@ -197,7 +197,7 @@ function FinancialTable({ sections, data }: { sections: SectionDef[]; data: any 
                             <tr>
                                 <td
                                     colSpan={periods.length + 1}
-                                    className="sticky left-0 px-5 pt-4 pb-1.5 bg-white dark:bg-zinc-900"
+                                    className="sticky left-0 px-5 pt-4 pb-1.5 bg-white dark:bg-[#1a1a1a]"
                                 >
                                     <div className={cn(
                                         "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md border text-[9px] font-black uppercase tracking-widest font-mono select-none",
@@ -218,18 +218,18 @@ function FinancialTable({ sections, data }: { sections: SectionDef[]; data: any 
                                     <tr
                                         key={row.key}
                                         className={cn(
-                                            "group border-b border-zinc-100 dark:border-zinc-800/50 transition-colors duration-100",
+                                            "group border-b border-zinc-100 dark:border-[#2a2a2a]/50 transition-colors duration-100",
                                             row.isTotal
-                                                ? "bg-zinc-50/80 dark:bg-zinc-800/20 hover:bg-zinc-100/70 dark:hover:bg-zinc-800/40"
-                                                : "hover:bg-zinc-50/60 dark:hover:bg-zinc-800/10"
+                                                ? "bg-stone-100/80 dark:bg-[#1a1a1a]/20 hover:bg-stone-100/70 dark:hover:bg-[#1a1a1a]/40"
+                                                : "hover:bg-stone-100/60 dark:hover:bg-[#1a1a1a]/10"
                                         )}
                                     >
                                         {/* Label */}
                                         <td className={cn(
                                             "sticky left-0 z-10 px-5 py-3 transition-colors duration-100",
                                             row.isTotal
-                                                ? "bg-zinc-50 dark:bg-zinc-800/20 group-hover:bg-zinc-100/70 dark:group-hover:bg-zinc-800/40"
-                                                : "bg-white dark:bg-zinc-900 group-hover:bg-zinc-50/60 dark:group-hover:bg-zinc-800/10"
+                                                ? "bg-stone-100 dark:bg-[#1a1a1a]/20 group-hover:bg-stone-100/70 dark:group-hover:bg-zinc-800/40"
+                                                : "bg-white dark:bg-[#1a1a1a] group-hover:bg-stone-100/60 dark:group-hover:bg-zinc-800/10"
                                         )}>
                                             <div className="flex items-center gap-2">
                                                 {row.isTotal
@@ -289,7 +289,7 @@ export default function FinancialTables({ kiBS, kiIS }: FinancialTablesProps) {
     if (!kiBS?.output?.length || !kiIS?.output?.length) return null;
 
     const footer = (
-        <div className="flex items-center gap-3 px-5 py-3 border-t border-zinc-100 dark:border-zinc-800">
+        <div className="flex items-center gap-3 px-5 py-3 border-t border-zinc-100 dark:border-[#2a2a2a]">
             <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse shrink-0" />
             <span className="text-[10px] text-zinc-400 dark:text-zinc-500 font-mono">
                 DART 공시 기준 · 단위 억 원 (KRW 100M) · 최근 5개 결산기
@@ -305,8 +305,8 @@ export default function FinancialTables({ kiBS, kiIS }: FinancialTablesProps) {
     return (
         <Tabs.Root defaultValue="bs" className="w-full">
             {/* Tab Bar */}
-            <div className="flex items-center justify-between px-5 py-3 border-b border-zinc-100 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-800/20">
-                <Tabs.List className="flex gap-1 bg-zinc-100 dark:bg-zinc-800 rounded-lg p-1">
+            <div className="flex items-center justify-between px-5 py-3 border-b border-zinc-100 dark:border-[#2a2a2a] bg-stone-100/50 dark:bg-[#1a1a1a]/20">
+                <Tabs.List className="flex gap-1 bg-stone-100 dark:bg-[#1a1a1a] rounded-lg p-1">
                     <Tabs.Trigger
                         value="bs"
                         className={cn(TAB_TRIGGER_BASE, "data-[state=active]:text-blue-700 dark:data-[state=active]:text-blue-300")}

--- a/cf-idiotquant/app/(search)/search/components/FinnhubTable.tsx
+++ b/cf-idiotquant/app/(search)/search/components/FinnhubTable.tsx
@@ -253,8 +253,8 @@ function SectionTable({
         <div className="overflow-x-auto">
             <table className="w-full border-collapse text-sm">
                 <thead>
-                    <tr className="border-b border-zinc-200 dark:border-zinc-800">
-                        <th className="sticky left-0 z-10 bg-white dark:bg-zinc-900 px-5 py-3 text-left min-w-[12rem] w-48">
+                    <tr className="border-b border-zinc-200 dark:border-[#2a2a2a]">
+                        <th className="sticky left-0 z-10 bg-white dark:bg-[#1a1a1a] px-5 py-3 text-left min-w-[12rem] w-48">
                             <span className="text-[10px] font-bold uppercase tracking-widest text-zinc-400 dark:text-zinc-500 font-mono select-none">
                                 Financial Metric
                             </span>
@@ -292,7 +292,7 @@ function SectionTable({
                             <tr>
                                 <td
                                     colSpan={columns.length + 1}
-                                    className="sticky left-0 px-5 pt-4 pb-1.5 bg-white dark:bg-zinc-900"
+                                    className="sticky left-0 px-5 pt-4 pb-1.5 bg-white dark:bg-[#1a1a1a]"
                                 >
                                     <div className={cn(
                                         "inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md border text-[9px] font-black uppercase tracking-widest font-mono select-none",
@@ -312,18 +312,18 @@ function SectionTable({
                                     <tr
                                         key={rowIdx}
                                         className={cn(
-                                            "group border-b border-zinc-100 dark:border-zinc-800/50 transition-colors duration-100",
+                                            "group border-b border-zinc-100 dark:border-[#2a2a2a]/50 transition-colors duration-100",
                                             item.isTotal
-                                                ? "bg-zinc-50/80 dark:bg-zinc-800/20 hover:bg-zinc-100/70 dark:hover:bg-zinc-800/40"
-                                                : "hover:bg-zinc-50/60 dark:hover:bg-zinc-800/10"
+                                                ? "bg-stone-100/80 dark:bg-[#1a1a1a]/20 hover:bg-stone-100/70 dark:hover:bg-[#1a1a1a]/40"
+                                                : "hover:bg-stone-100/60 dark:hover:bg-[#1a1a1a]/10"
                                         )}
                                     >
                                         {/* Label */}
                                         <td className={cn(
                                             "sticky left-0 z-10 px-5 py-3 transition-colors duration-100",
                                             item.isTotal
-                                                ? "bg-zinc-50 dark:bg-zinc-800/20 group-hover:bg-zinc-100/70 dark:group-hover:bg-zinc-800/40"
-                                                : "bg-white dark:bg-zinc-900 group-hover:bg-zinc-50/60 dark:group-hover:bg-zinc-800/10"
+                                                ? "bg-stone-100 dark:bg-[#1a1a1a]/20 group-hover:bg-stone-100/70 dark:group-hover:bg-zinc-800/40"
+                                                : "bg-white dark:bg-[#1a1a1a] group-hover:bg-stone-100/60 dark:group-hover:bg-zinc-800/10"
                                         )}>
                                             <div className="flex items-center gap-2">
                                                 {item.isTotal
@@ -400,7 +400,7 @@ export default function FinnhubTable({ data = [], className = "" }: Props) {
     if (!columns.length) return null;
 
     const footer = (
-        <div className="flex items-center gap-3 px-5 py-3 border-t border-zinc-100 dark:border-zinc-800">
+        <div className="flex items-center gap-3 px-5 py-3 border-t border-zinc-100 dark:border-[#2a2a2a]">
             <span className="w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse shrink-0" />
             <span className="text-[10px] text-zinc-400 dark:text-zinc-500 font-mono">
                 Finnhub · SEC Fundamentals · US-GAAP · USD
@@ -417,8 +417,8 @@ export default function FinnhubTable({ data = [], className = "" }: Props) {
         <div className={cn("w-full", className)}>
             <Tabs.Root defaultValue="bs">
                 {/* Tab Bar */}
-                <div className="flex items-center justify-between px-5 py-3 border-b border-zinc-100 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-800/20">
-                    <Tabs.List className="flex gap-1 bg-zinc-100 dark:bg-zinc-800 rounded-lg p-1">
+                <div className="flex items-center justify-between px-5 py-3 border-b border-zinc-100 dark:border-[#2a2a2a] bg-stone-100/50 dark:bg-[#1a1a1a]/20">
+                    <Tabs.List className="flex gap-1 bg-stone-100 dark:bg-[#1a1a1a] rounded-lg p-1">
                         <Tabs.Trigger
                             value="bs"
                             className={cn(TAB_TRIGGER_BASE, "data-[state=active]:text-blue-700 dark:data-[state=active]:text-blue-300")}

--- a/cf-idiotquant/app/(search)/search/components/SearchGuide.tsx
+++ b/cf-idiotquant/app/(search)/search/components/SearchGuide.tsx
@@ -24,7 +24,7 @@ const GRADES = [
   { grade: "SS",  range: "+150% 이상", desc: "강한 저평가",   bg: "bg-amber-500",  text: "text-white", glow: "shadow-amber-500/20" },
   { grade: "S",   range: "+100% 이상", desc: "저평가",        bg: "bg-emerald-500", text: "text-white", glow: "shadow-emerald-500/20" },
   { grade: "A",   range: "+50% 이상",  desc: "적정 이하",     bg: "bg-slate-500",  text: "text-white", glow: "" },
-  { grade: "B",   range: "0% 이상",    desc: "적정가 수준",   bg: "bg-zinc-200 dark:bg-zinc-700", text: "text-zinc-700 dark:text-zinc-200", glow: "" },
+  { grade: "B",   range: "0% 이상",    desc: "적정가 수준",   bg: "bg-zinc-200 dark:bg-[#3a3a3a]", text: "text-zinc-700 dark:text-zinc-200", glow: "" },
   { grade: "F",   range: "0% 미만",    desc: "고평가",        bg: "bg-red-500",    text: "text-white", glow: "shadow-red-500/20" },
 ];
 
@@ -50,7 +50,7 @@ const MOCK_VALUATION = [
 // =========================================================================
 export const SearchGuide = () => {
   return (
-    <div className="w-full min-h-screen bg-zinc-50 dark:bg-zinc-950 selection:bg-blue-500/20">
+    <div className="w-full min-h-screen bg-stone-100 dark:bg-[#0d0d0d] selection:bg-blue-500/20">
 
       {/* ────────── 히어로 ────────── */}
       <section className="relative overflow-hidden pt-20 pb-16 px-4">
@@ -65,7 +65,7 @@ export const SearchGuide = () => {
 
         <div className="max-w-3xl mx-auto text-center">
           {/* 상태 배지 */}
-          <div className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 shadow-sm mb-8">
+          <div className="inline-flex items-center gap-2 px-3.5 py-1.5 rounded-full bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] shadow-sm mb-8">
             <span className="relative flex h-2 w-2">
               <span className="animate-ping absolute h-full w-full rounded-full bg-emerald-400 opacity-75" />
               <span className="relative rounded-full h-2 w-2 bg-emerald-500" />
@@ -89,7 +89,7 @@ export const SearchGuide = () => {
           </p>
 
           {/* 검색창 유도 */}
-          <div className="flex items-center gap-3 max-w-md mx-auto px-4 py-3.5 bg-white dark:bg-zinc-900 border-2 border-dashed border-zinc-300 dark:border-zinc-700 rounded-2xl mb-8 text-zinc-400 dark:text-zinc-500 cursor-default">
+          <div className="flex items-center gap-3 max-w-md mx-auto px-4 py-3.5 bg-white dark:bg-[#1a1a1a] border-2 border-dashed border-zinc-300 dark:border-[#222222] rounded-2xl mb-8 text-zinc-400 dark:text-zinc-500 cursor-default">
             <Search className="w-4 h-4 shrink-0" />
             <span className="text-sm font-medium flex-1 text-left">위 검색창에 종목명 또는 티커 입력</span>
             <ArrowRight className="w-4 h-4 shrink-0 opacity-40" />
@@ -120,7 +120,7 @@ export const SearchGuide = () => {
       </section>
 
       {/* ────────── 아웃풋 프리뷰 ────────── */}
-      <section className="px-4 pb-20 border-t border-zinc-200 dark:border-zinc-800 pt-16">
+      <section className="px-4 pb-20 border-t border-zinc-200 dark:border-[#2a2a2a] pt-16">
         <div className="max-w-5xl mx-auto">
           <div className="text-center mb-10">
             <p className="text-[11px] font-bold text-zinc-400 uppercase tracking-widest mb-2 font-mono">Output Preview</p>
@@ -133,7 +133,7 @@ export const SearchGuide = () => {
           <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
 
             {/* 종목 요약 카드 */}
-            <div className="lg:col-span-2 bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 p-6 shadow-sm flex flex-col gap-5">
+            <div className="lg:col-span-2 bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] p-6 shadow-sm flex flex-col gap-5">
               {/* 헤더 */}
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
@@ -151,7 +151,7 @@ export const SearchGuide = () => {
 
               {/* 가격 & NCAV */}
               <div className="grid grid-cols-2 gap-3">
-                <div className="p-3.5 bg-zinc-50 dark:bg-zinc-800/50 rounded-xl border border-zinc-100 dark:border-zinc-800">
+                <div className="p-3.5 bg-stone-100 dark:bg-[#1a1a1a]/50 rounded-xl border border-zinc-100 dark:border-[#2a2a2a]">
                   <p className="text-[9px] text-zinc-400 font-bold uppercase tracking-wider mb-1">현재가</p>
                   <p className="text-lg font-black text-zinc-900 dark:text-white font-mono">₩78,500</p>
                 </div>
@@ -167,15 +167,15 @@ export const SearchGuide = () => {
                   <span className="text-zinc-400 uppercase tracking-wider">안전마진 (≤ NCAV × 0.67)</span>
                   <span className="text-emerald-600 dark:text-emerald-400">충족 ✓</span>
                 </div>
-                <div className="h-1.5 bg-zinc-100 dark:bg-zinc-800 rounded-full overflow-hidden">
+                <div className="h-1.5 bg-stone-100 dark:bg-[#1a1a1a] rounded-full overflow-hidden">
                   <div className="h-full w-[67%] bg-gradient-to-r from-emerald-400 to-emerald-500 rounded-full" />
                 </div>
               </div>
 
               {/* 하단 지표 */}
-              <div className="flex gap-0 pt-3 border-t border-zinc-100 dark:border-zinc-800">
+              <div className="flex gap-0 pt-3 border-t border-zinc-100 dark:border-[#2a2a2a]">
                 {[["PER", "12.5x"], ["PBR", "1.4x"], ["EPS", "₩6,280"]].map(([k, v], i) => (
-                  <div key={k} className={cn("flex-1 text-center py-1", i < 2 && "border-r border-zinc-100 dark:border-zinc-800")}>
+                  <div key={k} className={cn("flex-1 text-center py-1", i < 2 && "border-r border-zinc-100 dark:border-[#2a2a2a]")}>
                     <p className="text-[9px] text-zinc-400 font-bold uppercase tracking-wider">{k}</p>
                     <p className="text-xs font-black font-mono text-zinc-700 dark:text-zinc-300 mt-0.5">{v}</p>
                   </div>
@@ -184,18 +184,18 @@ export const SearchGuide = () => {
             </div>
 
             {/* 밸류에이션 테이블 */}
-            <div className="lg:col-span-3 bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 overflow-hidden shadow-sm flex flex-col">
-              <div className="px-5 py-4 border-b border-zinc-100 dark:border-zinc-800 flex items-center gap-2">
+            <div className="lg:col-span-3 bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] overflow-hidden shadow-sm flex flex-col">
+              <div className="px-5 py-4 border-b border-zinc-100 dark:border-[#2a2a2a] flex items-center gap-2">
                 <BarChart3 className="w-4 h-4 text-zinc-400" />
                 <span className="text-sm font-extrabold text-zinc-700 dark:text-zinc-300">밸류에이션 모델별 목표주가</span>
-                <span className="ml-auto text-[9px] font-mono font-black text-zinc-400 bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-md uppercase tracking-wider">Sample</span>
+                <span className="ml-auto text-[9px] font-mono font-black text-zinc-400 bg-stone-100 dark:bg-[#1a1a1a] px-2 py-0.5 rounded-md uppercase tracking-wider">Sample</span>
               </div>
 
               <div className="flex-1 p-4 space-y-2">
                 {MOCK_VALUATION.map(r => (
-                  <div key={r.model} className="flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors group">
+                  <div key={r.model} className="flex items-center gap-3 px-3 py-2.5 rounded-xl hover:bg-stone-100 dark:hover:bg-[#1a1a1a]/50 transition-colors group">
                     <span className="w-12 text-xs font-black font-mono text-zinc-600 dark:text-zinc-400 shrink-0">{r.model}</span>
-                    <div className="flex-1 h-1.5 bg-zinc-100 dark:bg-zinc-800 rounded-full overflow-hidden">
+                    <div className="flex-1 h-1.5 bg-stone-100 dark:bg-[#1a1a1a] rounded-full overflow-hidden">
                       <div
                         className={cn("h-full rounded-full transition-all", r.up ? "bg-emerald-500" : "bg-red-400")}
                         style={{ width: `${r.pct}%` }}
@@ -218,7 +218,7 @@ export const SearchGuide = () => {
                 ))}
               </div>
 
-              <div className="px-5 py-3 bg-zinc-50 dark:bg-zinc-800/30 border-t border-zinc-100 dark:border-zinc-800 flex items-start gap-2">
+              <div className="px-5 py-3 bg-stone-100 dark:bg-[#1a1a1a]/30 border-t border-zinc-100 dark:border-[#2a2a2a] flex items-start gap-2">
                 <Sparkles className="w-3.5 h-3.5 text-amber-500 mt-0.5 shrink-0" />
                 <p className="text-[11px] text-zinc-400 dark:text-zinc-500 leading-relaxed">
                   실제 분석에는 현재 주가 기준 실시간 재무 데이터가 사용됩니다. 위 수치는 설명용 샘플입니다.
@@ -230,7 +230,7 @@ export const SearchGuide = () => {
       </section>
 
       {/* ────────── NCAV 등급 스케일 ────────── */}
-      <section className="px-4 py-20 border-t border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/30">
+      <section className="px-4 py-20 border-t border-zinc-200 dark:border-[#2a2a2a] bg-white dark:bg-[#1a1a1a]/30">
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-10">
             <p className="text-[11px] font-bold text-zinc-400 uppercase tracking-widest mb-2 font-mono">NCAV Grade Scale</p>
@@ -245,7 +245,7 @@ export const SearchGuide = () => {
 
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2.5 mb-8">
             {GRADES.map(g => (
-              <div key={g.grade} className="flex flex-col items-center gap-3 p-4 bg-zinc-50 dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 text-center">
+              <div key={g.grade} className="flex flex-col items-center gap-3 p-4 bg-stone-100 dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] text-center">
                 <span className={cn(
                   "w-11 h-11 rounded-xl flex items-center justify-center text-base font-black font-mono shadow-md",
                   g.bg, g.text, g.glow
@@ -261,7 +261,7 @@ export const SearchGuide = () => {
           </div>
 
           {/* 투자 기준 공식 */}
-          <div className="flex flex-wrap items-center justify-center gap-3 p-4 bg-zinc-50 dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 text-sm">
+          <div className="flex flex-wrap items-center justify-center gap-3 p-4 bg-stone-100 dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] text-sm">
             <span className="text-zinc-500 dark:text-zinc-400 font-medium">투자 기준</span>
             <code className="font-mono font-black text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-950/30 px-3 py-1.5 rounded-xl border border-blue-200/50 dark:border-blue-800/40">
               시가총액 {'<'} NCAV × 0.67
@@ -272,7 +272,7 @@ export const SearchGuide = () => {
       </section>
 
       {/* ────────── 6가지 밸류에이션 모델 ────────── */}
-      <section className="px-4 py-20 border-t border-zinc-200 dark:border-zinc-800">
+      <section className="px-4 py-20 border-t border-zinc-200 dark:border-[#2a2a2a]">
         <div className="max-w-4xl mx-auto">
           <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4 mb-8">
             <div>
@@ -287,7 +287,7 @@ export const SearchGuide = () => {
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {MODELS.map(m => (
               <div key={m.name}
-                className="flex items-center gap-4 p-4 bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 hover:border-zinc-300 dark:hover:border-zinc-700 transition-colors shadow-sm"
+                className="flex items-center gap-4 p-4 bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] hover:border-zinc-300 dark:hover:border-zinc-700 transition-colors shadow-sm"
               >
                 <div className={cn("px-3 py-2 rounded-xl font-black font-mono text-lg tracking-tight shrink-0 min-w-[4rem] text-center", m.bg, m.color)}>
                   {m.name}
@@ -303,7 +303,7 @@ export const SearchGuide = () => {
       </section>
 
       {/* ────────── 3단계 사용법 ────────── */}
-      <section className="px-4 py-20 border-t border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/30">
+      <section className="px-4 py-20 border-t border-zinc-200 dark:border-[#2a2a2a] bg-white dark:bg-[#1a1a1a]/30">
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-10">
             <p className="text-[11px] font-bold text-zinc-400 uppercase tracking-widest mb-2 font-mono">How It Works</p>
@@ -338,7 +338,7 @@ export const SearchGuide = () => {
                 border: "border-emerald-200/60 dark:border-emerald-900/40",
               },
             ].map((s, i) => (
-              <div key={i} className="flex flex-col gap-4 p-6 bg-zinc-50 dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 relative z-10">
+              <div key={i} className="flex flex-col gap-4 p-6 bg-stone-100 dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] relative z-10">
                 <div className="flex items-center gap-3">
                   <div className={cn("p-2.5 rounded-xl border", s.bg, s.border, s.color)}>{s.icon}</div>
                   <span className="text-3xl font-black font-mono text-zinc-100 dark:text-zinc-800 select-none">{s.step}</span>
@@ -354,7 +354,7 @@ export const SearchGuide = () => {
       </section>
 
       {/* ────────── 푸터 ────────── */}
-      <footer className="border-t border-zinc-200 dark:border-zinc-800 py-10 px-4">
+      <footer className="border-t border-zinc-200 dark:border-[#2a2a2a] py-10 px-4">
         <div className="max-w-4xl mx-auto flex flex-col items-center gap-5">
 
           {/* 빠른 검색 반복 */}

--- a/cf-idiotquant/app/(search)/search/components/StockCard.tsx
+++ b/cf-idiotquant/app/(search)/search/components/StockCard.tsx
@@ -131,7 +131,7 @@ const GRADE_CONFIG = {
     frameGradient: "linear-gradient(135deg,#94a3b8,#cbd5e1,#94a3b8)",
     glow: "shadow-[0_0_16px_rgba(148,163,184,0.15)]",
     darkCard: false,
-    cardBodyCls: "bg-white dark:bg-zinc-950",
+    cardBodyCls: "bg-white dark:bg-[#0d0d0d]",
     label: "STABLE ASSET",
     labelColor: "text-slate-500 dark:text-slate-400",
     badgeGradient: "linear-gradient(90deg,#475569,#94a3b8)",
@@ -145,10 +145,10 @@ const GRADE_CONFIG = {
     typeBorder: "border-slate-300/50 dark:border-slate-700/40",
     typeText: "text-slate-500 dark:text-slate-400",
     statBg: "bg-slate-50 dark:bg-slate-900/50 border-slate-200/60 dark:border-slate-700/40",
-    statDivide: "divide-zinc-100 dark:divide-zinc-800/60",
+    statDivide: "divide-zinc-100 dark:divide-[#2a2a2a]/60",
     statLabel: "text-zinc-400 dark:text-zinc-500",
     statValue: "text-zinc-700 dark:text-zinc-300",
-    xpTrack: "bg-zinc-100 dark:bg-zinc-800",
+    xpTrack: "bg-stone-100 dark:bg-[#1a1a1a]",
     xpFrom: "from-slate-400", xpTo: "to-slate-500",
     tierColor: "text-zinc-400",
     xpPctColor: "text-zinc-400",
@@ -165,7 +165,7 @@ const GRADE_CONFIG = {
     frameGradient: "linear-gradient(135deg,#71717a,#a1a1aa,#71717a)",
     glow: "shadow-md",
     darkCard: false,
-    cardBodyCls: "bg-white dark:bg-zinc-950",
+    cardBodyCls: "bg-white dark:bg-[#0d0d0d]",
     label: "FAIR VALUE",
     labelColor: "text-zinc-500 dark:text-zinc-400",
     badgeGradient: "linear-gradient(90deg,#3f3f46,#71717a)",
@@ -173,16 +173,16 @@ const GRADE_CONFIG = {
     nameColor: "text-zinc-900 dark:text-zinc-100",
     tickerColor: "text-zinc-400",
     artBg: "from-zinc-100 to-zinc-200 dark:from-zinc-900 dark:to-zinc-950",
-    artBorder: "border-zinc-300/50 dark:border-zinc-700/40",
+    artBorder: "border-zinc-300/50 dark:border-[#222222]/40",
     artShadow: "",
     typeGradient: "linear-gradient(90deg,rgba(113,113,122,0.07),rgba(161,161,170,0.07))",
-    typeBorder: "border-zinc-300/50 dark:border-zinc-700/40",
+    typeBorder: "border-zinc-300/50 dark:border-[#222222]/40",
     typeText: "text-zinc-500 dark:text-zinc-400",
-    statBg: "bg-zinc-50 dark:bg-zinc-900/50 border-zinc-200/60 dark:border-zinc-700/40",
-    statDivide: "divide-zinc-100 dark:divide-zinc-800/60",
+    statBg: "bg-stone-100 dark:bg-[#1a1a1a]/50 border-zinc-200/60 dark:border-[#222222]/40",
+    statDivide: "divide-zinc-100 dark:divide-[#2a2a2a]/60",
     statLabel: "text-zinc-400 dark:text-zinc-500",
     statValue: "text-zinc-700 dark:text-zinc-300",
-    xpTrack: "bg-zinc-100 dark:bg-zinc-800",
+    xpTrack: "bg-stone-100 dark:bg-[#1a1a1a]",
     xpFrom: "from-zinc-400", xpTo: "to-zinc-500",
     tierColor: "text-zinc-400",
     xpPctColor: "text-zinc-400",
@@ -199,7 +199,7 @@ const GRADE_CONFIG = {
     frameGradient: "linear-gradient(135deg,#ef4444,#f87171,#ef4444)",
     glow: "shadow-[0_0_22px_rgba(239,68,68,0.25)]",
     darkCard: false,
-    cardBodyCls: "bg-white dark:bg-zinc-950",
+    cardBodyCls: "bg-white dark:bg-[#0d0d0d]",
     label: "OVERVALUED",
     labelColor: "text-red-500 dark:text-red-400",
     badgeGradient: "linear-gradient(90deg,#b91c1c,#ef4444)",
@@ -216,7 +216,7 @@ const GRADE_CONFIG = {
     statDivide: "divide-red-100/50 dark:divide-red-900/30",
     statLabel: "text-red-300 dark:text-red-500",
     statValue: "text-zinc-700 dark:text-zinc-300",
-    xpTrack: "bg-zinc-100 dark:bg-zinc-800",
+    xpTrack: "bg-stone-100 dark:bg-[#1a1a1a]",
     xpFrom: "from-red-400", xpTo: "to-rose-500",
     tierColor: "text-zinc-400",
     xpPctColor: "text-zinc-400",
@@ -279,7 +279,7 @@ const getLevelTier = (level: number) => {
   };
   return {
     title: "BEGINNER", from: "from-zinc-300", to: "to-zinc-400",
-    badge: "bg-zinc-100 text-zinc-600 dark:bg-zinc-900 dark:text-zinc-400",
+    badge: "bg-stone-100 text-zinc-600 dark:bg-[#1a1a1a] dark:text-zinc-400",
     desc: "관심을 막 시작한 단계. 조회할수록 XP가 누적됩니다.",
     next: "WATCHLIST" as string | null, nextLevel: 4 as number | null,
   };
@@ -952,7 +952,7 @@ export const StockCard = ({ stock, chartConfig, isCompact = false, stockXpProfil
 
         {/* ════════════════ BACK ════════════════ */}
         <div
-          className="absolute inset-0 rounded-[1.75rem] bg-white dark:bg-zinc-950 flex flex-col shadow-xl overflow-hidden"
+          className="absolute inset-0 rounded-[1.75rem] bg-white dark:bg-[#0d0d0d] flex flex-col shadow-xl overflow-hidden"
           style={{
             WebkitBackfaceVisibility: "hidden",
             backfaceVisibility: "hidden",
@@ -965,7 +965,7 @@ export const StockCard = ({ stock, chartConfig, isCompact = false, stockXpProfil
           {/* 등급 컬러 헤더 글로우 */}
           <div className="absolute inset-x-0 top-0 h-32 opacity-[0.08] pointer-events-none" style={{ background: cfg.frameGradient }} />
           {/* 테두리 */}
-          <div className="absolute inset-0 rounded-[1.75rem] border-2 border-zinc-200 dark:border-zinc-800 pointer-events-none" />
+          <div className="absolute inset-0 rounded-[1.75rem] border-2 border-zinc-200 dark:border-[#2a2a2a] pointer-events-none" />
 
           <div className="relative flex flex-col gap-2.5 p-3.5 h-full overflow-y-auto">
 
@@ -980,7 +980,7 @@ export const StockCard = ({ stock, chartConfig, isCompact = false, stockXpProfil
               {(() => {
                 const meta = GRADE_META[grade] ?? GRADE_META.B;
                 return (
-                  <div className="flex gap-2.5 p-2.5 rounded-xl bg-zinc-50 dark:bg-zinc-900/60 border border-zinc-200/70 dark:border-zinc-800/70 mb-2">
+                  <div className="flex gap-2.5 p-2.5 rounded-xl bg-stone-100 dark:bg-[#1a1a1a]/60 border border-zinc-200/70 dark:border-[#2a2a2a]/70 mb-2">
                     <div className="shrink-0 flex flex-col items-center gap-1 pt-0.5">
                       <span
                         className={cn("text-xl font-black font-mono leading-none", cfg.labelColor)}
@@ -1017,7 +1017,7 @@ export const StockCard = ({ stock, chartConfig, isCompact = false, stockXpProfil
             </div>
 
             {/* 구분선 */}
-            <div className="border-t border-zinc-200 dark:border-zinc-800" />
+            <div className="border-t border-zinc-200 dark:border-[#2a2a2a]" />
 
             {/* ── 레벨 섹션 ── */}
             <div>
@@ -1026,7 +1026,7 @@ export const StockCard = ({ stock, chartConfig, isCompact = false, stockXpProfil
                 <span className="text-[8px] font-black uppercase tracking-widest font-mono text-zinc-400">카드 레벨</span>
               </div>
 
-              <div className="p-2.5 rounded-xl bg-zinc-900 dark:bg-zinc-950 border border-zinc-800">
+              <div className="p-2.5 rounded-xl bg-zinc-900 dark:bg-[#0d0d0d] border border-zinc-800">
                 {/* 레벨 헤더 */}
                 <div className="flex items-center justify-between mb-2">
                   <div className="flex items-center gap-1.5">
@@ -1073,7 +1073,7 @@ export const StockCard = ({ stock, chartConfig, isCompact = false, stockXpProfil
             </div>
 
             {/* ── 푸터 ── */}
-            <div className="mt-auto pt-2 border-t border-zinc-200 dark:border-zinc-800 flex items-center justify-center gap-1.5 shrink-0">
+            <div className="mt-auto pt-2 border-t border-zinc-200 dark:border-[#2a2a2a] flex items-center justify-center gap-1.5 shrink-0">
               {stock?.isUs ? <DollarSign size={9} className="text-blue-400" /> : <Coins size={9} className="text-indigo-400" />}
               <span className="text-[7px] font-black text-zinc-300 dark:text-zinc-700 tracking-[0.2em] uppercase font-mono">
                 {stock?.isUs ? "Finnhub · IdiotQuant" : "Korea Investment · IdiotQuant"}

--- a/cf-idiotquant/app/(search)/search/components/StockHeader.tsx
+++ b/cf-idiotquant/app/(search)/search/components/StockHeader.tsx
@@ -46,9 +46,9 @@ export const StockHeader = ({ data, isUs, isFixed }: StockHeaderProps) => {
     >
       <div
         className={cn(
-          "bg-white dark:bg-zinc-900 border-zinc-200 dark:border-zinc-800 transition-all",
+          "bg-white dark:bg-[#1a1a1a] border-zinc-200 dark:border-[#2a2a2a] transition-all",
           isFixed 
-            ? "rounded-none border-b shadow-lg backdrop-blur-md bg-white/90 dark:bg-zinc-900/90" 
+            ? "rounded-none border-b shadow-lg backdrop-blur-md bg-white/90 dark:bg-[#111111]/90" 
             : "rounded-2xl border shadow-sm mx-auto"
         )}
       >

--- a/cf-idiotquant/app/(search)/search/components/StockMetrics.tsx
+++ b/cf-idiotquant/app/(search)/search/components/StockMetrics.tsx
@@ -26,7 +26,7 @@ function MetricCard({ m }: { m: MetricItem }) {
       "p-3.5 rounded-xl border relative group cursor-help transition-colors select-none",
       m.highlight
         ? "bg-indigo-50 dark:bg-indigo-950/20 border-indigo-200/60 dark:border-indigo-900/40"
-        : "bg-zinc-50 dark:bg-zinc-800/50 border-zinc-100 dark:border-zinc-800 hover:border-zinc-200 dark:hover:border-zinc-700"
+        : "bg-stone-100 dark:bg-[#1a1a1a]/50 border-zinc-100 dark:border-[#2a2a2a] hover:border-zinc-200 dark:hover:border-zinc-700"
     )}>
       <p className={cn(
         "text-[9px] font-bold uppercase tracking-wider mb-1.5 truncate",
@@ -52,7 +52,7 @@ function MetricCard({ m }: { m: MetricItem }) {
       )}
 
       {/* 호버 툴팁 */}
-      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block w-48 bg-zinc-900 dark:bg-zinc-800 text-white text-[10px] p-2.5 rounded-xl shadow-xl border border-zinc-700/60 z-50 pointer-events-none whitespace-normal break-keep text-center leading-relaxed">
+      <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block w-48 bg-zinc-900 dark:bg-[#1a1a1a] text-white text-[10px] p-2.5 rounded-xl shadow-xl border border-zinc-700/60 z-50 pointer-events-none whitespace-normal break-keep text-center leading-relaxed">
         <p className="font-bold text-zinc-400 text-[9px] pb-1 mb-1 tracking-widest font-mono uppercase border-b border-zinc-700">{m.label}</p>
         <p className="text-zinc-200 font-medium">{m.desc}</p>
         <div className="absolute top-full left-1/2 -translate-x-1/2 border-[5px] border-transparent border-t-zinc-900 dark:border-t-zinc-800" />
@@ -67,7 +67,7 @@ function SectionLabel({ icon, label }: { icon: React.ReactNode; label: string })
     <div className="flex items-center gap-2 mb-2.5">
       <span className="text-zinc-400">{icon}</span>
       <span className="text-[10px] font-bold text-zinc-400 uppercase tracking-widest font-mono">{label}</span>
-      <div className="flex-1 h-px bg-zinc-100 dark:bg-zinc-800" />
+      <div className="flex-1 h-px bg-stone-100 dark:bg-[#1a1a1a]" />
     </div>
   );
 }
@@ -140,12 +140,12 @@ export const StockMetrics = ({ data, isUs }: { data: any; isUs: boolean }) => {
   const volumeMetrics    = metrics.filter(m => m.type === "volume");
 
   return (
-    <div className="w-full h-full bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm flex flex-col">
+    <div className="w-full h-full bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] shadow-sm flex flex-col">
 
       {/* ── 헤더 ── */}
-      <div className="px-5 py-4 border-b border-zinc-100 dark:border-zinc-800 flex items-center justify-between shrink-0">
+      <div className="px-5 py-4 border-b border-zinc-100 dark:border-[#2a2a2a] flex items-center justify-between shrink-0">
         <div className="flex items-center gap-2.5">
-          <div className="w-7 h-7 bg-zinc-100 dark:bg-zinc-800 rounded-lg flex items-center justify-center border border-zinc-200 dark:border-zinc-700 shrink-0">
+          <div className="w-7 h-7 bg-stone-100 dark:bg-[#1a1a1a] rounded-lg flex items-center justify-center border border-zinc-200 dark:border-[#222222] shrink-0">
             <BarChart3 size={14} className="text-zinc-500 dark:text-zinc-400" />
           </div>
           <div>

--- a/cf-idiotquant/app/(search)/search/components/ValuationSection.tsx
+++ b/cf-idiotquant/app/(search)/search/components/ValuationSection.tsx
@@ -159,9 +159,9 @@ const DEFAULT_CONFIG: ModelConfig = {
   icon: <BarChart3 size={14} />,
   dotBg: "bg-zinc-500",
   accentLine: "bg-zinc-400",
-  iconBg: "bg-zinc-100 dark:bg-zinc-800",
+  iconBg: "bg-stone-100 dark:bg-[#1a1a1a]",
   iconColor: "text-zinc-500 dark:text-zinc-400",
-  badgeClass: "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-400 border border-zinc-200 dark:border-zinc-700",
+  badgeClass: "bg-stone-100 dark:bg-[#1a1a1a] text-zinc-600 dark:text-zinc-400 border border-zinc-200 dark:border-[#222222]",
   textColor: "text-zinc-600 dark:text-zinc-400",
 };
 
@@ -234,13 +234,13 @@ export const ValuationSection = ({ data, isUs }: ValuationSectionProps) => {
     <div className="w-full flex flex-col">
 
       {/* ────── 모델 요약 바 ────── */}
-      <div className="px-5 pt-5 pb-4 border-b border-zinc-100 dark:border-zinc-800">
+      <div className="px-5 pt-5 pb-4 border-b border-zinc-100 dark:border-[#2a2a2a]">
         <div className="flex items-center gap-2 mb-4">
           <Target size={13} className="text-zinc-400 shrink-0" />
           <span className="text-xs font-extrabold text-zinc-600 dark:text-zinc-300 tracking-tight">
             모델별 목표주가 요약
           </span>
-          <span className="ml-auto text-[10px] font-mono font-bold text-zinc-400 dark:text-zinc-500 bg-zinc-100 dark:bg-zinc-800 px-2 py-0.5 rounded-md uppercase tracking-wider">
+          <span className="ml-auto text-[10px] font-mono font-bold text-zinc-400 dark:text-zinc-500 bg-stone-100 dark:bg-[#1a1a1a] px-2 py-0.5 rounded-md uppercase tracking-wider">
             {models.length} Models
           </span>
         </div>
@@ -265,7 +265,7 @@ export const ValuationSection = ({ data, isUs }: ValuationSectionProps) => {
                 <span className={cn("text-[11px] font-black font-mono w-10 shrink-0", config.textColor)}>
                   {type}
                 </span>
-                <div className="flex-1 h-1.5 bg-zinc-100 dark:bg-zinc-800 rounded-full overflow-hidden">
+                <div className="flex-1 h-1.5 bg-stone-100 dark:bg-[#1a1a1a] rounded-full overflow-hidden">
                   <div
                     className={cn(
                       "h-full rounded-full transition-all duration-500",
@@ -292,7 +292,7 @@ export const ValuationSection = ({ data, isUs }: ValuationSectionProps) => {
       </div>
 
       {/* ────── 필터 탭 ────── */}
-      <div className="px-5 py-3 border-b border-zinc-100 dark:border-zinc-800 flex items-center gap-1">
+      <div className="px-5 py-3 border-b border-zinc-100 dark:border-[#2a2a2a] flex items-center gap-1">
         {([
           { id: "ALL",     label: "전체",     count: models.length },
           { id: "ASSET",   label: "자산가치", count: assetCount },
@@ -305,7 +305,7 @@ export const ValuationSection = ({ data, isUs }: ValuationSectionProps) => {
               "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold transition-all duration-150",
               activeTab === tab.id
                 ? "bg-zinc-900 dark:bg-white text-white dark:text-zinc-900"
-                : "text-zinc-500 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 hover:text-zinc-800 dark:hover:text-zinc-200"
+                : "text-zinc-500 dark:text-zinc-400 hover:bg-stone-100 dark:hover:bg-[#1a1a1a] hover:text-zinc-800 dark:hover:text-zinc-200"
             )}
           >
             {tab.label}
@@ -313,7 +313,7 @@ export const ValuationSection = ({ data, isUs }: ValuationSectionProps) => {
               "text-[9px] font-black px-1.5 py-0.5 rounded-full",
               activeTab === tab.id
                 ? "bg-white/20 dark:bg-black/20"
-                : "bg-zinc-100 dark:bg-zinc-800 text-zinc-500 dark:text-zinc-500"
+                : "bg-stone-100 dark:bg-[#1a1a1a] text-zinc-500 dark:text-zinc-500"
             )}>
               {tab.count}
             </span>
@@ -375,7 +375,7 @@ function StrategyCard({ modelType, result, currency }: StrategyCardProps) {
   );
 
   return (
-    <div className="bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm overflow-hidden flex flex-col">
+    <div className="bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] shadow-sm overflow-hidden flex flex-col">
 
       {/* 상단 컬러 액센트 라인 */}
       <div className={cn("h-0.5 w-full shrink-0", config.accentLine)} />
@@ -383,7 +383,7 @@ function StrategyCard({ modelType, result, currency }: StrategyCardProps) {
       {/* 카드 헤더 */}
       <div
         onClick={() => setIsExpanded(!isExpanded)}
-        className="px-5 py-4 border-b border-zinc-100 dark:border-zinc-800 flex items-center justify-between cursor-pointer hover:bg-zinc-50/50 dark:hover:bg-zinc-900/50 transition-colors select-none"
+        className="px-5 py-4 border-b border-zinc-100 dark:border-[#2a2a2a] flex items-center justify-between cursor-pointer hover:bg-stone-100/50 dark:hover:bg-[#1f1f1f]/50 transition-colors select-none"
       >
         <div className="flex items-center gap-3 min-w-0">
           <div className={cn(
@@ -407,7 +407,7 @@ function StrategyCard({ modelType, result, currency }: StrategyCardProps) {
             <p className="text-[10px] font-mono text-zinc-400 mt-0.5 truncate">{result.formula}</p>
           </div>
         </div>
-        <div className="shrink-0 p-1 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors ml-2">
+        <div className="shrink-0 p-1 text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 rounded-lg hover:bg-stone-100 dark:hover:bg-[#1a1a1a] transition-colors ml-2">
           {isExpanded ? <ChevronUp size={15} /> : <ChevronDown size={15} />}
         </div>
       </div>
@@ -416,7 +416,7 @@ function StrategyCard({ modelType, result, currency }: StrategyCardProps) {
       {isExpanded && (
         <>
           {/* 모델 설명 */}
-          <div className="px-5 py-3.5 border-b border-zinc-50 dark:border-zinc-800/60 bg-zinc-50/30 dark:bg-zinc-800/10">
+          <div className="px-5 py-3.5 border-b border-zinc-50 dark:border-[#2a2a2a]/60 bg-stone-100/30 dark:bg-[#1a1a1a]/10">
             <p className="text-[11px] text-zinc-500 dark:text-zinc-400 leading-relaxed break-keep">
               {config.description.summary}
             </p>
@@ -424,11 +424,11 @@ function StrategyCard({ modelType, result, currency }: StrategyCardProps) {
 
           {/* 핵심 지표 그리드 */}
           {extendedMetrics.length > 0 && (
-            <div className="px-5 py-4 grid grid-cols-2 sm:grid-cols-4 gap-2.5 border-b border-zinc-100 dark:border-zinc-800">
+            <div className="px-5 py-4 grid grid-cols-2 sm:grid-cols-4 gap-2.5 border-b border-zinc-100 dark:border-[#2a2a2a]">
               {extendedMetrics.map((m: any, i: number) => (
                 <div
                   key={i}
-                  className="p-3 bg-zinc-50 dark:bg-zinc-800/50 rounded-xl border border-zinc-100 dark:border-zinc-800"
+                  className="p-3 bg-stone-100 dark:bg-[#1a1a1a]/50 rounded-xl border border-zinc-100 dark:border-[#2a2a2a]"
                 >
                   <p className="text-[9px] text-zinc-400 font-bold uppercase tracking-wider mb-1 truncate">
                     {m.label}
@@ -445,7 +445,7 @@ function StrategyCard({ modelType, result, currency }: StrategyCardProps) {
           <div className="overflow-x-auto">
             <table className="w-full text-left">
               <thead>
-                <tr className="bg-zinc-50 dark:bg-zinc-800/30">
+                <tr className="bg-stone-100 dark:bg-[#1a1a1a]/30">
                   {result.headers.map((h: any, i: number) => (
                     <th
                       key={i}
@@ -469,10 +469,10 @@ function StrategyCard({ modelType, result, currency }: StrategyCardProps) {
                     <tr
                       key={idx}
                       className={cn(
-                        "border-t border-zinc-100 dark:border-zinc-800 transition-colors",
+                        "border-t border-zinc-100 dark:border-[#2a2a2a] transition-colors",
                         isBase
-                          ? "bg-zinc-50/80 dark:bg-zinc-800/30"
-                          : "hover:bg-zinc-50/40 dark:hover:bg-zinc-800/10"
+                          ? "bg-stone-100/80 dark:bg-[#1a1a1a]/30"
+                          : "hover:bg-stone-100/40 dark:hover:bg-[#1a1a1a]/10"
                       )}
                     >
                       <td className="px-5 py-3 whitespace-nowrap">
@@ -518,7 +518,7 @@ function StrategyCard({ modelType, result, currency }: StrategyCardProps) {
           </div>
 
           {/* 푸터 노트 */}
-          <div className="px-5 py-3 border-t border-zinc-100 dark:border-zinc-800 bg-zinc-50/30 dark:bg-zinc-800/10 flex items-start gap-2">
+          <div className="px-5 py-3 border-t border-zinc-100 dark:border-[#2a2a2a] bg-stone-100/30 dark:bg-[#1a1a1a]/10 flex items-start gap-2">
             <Sparkles size={12} className="text-amber-500 shrink-0 mt-0.5" />
             <p className="text-[11px] text-zinc-400 dark:text-zinc-500 leading-relaxed">
               {result.footerNotice}

--- a/cf-idiotquant/app/(search)/search/page.tsx
+++ b/cf-idiotquant/app/(search)/search/page.tsx
@@ -12,7 +12,7 @@ function SearchRedirect() {
         router.replace(ticker ? `/analyze?ticker=${encodeURIComponent(ticker)}` : '/analyze');
     }, [router, searchParams]);
     return (
-        <div className="flex items-center justify-center min-h-screen bg-zinc-50 dark:bg-zinc-950">
+        <div className="flex items-center justify-center min-h-screen bg-stone-50 dark:bg-[#0d0d0d]">
             <Loader2 className="animate-spin text-blue-600" size={24} />
         </div>
     );
@@ -21,7 +21,7 @@ function SearchRedirect() {
 export default function SearchPage() {
     return (
         <Suspense fallback={
-            <div className="flex items-center justify-center min-h-screen bg-zinc-50 dark:bg-zinc-950">
+            <div className="flex items-center justify-center min-h-screen bg-stone-50 dark:bg-[#0d0d0d]">
                 <Loader2 className="animate-spin text-blue-600" size={24} />
             </div>
         }>

--- a/cf-idiotquant/app/not-found.tsx
+++ b/cf-idiotquant/app/not-found.tsx
@@ -10,13 +10,13 @@ interface NotFoundProps {
 
 export default function NotFound({ warnText = "Oops! Not Found!" }: NotFoundProps) {
   return (
-    <div className="min-h-[80vh] flex items-center justify-center p-6 bg-zinc-50 dark:bg-black transition-colors duration-300">
+    <div className="min-h-[80vh] flex items-center justify-center p-6 bg-stone-50 dark:bg-[#0d0d0d] transition-colors duration-300">
       <div className="max-w-md w-full flex flex-col items-center text-center">
         
         {/* Animated Icon Section */}
         <div className="relative mb-8">
           <div className="absolute inset-0 bg-blue-500/20 blur-[60px] rounded-full animate-pulse" />
-          <div className="relative flex items-center justify-center w-24 h-24 rounded-3xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 shadow-xl">
+          <div className="relative flex items-center justify-center w-24 h-24 rounded-3xl bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] shadow-xl">
             <Search className="w-10 h-10 text-blue-500 animate-bounce" />
             <AlertCircle className="absolute -top-1 -right-1 w-6 h-6 text-red-500 fill-white dark:fill-zinc-900" />
           </div>
@@ -33,7 +33,7 @@ export default function NotFound({ warnText = "Oops! Not Found!" }: NotFoundProp
             입력하신 주소가 정확한지 다시 한번 확인해 주세요.
           </p>
 
-          <div className="inline-block px-4 py-2 rounded-lg bg-zinc-200/50 dark:bg-zinc-800/50 border border-zinc-300 dark:border-zinc-700">
+          <div className="inline-block px-4 py-2 rounded-lg bg-zinc-200/50 dark:bg-[#2a2a2a]/50 border border-zinc-300 dark:border-[#3a3a3a]">
             <code className="text-sm font-mono font-bold text-zinc-700 dark:text-zinc-300 tracking-tight">
               {warnText}
             </code>
@@ -43,14 +43,14 @@ export default function NotFound({ warnText = "Oops! Not Found!" }: NotFoundProp
         {/* Action Button */}
         <Link href="/" className="group relative">
           <div className="absolute -inset-0.5 bg-gradient-to-r from-blue-600 to-indigo-600 rounded-xl blur opacity-30 group-hover:opacity-100 transition duration-300" />
-          <button className="relative flex items-center justify-center gap-2 px-8 py-4 bg-white dark:bg-zinc-900 text-zinc-900 dark:text-white rounded-xl font-bold border border-zinc-200 dark:border-zinc-800 transition-all hover:scale-[1.02] active:scale-[0.98]">
+          <button className="relative flex items-center justify-center gap-2 px-8 py-4 bg-white dark:bg-[#1a1a1a] text-zinc-900 dark:text-white rounded-xl font-bold border border-zinc-200 dark:border-[#2a2a2a] transition-all hover:scale-[1.02] active:scale-[0.98]">
             <Home className="w-4 h-4 text-blue-500" />
             메인 페이지로 돌아가기
           </button>
         </Link>
 
         {/* Footer info for system feel */}
-        <div className="mt-16 pt-8 border-t border-dashed border-zinc-200 dark:border-zinc-800 w-full">
+        <div className="mt-16 pt-8 border-t border-dashed border-zinc-200 dark:border-[#2a2a2a] w-full">
           <p className="text-[10px] font-black text-zinc-400 uppercase tracking-[0.3em]">
             System Error Code: 404_NOT_FOUND
           </p>

--- a/cf-idiotquant/components/LineChart.tsx
+++ b/cf-idiotquant/components/LineChart.tsx
@@ -38,7 +38,7 @@ const tailwindPalette = {
 const CustomTooltip = ({ active, payload, label, mode }: any) => {
     if (active && payload && payload.length) {
         return (
-            <div className="bg-white/80 dark:bg-zinc-950/80 backdrop-blur-md px-3 py-2 rounded-xl border border-zinc-200/60 dark:border-zinc-800/80 shadow-xl text-[11px] font-medium transition-all duration-200">
+            <div className="bg-white/80 dark:bg-[#0d0d0d]/80 backdrop-blur-md px-3 py-2 rounded-xl border border-zinc-200/60 dark:border-[#2a2a2a]/80 shadow-xl text-[11px] font-medium transition-all duration-200">
                 <p className="text-zinc-400 dark:text-zinc-500 font-bold mb-1 font-mono tracking-wider">{label}</p>
                 <div className="space-y-1">
                     {payload.map((entry: any, index: number) => (

--- a/cf-idiotquant/components/authButton.tsx
+++ b/cf-idiotquant/components/authButton.tsx
@@ -26,7 +26,7 @@ export default function AuthButton() {
     }, [status, router])
 
     if (status === "loading") {
-        return <div className="w-full h-12 rounded-xl bg-zinc-100 dark:bg-zinc-800 animate-pulse" />
+        return <div className="w-full h-12 rounded-xl bg-zinc-100 dark:bg-[#2a2a2a] animate-pulse" />
     }
 
     if (session) {

--- a/cf-idiotquant/components/balance/portfolioChart.tsx
+++ b/cf-idiotquant/components/balance/portfolioChart.tsx
@@ -36,7 +36,7 @@ function PieTooltip({ active, payload, isUs }: { active?: boolean; payload?: any
     : "";
 
   return (
-    <div className="bg-white dark:bg-zinc-800 px-3 py-2 rounded-lg border border-zinc-200 dark:border-zinc-700 shadow-lg">
+    <div className="bg-white dark:bg-[#2a2a2a] px-3 py-2 rounded-lg border border-zinc-200 dark:border-[#3a3a3a] shadow-lg">
       <p className="text-xs font-bold text-zinc-900 dark:text-white">{name}</p>
       <p className="text-xs text-zinc-600 dark:text-zinc-300">
         {formatter(value)}{pctStr ? ` (${pctStr})` : ""}
@@ -51,7 +51,7 @@ function BarTooltip({ active, payload }: { active?: boolean; payload?: any[] }) 
   const { name, value } = payload[0];
 
   return (
-    <div className="bg-white dark:bg-zinc-800 px-3 py-2 rounded-lg border border-zinc-200 dark:border-zinc-700 shadow-lg">
+    <div className="bg-white dark:bg-[#2a2a2a] px-3 py-2 rounded-lg border border-zinc-200 dark:border-[#3a3a3a] shadow-lg">
       <p className="text-xs font-bold text-zinc-900 dark:text-white">{name}</p>
       <p className="text-xs font-mono text-zinc-600 dark:text-zinc-300">
         {value.toFixed(2)}%
@@ -88,7 +88,7 @@ function PortfolioPieChart({ output1, isUs }: PortfolioPieChartProps) {
   if (pieData.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-12 gap-3">
-        <div className="p-4 rounded-2xl bg-zinc-100 dark:bg-zinc-800">
+        <div className="p-4 rounded-2xl bg-zinc-100 dark:bg-[#2a2a2a]">
           <InboxIcon size={24} className="text-zinc-400" />
         </div>
         <p className="text-sm font-medium text-zinc-400">보유 종목이 없습니다</p>
@@ -130,7 +130,7 @@ function PortfolioPieChart({ output1, isUs }: PortfolioPieChartProps) {
           const formatter = isUs ? fmtUsd : fmtKrw;
 
           return (
-            <div key={index} className="flex items-center gap-3 pb-2.5 border-b border-zinc-100 dark:border-zinc-800 last:border-0">
+            <div key={index} className="flex items-center gap-3 pb-2.5 border-b border-zinc-100 dark:border-[#2a2a2a] last:border-0">
               <div
                 className="w-2.5 h-2.5 rounded-full shrink-0"
                 style={{ backgroundColor: colors[index % colors.length] }}
@@ -176,7 +176,7 @@ function ProfitBarChart({ output1, isUs }: PortfolioPieChartProps) {
   if (barData.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-12 gap-3">
-        <div className="p-4 rounded-2xl bg-zinc-100 dark:bg-zinc-800">
+        <div className="p-4 rounded-2xl bg-zinc-100 dark:bg-[#2a2a2a]">
           <InboxIcon size={24} className="text-zinc-400" />
         </div>
         <p className="text-sm font-medium text-zinc-400">수익률 데이터가 없습니다</p>
@@ -243,7 +243,7 @@ export function PortfolioChartSection({
 
   return (
     <>
-      <div className="flex items-center gap-2 mb-6 bg-zinc-100 dark:bg-zinc-800 p-1 rounded-xl w-fit">
+      <div className="flex items-center gap-2 mb-6 bg-zinc-100 dark:bg-[#2a2a2a] p-1 rounded-xl w-fit">
         <TabButton
           active={activeTab === "pie"}
           onClick={() => setActiveTab("pie")}

--- a/cf-idiotquant/components/balance/sectionNav.tsx
+++ b/cf-idiotquant/components/balance/sectionNav.tsx
@@ -54,7 +54,7 @@ export function SectionNav({ sections }: { sections: NavSection[] }) {
   }, [sections]);
 
   return (
-    <nav className="sticky top-0 z-30 bg-white/80 dark:bg-zinc-950/80 backdrop-blur-md border-b border-zinc-200 dark:border-zinc-800 transition-colors duration-300">
+    <nav className="sticky top-0 z-30 bg-white/80 dark:bg-[#0d0d0d]/80 backdrop-blur-md border-b border-zinc-200 dark:border-[#2a2a2a] transition-colors duration-300">
       <div className="max-w-7xl mx-auto px-4 py-3 md:py-4">
         <div className="flex items-center gap-2 overflow-x-auto scrollbar-hide">
           {sections.map(({ id, label, icon }) => (
@@ -65,7 +65,7 @@ export function SectionNav({ sections }: { sections: NavSection[] }) {
                 "flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-bold whitespace-nowrap transition-all shrink-0",
                 activeId === id
                   ? "bg-zinc-900 dark:bg-white text-white dark:text-zinc-900"
-                  : "text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                  : "text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-white hover:bg-zinc-100 dark:hover:bg-[#2a2a2a]"
               )}
             >
               <span className="shrink-0">{icon}</span>

--- a/cf-idiotquant/components/balance/shared.tsx
+++ b/cf-idiotquant/components/balance/shared.tsx
@@ -103,8 +103,8 @@ export function ToastContainer({ toasts, onRemove }: { toasts: ToastItem[]; onRe
 // =========================================================================
 export function LoadingState({ message = "계좌 데이터를 불러오는 중..." }: { message?: string }) {
   return (
-    <div className="h-screen w-full flex flex-col items-center justify-center bg-zinc-50 dark:bg-black gap-3">
-      <div className="p-4 rounded-2xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 shadow-sm">
+    <div className="h-screen w-full flex flex-col items-center justify-center bg-stone-50 dark:bg-[#0d0d0d] gap-3">
+      <div className="p-4 rounded-2xl bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] shadow-sm">
         <Loader2 className="w-7 h-7 text-blue-500 animate-spin" />
       </div>
       <p className="text-sm font-bold text-zinc-400">{message}</p>
@@ -119,9 +119,9 @@ export function SectionHeader({
   badge?: React.ReactNode; action?: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-5 pb-4 border-b border-zinc-100 dark:border-zinc-800/80">
+    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-5 pb-4 border-b border-zinc-100 dark:border-[#2a2a2a]/80">
       <div className="flex items-center gap-3">
-        <div className="p-2 bg-zinc-100 dark:bg-zinc-800 rounded-xl text-zinc-600 dark:text-zinc-400 shrink-0">
+        <div className="p-2 bg-zinc-100 dark:bg-[#2a2a2a] rounded-xl text-zinc-600 dark:text-zinc-400 shrink-0">
           {icon}
         </div>
         <div>
@@ -129,7 +129,7 @@ export function SectionHeader({
             <h3 className="font-black text-base text-zinc-900 dark:text-zinc-100 tracking-tight">{title}</h3>
             {badge}
           </div>
-          {subtitle && <p className="text-xs text-zinc-500 dark:text-zinc-500 mt-0.5">{subtitle}</p>}
+          {subtitle && <p className="text-xs text-zinc-500 dark:text-neutral-500 mt-0.5">{subtitle}</p>}
         </div>
       </div>
       {action && <div className="shrink-0 self-start sm:self-center">{action}</div>}
@@ -144,7 +144,7 @@ export function TabButton({ active, onClick, children }: { active: boolean; onCl
       className={cn(
         "px-3 py-1.5 rounded-lg text-xs font-black transition-all whitespace-nowrap",
         active
-          ? "bg-white dark:bg-zinc-950 text-zinc-950 dark:text-white shadow-sm"
+          ? "bg-white dark:bg-[#0d0d0d] text-zinc-950 dark:text-white shadow-sm"
           : "text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-300"
       )}
     >
@@ -158,7 +158,7 @@ export function EmptyRow({ colSpan, message }: { colSpan: number; message: strin
     <tr>
       <td colSpan={colSpan}>
         <div className="flex flex-col items-center justify-center py-14 gap-3">
-          <div className="p-3 rounded-2xl bg-zinc-100 dark:bg-zinc-800">
+          <div className="p-3 rounded-2xl bg-zinc-100 dark:bg-[#2a2a2a]">
             <InboxIcon size={20} className="text-zinc-400" />
           </div>
           <p className="text-sm text-zinc-400 font-medium">{message}</p>
@@ -171,17 +171,17 @@ export function EmptyRow({ colSpan, message }: { colSpan: number; message: strin
 // =========================================================================
 // KPI 카드 (단일값 — KR)
 // =========================================================================
-export function KpiCard({ label, value, sub, icon, iconBg, valueColor = "text-zinc-900 dark:text-white", accentColor = "bg-zinc-200 dark:bg-zinc-700" }: {
+export function KpiCard({ label, value, sub, icon, iconBg, valueColor = "text-zinc-900 dark:text-white", accentColor = "bg-zinc-200 dark:bg-[#3a3a3a]" }: {
   label: string; value: string | null; sub: string;
   icon: React.ReactNode; iconBg: string; valueColor?: string; accentColor?: string;
 }) {
   if (value === null) return <KpiCardSkeleton />;
 
   return (
-    <div className="relative bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm overflow-hidden flex flex-col justify-between gap-3 p-4 sm:p-5">
+    <div className="relative bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] shadow-sm overflow-hidden flex flex-col justify-between gap-3 p-4 sm:p-5">
       <div className={cn("absolute top-0 left-0 right-0 h-0.5", accentColor)} />
       <div className="flex items-center justify-between">
-        <span className="text-[10px] font-black text-zinc-400 dark:text-zinc-500 uppercase tracking-wider leading-tight">{label}</span>
+        <span className="text-[10px] font-black text-zinc-400 dark:text-neutral-500 uppercase tracking-wider leading-tight">{label}</span>
         <div className={cn("p-2 rounded-xl shrink-0", iconBg)}>{icon}</div>
       </div>
       <div>
@@ -198,7 +198,7 @@ export function KpiCard({ label, value, sub, icon, iconBg, valueColor = "text-zi
 export function UsdKpiCard({
   label, mainValue, mainColor = "text-zinc-900 dark:text-white",
   subLabel, subValue, subColor = "text-zinc-800 dark:text-zinc-200",
-  icon, iconBg, loading, accentColor = "bg-zinc-200 dark:bg-zinc-700",
+  icon, iconBg, loading, accentColor = "bg-zinc-200 dark:bg-[#3a3a3a]",
 }: {
   label: string; mainValue: string | null; mainColor?: string;
   subLabel: string; subValue: string | null; subColor?: string;
@@ -207,15 +207,15 @@ export function UsdKpiCard({
   if (loading || mainValue === null) return <UsdKpiCardSkeleton />;
 
   return (
-    <div className="relative bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-4 sm:p-5 shadow-sm overflow-hidden flex flex-col justify-between gap-3">
+    <div className="relative bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] rounded-2xl p-4 sm:p-5 shadow-sm overflow-hidden flex flex-col justify-between gap-3">
       <div className={cn("absolute top-0 left-0 right-0 h-0.5", accentColor)} />
       <div className="flex items-center justify-between">
-        <span className="text-[10px] font-black text-zinc-400 dark:text-zinc-500 uppercase tracking-wider leading-tight">{label}</span>
+        <span className="text-[10px] font-black text-zinc-400 dark:text-neutral-500 uppercase tracking-wider leading-tight">{label}</span>
         <div className={cn("p-2 rounded-xl shrink-0", iconBg)}>{icon}</div>
       </div>
       <div>
         <div className={cn("text-xl sm:text-2xl font-black tracking-tight font-mono", mainColor)}>{mainValue}</div>
-        <div className="mt-2 pt-2 border-t border-zinc-100 dark:border-zinc-800 flex items-center justify-between text-[10px] font-bold text-zinc-400">
+        <div className="mt-2 pt-2 border-t border-zinc-100 dark:border-[#2a2a2a] flex items-center justify-between text-[10px] font-bold text-zinc-400">
           <span>{subLabel}</span>
           <span className={cn("font-mono", subColor)}>{subValue}</span>
         </div>
@@ -240,7 +240,7 @@ export function OrderTabAction({
   onRefresh: () => void;
 }) {
   return (
-    <div className="flex items-center gap-1 bg-zinc-100 dark:bg-zinc-800 p-1 rounded-xl">
+    <div className="flex items-center gap-1 bg-zinc-100 dark:bg-[#2a2a2a] p-1 rounded-xl">
       <TabButton active={viewerTab === "ccnl"} onClick={() => setViewerTab("ccnl")}>
         체결 ({ccnlCount})
       </TabButton>
@@ -291,7 +291,7 @@ export function BalanceHeaderActions({
           "flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-bold border transition-all",
           autoRefresh
             ? "bg-emerald-50 dark:bg-emerald-950/30 text-emerald-600 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800"
-            : "bg-white dark:bg-zinc-900 text-zinc-500 border-zinc-200 dark:border-zinc-800 hover:border-zinc-400"
+            : "bg-white dark:bg-[#1a1a1a] text-zinc-500 border-zinc-200 dark:border-[#2a2a2a] hover:border-zinc-400"
         )}
       >
         <Activity size={13} className={autoRefresh ? "animate-pulse text-emerald-500" : ""} />
@@ -300,7 +300,7 @@ export function BalanceHeaderActions({
       <button
         onClick={onRefresh}
         disabled={isLoading}
-        className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 text-xs font-bold text-zinc-600 dark:text-zinc-400 hover:border-zinc-400 transition-all disabled:opacity-50"
+        className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] text-xs font-bold text-zinc-600 dark:text-zinc-400 hover:border-zinc-400 transition-all disabled:opacity-50"
       >
         <RefreshCw size={13} className={isLoading ? "animate-spin" : ""} />
         새로고침
@@ -335,15 +335,15 @@ export function pnlAccentColor(positive: boolean) {
 // =========================================================================
 export function KpiCardSkeleton() {
   return (
-    <div className="relative bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm overflow-hidden flex flex-col justify-between gap-3 p-4 sm:p-5">
-      <div className="absolute top-0 left-0 right-0 h-0.5 bg-zinc-200 dark:bg-zinc-700 animate-pulse" />
+    <div className="relative bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] shadow-sm overflow-hidden flex flex-col justify-between gap-3 p-4 sm:p-5">
+      <div className="absolute top-0 left-0 right-0 h-0.5 bg-zinc-200 dark:bg-[#3a3a3a] animate-pulse" />
       <div className="flex items-center justify-between">
-        <div className="h-3 w-20 bg-zinc-200 dark:bg-zinc-700 rounded animate-pulse" />
-        <div className="h-8 w-8 bg-zinc-100 dark:bg-zinc-800 rounded-xl animate-pulse" />
+        <div className="h-3 w-20 bg-zinc-200 dark:bg-[#3a3a3a] rounded animate-pulse" />
+        <div className="h-8 w-8 bg-zinc-100 dark:bg-[#2a2a2a] rounded-xl animate-pulse" />
       </div>
       <div>
-        <div className="h-7 w-32 bg-zinc-200 dark:bg-zinc-700 rounded-lg animate-pulse mb-2" />
-        <div className="h-3 w-24 bg-zinc-100 dark:bg-zinc-800 rounded animate-pulse" />
+        <div className="h-7 w-32 bg-zinc-200 dark:bg-[#3a3a3a] rounded-lg animate-pulse mb-2" />
+        <div className="h-3 w-24 bg-zinc-100 dark:bg-[#2a2a2a] rounded animate-pulse" />
       </div>
     </div>
   );
@@ -351,16 +351,16 @@ export function KpiCardSkeleton() {
 
 export function UsdKpiCardSkeleton() {
   return (
-    <div className="relative bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-4 sm:p-5 shadow-sm overflow-hidden flex flex-col justify-between gap-3">
-      <div className="absolute top-0 left-0 right-0 h-0.5 bg-zinc-200 dark:bg-zinc-700 animate-pulse" />
+    <div className="relative bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] rounded-2xl p-4 sm:p-5 shadow-sm overflow-hidden flex flex-col justify-between gap-3">
+      <div className="absolute top-0 left-0 right-0 h-0.5 bg-zinc-200 dark:bg-[#3a3a3a] animate-pulse" />
       <div className="flex items-center justify-between">
-        <div className="h-3 w-20 bg-zinc-200 dark:bg-zinc-700 rounded animate-pulse" />
-        <div className="h-8 w-8 bg-zinc-100 dark:bg-zinc-800 rounded-xl animate-pulse" />
+        <div className="h-3 w-20 bg-zinc-200 dark:bg-[#3a3a3a] rounded animate-pulse" />
+        <div className="h-8 w-8 bg-zinc-100 dark:bg-[#2a2a2a] rounded-xl animate-pulse" />
       </div>
       <div>
-        <div className="h-7 w-32 bg-zinc-200 dark:bg-zinc-700 rounded-lg animate-pulse mb-2" />
-        <div className="mt-2 pt-2 border-t border-zinc-100 dark:border-zinc-800">
-          <div className="h-3 w-24 bg-zinc-100 dark:bg-zinc-800 rounded animate-pulse" />
+        <div className="h-7 w-32 bg-zinc-200 dark:bg-[#3a3a3a] rounded-lg animate-pulse mb-2" />
+        <div className="mt-2 pt-2 border-t border-zinc-100 dark:border-[#2a2a2a]">
+          <div className="h-3 w-24 bg-zinc-100 dark:bg-[#2a2a2a] rounded animate-pulse" />
         </div>
       </div>
     </div>
@@ -370,13 +370,13 @@ export function UsdKpiCardSkeleton() {
 export function ChartSectionSkeleton() {
   return (
     <div className="flex flex-col sm:flex-row gap-6 items-center py-8">
-      <div className="w-48 h-48 rounded-full bg-zinc-100 dark:bg-zinc-800 animate-pulse shrink-0" />
+      <div className="w-48 h-48 rounded-full bg-zinc-100 dark:bg-[#2a2a2a] animate-pulse shrink-0" />
       <div className="flex-1 space-y-3 w-full">
         {[1, 2, 3, 4, 5].map(i => (
           <div key={i} className="flex items-center gap-3">
-            <div className="h-3 w-3 rounded-full bg-zinc-200 dark:bg-zinc-700 animate-pulse shrink-0" />
-            <div className="h-3 flex-1 bg-zinc-100 dark:bg-zinc-800 rounded animate-pulse" />
-            <div className="h-3 w-16 bg-zinc-200 dark:bg-zinc-700 rounded animate-pulse shrink-0" />
+            <div className="h-3 w-3 rounded-full bg-zinc-200 dark:bg-[#3a3a3a] animate-pulse shrink-0" />
+            <div className="h-3 flex-1 bg-zinc-100 dark:bg-[#2a2a2a] rounded animate-pulse" />
+            <div className="h-3 w-16 bg-zinc-200 dark:bg-[#3a3a3a] rounded animate-pulse shrink-0" />
           </div>
         ))}
       </div>
@@ -392,7 +392,7 @@ export function SectionPanel({ id, children, className }: { id?: string; childre
     <section
       id={id}
       className={cn(
-        "bg-white dark:bg-zinc-900 rounded-2xl border border-zinc-200 dark:border-zinc-800 shadow-sm p-5 md:p-6",
+        "bg-white dark:bg-[#1a1a1a] rounded-2xl border border-zinc-200 dark:border-[#2a2a2a] shadow-sm p-5 md:p-6",
         "animate-in fade-in duration-500",
         className
       )}
@@ -408,7 +408,7 @@ export function SectionPanel({ id, children, className }: { id?: string; childre
 export function TableHeader({ headers }: { headers: { label: string; align?: string }[] }) {
   return (
     <thead>
-      <tr className="bg-zinc-50 dark:bg-zinc-800/60 border-b border-zinc-100 dark:border-zinc-800">
+      <tr className="bg-stone-50 dark:bg-[#2a2a2a]/60 border-b border-zinc-100 dark:border-[#2a2a2a]">
         {headers.map(h => (
           <th
             key={h.label}

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -83,13 +83,13 @@ export default function StockListTable({
                 <div key={`batch-${amt}`} className="inline-flex rounded-lg shadow-sm border border-red-200 dark:border-red-800 overflow-hidden">
                   <button
                     onClick={() => doTokenPlusAll(amt)}
-                    className="bg-white dark:bg-zinc-900 hover:bg-red-50 dark:hover:bg-red-950 px-3 py-1.5 text-xs font-medium text-red-700 transition-colors border-r border-red-100 dark:border-red-800"
+                    className="bg-white dark:bg-[#1a1a1a] hover:bg-red-50 dark:hover:bg-red-950 px-3 py-1.5 text-xs font-medium text-red-700 transition-colors border-r border-red-100 dark:border-red-800"
                   >
                     +{amt / 10000}만
                   </button>
                   <button
                     onClick={() => doTokenMinusAll(amt)}
-                    className="bg-white dark:bg-zinc-900 hover:bg-red-50 dark:hover:bg-red-950 px-2 py-1.5 text-red-600 transition-colors"
+                    className="bg-white dark:bg-[#1a1a1a] hover:bg-red-50 dark:hover:bg-red-950 px-2 py-1.5 text-red-600 transition-colors"
                   >
                     <Minus className="w-3.5 h-3.5" />
                   </button>
@@ -101,9 +101,9 @@ export default function StockListTable({
       )}
 
       {/* 2. Desktop View (Table) */}
-      <div className="relative overflow-x-auto rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-zinc-800 dark:bg-zinc-950">
+      <div className="relative overflow-x-auto rounded-xl border border-zinc-200 bg-white shadow-sm dark:border-[#2a2a2a] dark:bg-[#0d0d0d]">
         <table className="w-full text-left text-[12px] border-collapse">
-          <thead className="bg-zinc-50/80 text-zinc-500 dark:bg-zinc-900/50 dark:text-zinc-400">
+          <thead className="bg-zinc-50/80 text-zinc-500 dark:bg-[#1a1a1a]/50 dark:text-zinc-400">
             <tr>
               <th className="px-4 py-3 font-semibold uppercase tracking-wider">종목</th>
               <th className="px-4 py-3 font-semibold uppercase tracking-wider text-center">PER / PBR</th>
@@ -114,7 +114,7 @@ export default function StockListTable({
               {isMaster && <th className="px-4 py-3 font-semibold uppercase tracking-wider text-right">Refill</th>}
             </tr>
           </thead>
-          <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
+          <tbody className="divide-y divide-zinc-100 dark:divide-[#2a2a2a]">
             {rows.length === 0 ? (
               <tr>
                 <td colSpan={isMaster ? 7 : 6} className="py-20 text-center">
@@ -132,7 +132,7 @@ export default function StockListTable({
                       onClick={() => { setSelected(row); setIsOpen(true); }}
                       className="flex items-center gap-2 group/btn"
                     >
-                      <div className="p-1.5 rounded-md bg-zinc-100 dark:bg-zinc-800 group-hover/btn:bg-blue-500 group-hover/btn:text-white transition-all">
+                      <div className="p-1.5 rounded-md bg-zinc-100 dark:bg-[#2a2a2a] group-hover/btn:bg-blue-500 group-hover/btn:text-white transition-all">
                         <TrendingUp className="w-3.5 h-3.5" />
                       </div>
                       <span className="font-bold text-sm text-zinc-900 dark:text-zinc-100 group-hover/btn:text-blue-600 transition-colors tracking-tight">
@@ -160,7 +160,7 @@ export default function StockListTable({
                       "inline-block px-2 py-0.5 rounded text-[11px] font-bold font-mono transition-colors",
                       Number(row.ncavRatio) > 1 
                         ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400" 
-                        : "bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500"
+                        : "bg-zinc-100 text-zinc-500 dark:bg-[#2a2a2a] dark:text-zinc-500"
                     )}>
                       {row.ncavRatio}
                     </span>
@@ -172,10 +172,10 @@ export default function StockListTable({
                     <td className="px-4 py-3">
                       <div className="flex justify-end gap-1.5">
                         {tokenAmounts.map(amt => (
-                          <div key={`indiv-${amt}`} className="flex items-center rounded-md border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 overflow-hidden shadow-xs">
+                          <div key={`indiv-${amt}`} className="flex items-center rounded-md border border-zinc-200 dark:border-[#2a2a2a] bg-white dark:bg-[#1a1a1a] overflow-hidden shadow-xs">
                             <button
                               onClick={() => doTokenPlusOne(amt, row.symbol)}
-                              className="px-2 py-1 hover:bg-zinc-50 dark:hover:bg-zinc-800 text-[10px] font-bold border-r border-zinc-100 dark:border-zinc-800"
+                              className="px-2 py-1 hover:bg-stone-50 dark:hover:bg-[#2a2a2a] text-[10px] font-bold border-r border-zinc-100 dark:border-[#2a2a2a]"
                             >
                               {amt / 10000}만
                             </button>
@@ -207,9 +207,9 @@ export default function StockListTable({
           />
           
           {/* Modal Content */}
-          <div className="relative w-full max-w-2xl overflow-hidden rounded-2xl bg-white shadow-2xl dark:bg-zinc-900 animate-in zoom-in-95 duration-300">
+          <div className="relative w-full max-w-2xl overflow-hidden rounded-2xl bg-white shadow-2xl dark:bg-[#1a1a1a] animate-in zoom-in-95 duration-300">
             {/* Header */}
-            <div className="flex items-center justify-between border-b border-zinc-100 p-4 dark:border-zinc-800">
+            <div className="flex items-center justify-between border-b border-zinc-100 p-4 dark:border-[#2a2a2a]">
               <div className="flex items-center gap-2">
                 <div className="rounded-lg bg-blue-600 p-1.5 text-white">
                   <BarChart3 className="h-4 w-4" />
@@ -220,7 +220,7 @@ export default function StockListTable({
               </div>
               <button 
                 onClick={closeModal}
-                className="rounded-full p-2 text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+                className="rounded-full p-2 text-zinc-400 hover:bg-zinc-100 dark:hover:bg-[#2a2a2a] transition-colors"
               >
                 <X className="h-5 w-5" />
               </button>
@@ -257,12 +257,12 @@ export default function StockListTable({
                   <span>Technical Metadata</span>
                 </div>
                 <div className="relative group">
-                  <pre className="max-h-[300px] overflow-auto rounded-xl border border-zinc-200 bg-zinc-50 p-4 font-mono text-[11px] leading-relaxed dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-400">
+                  <pre className="max-h-[300px] overflow-auto rounded-xl border border-zinc-200 bg-stone-50 p-4 font-mono text-[11px] leading-relaxed dark:border-[#2a2a2a] dark:bg-[#0d0d0d] dark:text-zinc-400">
                     {JSON.stringify(selected, null, 2)}
                   </pre>
                   <button 
                     onClick={() => navigator.clipboard.writeText(JSON.stringify(selected))}
-                    className="absolute right-3 top-3 rounded-md bg-white p-2 shadow-sm border border-zinc-200 opacity-0 group-hover:opacity-100 hover:bg-blue-50 transition-all dark:bg-zinc-800 dark:border-zinc-700"
+                    className="absolute right-3 top-3 rounded-md bg-white p-2 shadow-sm border border-zinc-200 opacity-0 group-hover:opacity-100 hover:bg-blue-50 transition-all dark:bg-[#2a2a2a] dark:border-[#3a3a3a]"
                   >
                     <Copy className="h-3.5 w-3.5 text-zinc-600 dark:text-zinc-300" />
                   </button>
@@ -271,7 +271,7 @@ export default function StockListTable({
             </div>
 
             {/* Footer */}
-            <div className="flex justify-end gap-3 border-t border-zinc-100 bg-zinc-50/50 p-4 dark:border-zinc-800 dark:bg-zinc-900/50">
+            <div className="flex justify-end gap-3 border-t border-zinc-100 bg-zinc-50/50 p-4 dark:border-[#2a2a2a] dark:bg-[#1a1a1a]/50">
               <button
                 onClick={closeModal}
                 className="rounded-lg bg-blue-600 px-8 py-2.5 text-sm font-bold text-white shadow-lg shadow-blue-500/20 hover:bg-blue-700 active:scale-95 transition-all"
@@ -289,7 +289,7 @@ export default function StockListTable({
 /** 상세 페이지용 스탯 컴포넌트 */
 function StatItem({ label, value, icon }: { label: string; value: string; icon: React.ReactNode }) {
   return (
-    <div className="flex flex-col gap-1.5 p-3 rounded-xl bg-zinc-50 border border-zinc-100 dark:bg-zinc-900 dark:border-zinc-800">
+    <div className="flex flex-col gap-1.5 p-3 rounded-xl bg-stone-50 border border-zinc-100 dark:bg-[#1a1a1a] dark:border-[#2a2a2a]">
       <div className="flex items-center gap-1.5 text-zinc-400 dark:text-zinc-500">
         {icon}
         <span className="text-[10px] font-black uppercase tracking-tight">{label}</span>

--- a/cf-idiotquant/components/inquireBalanceResult.tsx
+++ b/cf-idiotquant/components/inquireBalanceResult.tsx
@@ -206,7 +206,7 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
                                     setIsDropdownOpen(true);
                                 }}
                                 placeholder={isUs ? "티커 또는 미국 ETF 검색..." : "종목코드 또는 국내 주식 검색..."}
-                                className="w-full pl-10 pr-10 py-2 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl text-xs font-bold focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent dark:text-white"
+                                className="w-full pl-10 pr-10 py-2 bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] rounded-xl text-xs font-bold focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-transparent dark:text-white"
                             />
                             {searchQuery && (
                                 <button 
@@ -222,13 +222,13 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
                         {isDropdownOpen && searchQuery.trim() && (
                             <>
                                 <div className="fixed inset-0 z-10" onClick={() => setIsDropdownOpen(false)} />
-                                <div className="absolute left-0 right-0 mt-2 max-h-60 overflow-y-auto bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl shadow-xl z-20 divide-y divide-zinc-100 dark:divide-zinc-800">
+                                <div className="absolute left-0 right-0 mt-2 max-h-60 overflow-y-auto bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] rounded-2xl shadow-xl z-20 divide-y divide-zinc-100 dark:divide-[#2a2a2a]">
                                     {filteredSearchResults.length > 0 ? (
                                         filteredSearchResults.map((stock) => (
                                             <div
                                                 key={stock.pdno}
                                                 onClick={() => handleOpenOrderModal(stock)}
-                                                className="flex items-center justify-between p-3.5 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 cursor-pointer transition-colors group"
+                                                className="flex items-center justify-between p-3.5 hover:bg-stone-50 dark:hover:bg-zinc-800/50 cursor-pointer transition-colors group"
                                             >
                                                 <div className="flex flex-col">
                                                     <span className="text-xs font-black dark:text-zinc-200 group-hover:text-blue-600 transition-colors">
@@ -252,7 +252,7 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
                     </div>
 
                     <div className="flex items-center gap-2">
-                        <span className="px-2 py-1 bg-zinc-200 dark:bg-zinc-800 rounded text-[10px] font-black text-zinc-600 dark:text-zinc-400 shrink-0">
+                        <span className="px-2 py-1 bg-zinc-200 dark:bg-[#2a2a2a] rounded text-[10px] font-black text-zinc-600 dark:text-zinc-400 shrink-0">
                             {isUs ? "KRW (고시환율 정산)" : "KRW"}
                         </span>
                         <button
@@ -272,9 +272,9 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
             </div>
 
             {/* 메인 요약 카드 */}
-            <div className="bg-white dark:bg-zinc-900 rounded-[2rem] border border-zinc-200 dark:border-zinc-800 shadow-sm overflow-hidden">
+            <div className="bg-white dark:bg-[#1a1a1a] rounded-[2rem] border border-zinc-200 dark:border-[#2a2a2a] shadow-sm overflow-hidden">
                 {session?.user?.name === process.env.NEXT_PUBLIC_MASTER && (
-                    <div className="p-4 border-b border-zinc-100 dark:border-zinc-800 bg-zinc-50/50 dark:bg-zinc-900/50 flex flex-wrap items-center gap-4">
+                    <div className="p-4 border-b border-zinc-100 dark:border-[#2a2a2a] bg-zinc-50/50 dark:bg-[#1a1a1a]/50 flex flex-wrap items-center gap-4">
                         <div className="flex items-center gap-1.5 px-2.5 py-1 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-lg text-[10px] font-black uppercase">
                             <Key size={12} /> MASTER MODE
                         </div>
@@ -286,7 +286,7 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
                             >
                                 {Array.isArray(props.kakaoMemberList?.list) ? (
                                     props.kakaoMemberList.list.map((item: any) => (
-                                        <option key={item.key} value={String(item.key)} className="dark:bg-zinc-900">
+                                        <option key={item.key} value={String(item.key)} className="dark:bg-[#1a1a1a]">
                                             {item.value?.nickname} ({item.key})
                                         </option>
                                     ))
@@ -299,7 +299,7 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
                     </div>
                 )}
 
-                <div className="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x border-zinc-100 dark:divide-zinc-800">
+                <div className="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x border-zinc-100 dark:divide-[#2a2a2a]">
                     <SummaryItem
                         label="평가 손익률"
                         value={`${totalProfitRate >= 0 ? "▲ +" : "▼ "}${totalProfitRate.toFixed(2)}%`}
@@ -321,7 +321,7 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
             </div>
 
             {props.kiBalance.msg1 && (
-                <div className="flex items-start gap-3 p-4 bg-zinc-100 dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl">
+                <div className="flex items-start gap-3 p-4 bg-zinc-100 dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] rounded-2xl">
                     <Info size={18} className="text-zinc-400 mt-0.5 shrink-0" />
                     <p className="text-sm text-zinc-600 dark:text-zinc-400 font-medium leading-relaxed">
                         {props.kiBalance.msg1}
@@ -330,7 +330,7 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
             )}
 
             {/* 테이블 섹션 */}
-            <div className="overflow-hidden bg-white dark:bg-zinc-900 rounded-[2rem] border border-zinc-200 dark:border-zinc-800 shadow-sm">
+            <div className="overflow-hidden bg-white dark:bg-[#1a1a1a] rounded-[2rem] border border-zinc-200 dark:border-[#2a2a2a] shadow-sm">
                 <SortableBalanceTable 
                     inventoryData={props.kiBalance.output1 || []} 
                     isUs={isUs} 
@@ -383,7 +383,7 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder }: { inventoryD
 
     // 모바일 카드 뷰
     const MobileCardList = () => (
-        <div className="divide-y divide-zinc-100 dark:divide-zinc-800">
+        <div className="divide-y divide-zinc-100 dark:divide-[#2a2a2a]">
             {sortedItems.length === 0 && (
                 <p className="py-10 text-center text-sm text-zinc-400">보유 종목이 없습니다.</p>
             )}
@@ -452,7 +452,7 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder }: { inventoryD
             <div className="hidden md:block overflow-x-auto">
                 <table className="w-full text-left border-collapse min-w-[900px]">
                     <thead>
-                        <tr className="bg-zinc-50 dark:bg-zinc-800/50 border-b border-zinc-100 dark:border-zinc-800">
+                        <tr className="bg-stone-50 dark:bg-[#2a2a2a]/50 border-b border-zinc-100 dark:border-[#2a2a2a]">
                             <th className="p-4 text-center w-16 text-[10px] font-black text-zinc-400 uppercase">#</th>
                             <TableHeader label="종목명" sortKey="name" currentConfig={sortConfig} onSort={handleSort} />
                             <TableHeader label="보유수량" sortKey="qty" align="right" currentConfig={sortConfig} onSort={handleSort} />
@@ -463,7 +463,7 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder }: { inventoryD
                             <th className="p-4 text-center text-[10px] font-black text-zinc-400 uppercase">Action</th>
                         </tr>
                     </thead>
-                    <tbody className="divide-y divide-zinc-100 dark:divide-zinc-800">
+                    <tbody className="divide-y divide-zinc-100 dark:divide-[#2a2a2a]">
                         {sortedItems.length === 0 && (
                             <tr>
                                 <td colSpan={8} className="py-10 text-center text-sm text-zinc-400">보유 종목이 없습니다.</td>
@@ -477,7 +477,7 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder }: { inventoryD
                             const isPositive = profitRt >= 0;
 
                             return (
-                                <tr key={idx} className="group hover:bg-zinc-50 dark:hover:bg-zinc-800/30 transition-colors">
+                                <tr key={idx} className="group hover:bg-stone-50 dark:hover:bg-zinc-800/30 transition-colors">
                                     <td className="p-4 text-center font-mono text-xs text-zinc-400">{idx + 1}</td>
                                     <td className="p-4">
                                         <div className="flex flex-col">
@@ -541,7 +541,7 @@ function TableHeader({ label, sortKey, align = "left", currentConfig, onSort }: 
                 <span className={`text-[10px] font-black uppercase tracking-widest ${isActive ? "text-blue-600" : "text-zinc-400"}`}>
                     {label}
                 </span>
-                <div className="text-zinc-300 dark:text-zinc-600">
+                <div className="text-zinc-300 dark:text-neutral-500">
                     {isActive ? (
                         currentConfig.direction === "asc" ? <ChevronUp size={14} className="text-blue-600" /> : <ChevronDown size={14} className="text-blue-600" />
                     ) : (
@@ -656,7 +656,7 @@ function OrderModal({ isUs, stock, balanceKey, kiOrderCash, reqPostOrderCash, ex
 
     return (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm animate-in fade-in duration-200">
-            <div className="w-full max-w-md bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-[2rem] p-6 shadow-2xl space-y-6 relative mx-4">
+            <div className="w-full max-w-md bg-white dark:bg-[#1a1a1a] border border-zinc-200 dark:border-[#2a2a2a] rounded-[2rem] p-6 shadow-2xl space-y-6 relative mx-4">
                 
                 <div className="flex items-center justify-between">
                     <div>
@@ -671,7 +671,7 @@ function OrderModal({ isUs, stock, balanceKey, kiOrderCash, reqPostOrderCash, ex
                     </button>
                 </div>
 
-                <div className="grid grid-cols-2 p-1 bg-zinc-100 dark:bg-zinc-800 rounded-xl">
+                <div className="grid grid-cols-2 p-1 bg-zinc-100 dark:bg-[#2a2a2a] rounded-xl">
                     <button
                         onClick={() => setBuyOrSell("buy")}
                         className={`py-2.5 text-sm font-black rounded-lg transition-all ${buyOrSell === "buy" ? "bg-rose-500 text-white shadow-md" : "text-zinc-500 hover:text-zinc-800 dark:hover:text-zinc-200"}`}
@@ -699,7 +699,7 @@ function OrderModal({ isUs, stock, balanceKey, kiOrderCash, reqPostOrderCash, ex
                                 min={isUs ? "0.01" : "1"}
                                 value={price}
                                 onChange={(e) => { setPrice(e.target.value); if (priceError) setPriceError(""); }}
-                                className={`w-full bg-zinc-50 dark:bg-zinc-800/50 border pl-8 pr-4 py-3 rounded-xl font-mono font-bold text-sm focus:outline-none focus:border-blue-600 dark:text-white ${priceError ? "border-rose-500 dark:border-rose-500" : "border-zinc-200 dark:border-zinc-800"}`}
+                                className={`w-full bg-stone-50 dark:bg-[#2a2a2a]/50 border pl-8 pr-4 py-3 rounded-xl font-mono font-bold text-sm focus:outline-none focus:border-blue-600 dark:text-white ${priceError ? "border-rose-500 dark:border-rose-500" : "border-zinc-200 dark:border-[#2a2a2a]"}`}
                                 placeholder={isUs ? "0.00" : "0"}
                             />
                         </div>
@@ -708,7 +708,7 @@ function OrderModal({ isUs, stock, balanceKey, kiOrderCash, reqPostOrderCash, ex
 
                     <div className="space-y-1.5">
                         <label className="text-xs font-black text-zinc-400 uppercase tracking-wider">주문 수량 (QTY)</label>
-                        <div className={`flex items-center border rounded-xl overflow-hidden ${qtyError ? "border-rose-500 dark:border-rose-500" : "border-zinc-200 dark:border-zinc-800"}`}>
+                        <div className={`flex items-center border rounded-xl overflow-hidden ${qtyError ? "border-rose-500 dark:border-rose-500" : "border-zinc-200 dark:border-[#2a2a2a]"}`}>
                             <button
                                 type="button"
                                 onClick={() => {
@@ -722,7 +722,7 @@ function OrderModal({ isUs, stock, balanceKey, kiOrderCash, reqPostOrderCash, ex
                                 type="number"
                                 value={qty}
                                 onChange={(e) => { setQty(e.target.value); if (qtyError) setQtyError(""); }}
-                                className="flex-1 bg-zinc-50 dark:bg-zinc-800/50 text-center font-mono font-bold text-sm focus:outline-none dark:text-white py-3 min-w-0"
+                                className="flex-1 bg-stone-50 dark:bg-[#2a2a2a]/50 text-center font-mono font-bold text-sm focus:outline-none dark:text-white py-3 min-w-0"
                                 placeholder="1"
                                 min="1"
                             />
@@ -740,7 +740,7 @@ function OrderModal({ isUs, stock, balanceKey, kiOrderCash, reqPostOrderCash, ex
                     </div>
                 </div>
 
-                <div className="p-4 bg-zinc-50 dark:bg-zinc-800/40 border border-zinc-100 dark:border-zinc-800 rounded-2xl flex justify-between items-center text-sm">
+                <div className="p-4 bg-stone-50 dark:bg-[#2a2a2a]/40 border border-zinc-100 dark:border-[#2a2a2a] rounded-2xl flex justify-between items-center text-sm">
                     <span className="font-bold text-zinc-400">예상 총 금액</span>
                     <span className="font-mono font-black dark:text-white">
                         {isUs

--- a/cf-idiotquant/components/searchAutoComplete.tsx
+++ b/cf-idiotquant/components/searchAutoComplete.tsx
@@ -168,9 +168,9 @@ const SearchAutocomplete = ({ validCorpNameArray, onSearchButton, placeHolder, o
             <div 
                 className={cn(
                     "relative flex items-center gap-2.5 w-full px-3.5 py-2 pb-1.5 rounded-2xl border transition-all duration-300 ease-in-out",
-                    "bg-zinc-100/90 dark:bg-zinc-900/90 border-zinc-200/60 dark:border-zinc-800/60 backdrop-blur-md",
+                    "bg-zinc-100/90 dark:bg-[#111111]/90 border-zinc-200/60 dark:border-[#2a2a2a]/60 backdrop-blur-md",
                     isFocused 
-                        ? "bg-white dark:bg-zinc-950 border-blue-500/80 dark:border-indigo-500/80 ring-4 ring-blue-500/10 dark:ring-indigo-500/10 shadow-lg" 
+                        ? "bg-white dark:bg-[#0d0d0d] border-blue-500/80 dark:border-indigo-500/80 ring-4 ring-blue-500/10 dark:ring-indigo-500/10 shadow-lg" 
                         : "hover:border-zinc-300 dark:hover:border-zinc-700"
                 )}
             >
@@ -217,7 +217,7 @@ const SearchAutocomplete = ({ validCorpNameArray, onSearchButton, placeHolder, o
                             if (onSearchStateChange) onSearchStateChange(isFocused, true);
                             inputRef.current?.focus();
                         }}
-                        className="p-1 hover:bg-zinc-200/60 dark:hover:bg-zinc-800/60 rounded-lg transition-colors shrink-0 group"
+                        className="p-1 hover:bg-zinc-200/60 dark:hover:bg-[#2a2a2a]/60 rounded-lg transition-colors shrink-0 group"
                         type="button"
                         aria-label="검색어 초기화"
                     >
@@ -233,10 +233,10 @@ const SearchAutocomplete = ({ validCorpNameArray, onSearchButton, placeHolder, o
                     id="search-listbox"
                     role="listbox"
                     aria-label="종목 검색 결과"
-                    className="absolute top-full mt-2 left-0 w-full bg-white/95 dark:bg-zinc-950/95 backdrop-blur-xl border border-zinc-200 dark:border-zinc-800/80 rounded-2xl shadow-2xl max-h-76 overflow-y-auto p-1.5 z-[70] animate-in fade-in zoom-in-95 duration-200 origin-top no-scrollbar"
+                    className="absolute top-full mt-2 left-0 w-full bg-white/95 dark:bg-[#0d0d0d]/95 backdrop-blur-xl border border-zinc-200 dark:border-[#2a2a2a]/80 rounded-2xl shadow-2xl max-h-76 overflow-y-auto p-1.5 z-[70] animate-in fade-in zoom-in-95 duration-200 origin-top no-scrollbar"
                 >
                     {/* 상단 라벨링 정보 바 */}
-                    <div className="px-2.5 py-1.5 text-[10px] font-black text-zinc-400 dark:text-zinc-500 uppercase tracking-widest border-b border-zinc-100 dark:border-zinc-900/50 mb-1 flex justify-between items-center sticky top-0 bg-white/90 dark:bg-zinc-950/90 backdrop-blur-md z-10">
+                    <div className="px-2.5 py-1.5 text-[10px] font-black text-zinc-400 dark:text-zinc-500 uppercase tracking-widest border-b border-zinc-100 dark:border-[#2a2a2a]/50 mb-1 flex justify-between items-center sticky top-0 bg-white/90 dark:bg-[#0d0d0d]/90 backdrop-blur-md z-10">
                         <span className="flex items-center gap-1">
                             <Sparkles className="w-3 h-3 text-blue-500 dark:text-indigo-400" />
                             퀀트 인텔리전스 추천
@@ -262,7 +262,7 @@ const SearchAutocomplete = ({ validCorpNameArray, onSearchButton, placeHolder, o
                                         "flex items-center justify-between text-xs py-2.5 px-3 cursor-pointer rounded-xl transition-all duration-150 font-medium my-0.5",
                                         isSelected
                                             ? "bg-blue-600 dark:bg-indigo-600 text-white font-bold shadow-sm translate-x-0.5"
-                                            : "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100/70 dark:hover:bg-zinc-900/70 hover:translate-x-0.5"
+                                            : "text-zinc-700 dark:text-zinc-300 hover:bg-zinc-100/70 dark:hover:bg-[#1f1f1f]/70 hover:translate-x-0.5"
                                     )}
                                 >
                                     <span className="truncate">

--- a/cf-idiotquant/components/strategyParser.tsx
+++ b/cf-idiotquant/components/strategyParser.tsx
@@ -58,7 +58,7 @@ export default function StrategyDescription({ strategyId }: StrategyDescriptionP
   if (!content) return null;
 
   return (
-    <div className="w-full rounded-2xl border border-blue-100 bg-white p-6 shadow-sm dark:border-blue-900/30 dark:bg-zinc-900 mb-6 transition-all hover:shadow-md">
+    <div className="w-full rounded-2xl border border-blue-100 bg-white p-6 shadow-sm dark:border-blue-900/30 dark:bg-[#1a1a1a] mb-6 transition-all hover:shadow-md">
       {/* 1. Header Section */}
       <div className="flex items-center gap-4 mb-6">
         <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-blue-50 text-blue-600 dark:bg-blue-900/20 dark:text-blue-400">
@@ -69,7 +69,7 @@ export default function StrategyDescription({ strategyId }: StrategyDescriptionP
             {content.title}
           </h4>
           <div className="mt-2 flex items-center gap-2">
-            <span className="inline-block px-2 py-0.5 text-[10px] font-mono font-bold bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400 rounded uppercase tracking-wider">
+            <span className="inline-block px-2 py-0.5 text-[10px] font-mono font-bold bg-zinc-100 text-zinc-500 dark:bg-[#2a2a2a] dark:text-zinc-400 rounded uppercase tracking-wider">
               {strategyId}
             </span>
           </div>
@@ -77,7 +77,7 @@ export default function StrategyDescription({ strategyId }: StrategyDescriptionP
       </div>
 
       {/* Horizontal Divider */}
-      <div className="h-px w-full bg-zinc-100 dark:bg-zinc-800 mb-6" />
+      <div className="h-px w-full bg-zinc-100 dark:bg-[#2a2a2a] mb-6" />
 
       {/* 2. Content Grid */}
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
@@ -85,7 +85,7 @@ export default function StrategyDescription({ strategyId }: StrategyDescriptionP
         {/* Left: Strategy Details (Main Content) */}
         <div className="lg:col-span-8 space-y-6">
           <section>
-            <div className="flex items-center gap-2 mb-3 text-[11px] font-black text-zinc-400 dark:text-zinc-500 uppercase tracking-widest">
+            <div className="flex items-center gap-2 mb-3 text-[11px] font-black text-zinc-400 dark:text-neutral-500 uppercase tracking-widest">
               <Search className="h-3.5 w-3.5" />
               <span>전략 메커니즘</span>
             </div>
@@ -94,7 +94,7 @@ export default function StrategyDescription({ strategyId }: StrategyDescriptionP
             </p>
           </section>
 
-          <section className="relative overflow-hidden rounded-xl bg-zinc-50 p-4 border border-zinc-100 dark:bg-zinc-800/40 dark:border-zinc-800">
+          <section className="relative overflow-hidden rounded-xl bg-stone-50 p-4 border border-zinc-100 dark:bg-[#2a2a2a]/40 dark:border-[#2a2a2a]">
             <div className="flex gap-3">
               <Info className="h-4 w-4 text-blue-500 shrink-0 mt-0.5" />
               <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-snug">
@@ -130,10 +130,10 @@ export default function StrategyDescription({ strategyId }: StrategyDescriptionP
       </div>
 
       {/* 3. Footer: Disclaimer */}
-      <div className="mt-8 pt-5 border-t border-zinc-100 dark:border-zinc-800">
+      <div className="mt-8 pt-5 border-t border-zinc-100 dark:border-[#2a2a2a]">
         <div className="flex gap-2">
           <ShieldCheck className="h-3.5 w-3.5 text-zinc-400 shrink-0 mt-0.5" />
-          <p className="text-[11px] text-zinc-400 dark:text-zinc-500 leading-relaxed italic">
+          <p className="text-[11px] text-zinc-400 dark:text-neutral-500 leading-relaxed italic">
             <span className="font-bold text-zinc-500 dark:text-zinc-400 not-italic mr-1">Disclaimer:</span>
             {content.philosophy} 본 리스트는 알고리즘에 의한 필터링 결과이며 종목 추천이 아닙니다. 모든 투자의 결과와 책임은 투자자 본인에게 귀속됩니다.
           </p>


### PR DESCRIPTION
## Summary

- PR #383(claude.ai UI 리디자인)에서 미처 교체되지 않은 `dark:bg-zinc-*` / `dark:border-zinc-*` / `dark:divide-zinc-*` 등 구 zinc 다크모드 색상을 전체 26개 파일에서 일괄 교체
- 색상 매핑: `zinc-900` → `#1a1a1a`(카드), `zinc-800` → `#2a2a2a`(패널/탭), `zinc-950` → `#0d0d0d`(페이지), `zinc-700` → `#3a3a3a`(스켈레톤)
- 계산기 인버티드 툴팁(`bg-zinc-950 text-white dark:bg-white`) 등 의도적 고대비 UI는 유지

## 변경 파일

- 페이지: `analyze`, `screener`, `calculator`, `balance-kr/us`, `login`, `not-found`, `search/page`
- 검색 컴포넌트 7개: `StockCard`, `StockHeader`, `StockMetrics`, `ValuationSection`, `SearchGuide`, `ErrorFallback`, `FinancialTables`
- 공통 컴포넌트: `searchAutoComplete`, `strategyParser`, `inquireBalanceResult`, `authButton`, `LineChart`
- Balance 컴포넌트: `shared`, `stockListTable`, `portfolioChart`, `sectionNav`

## Test plan

- [ ] 다크모드: 모든 카드/패널 배경이 `#1a1a1a`, 탭/섹션 bg가 `#2a2a2a` 계열인지 확인
- [ ] 라이트모드: 기존 흰색 카드 유지 확인
- [ ] 스크리너, 분석, 계산기, 잔고 페이지 기능 회귀 없음 확인
- [ ] TypeScript 에러 없음 (`npx tsc --noEmit` — 기존 `three` 타입 오류만 존재)

https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA)_