### PR TITLE
fix: 잔고 보유수량·매입단가 오표시 + analyze 비로그인 주가 미표시 수정

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -382,6 +382,14 @@ function AnalyzeContent() {
       (krOrUs === 'US' && data.usSearchInfo.state === 'fulfilled' && data.finnhubData.state === 'fulfilled')
     );
 
+  // 가격 정보만 필요한 섹션(StockCard·기본 지표)을 위한 조건 — 재무제표 없이도 주가·PBR·PER·EPS 표시
+  const isPriceLoaded =
+    tickerFromUrl === name &&
+    (
+      (krOrUs === 'KR' && data.kiChart.state === 'fulfilled') ||
+      (krOrUs === 'US' && data.usSearchInfo.state === 'fulfilled' && data.usDetail?.output?.last !== "")
+    );
+
   const currency = krOrUs === 'US' ? '$' : '₩';
   const isInWatchlist = useAppSelector(state => selectIsLiked(state, tickerFromUrl ?? ''));
 
@@ -396,31 +404,32 @@ function AnalyzeContent() {
   }, [krOrUs, data]);
 
   // 핵심 지표 + StockCard props 통합 (중복 계산 방지)
+  // isPriceLoaded 시점부터 가격·PBR·PER·EPS 표시. NCAV·fairValue·srimScore는 isLoaded 이후에 채워짐.
   const stockData = useMemo(() => {
-    if (!isLoaded) return null;
+    if (!isPriceLoaded) return null;
     if (krOrUs === 'KR') {
-      const ncavRatio = calculateKrNcavRatio(data.kiBS, data.kiChart);
+      const ncavRatio = isLoaded ? calculateKrNcavRatio(data.kiBS, data.kiChart) : 0;
       const pbr = Number(data?.kiPrice?.output?.pbr ?? 0);
       const per = Number(data?.kiPrice?.output?.per ?? 0);
       const eps = Number(data?.kiPrice?.output?.eps ?? 0);
       const curPrice = Number(data?.kiPrice?.output?.stck_prpr ?? 0);
-      const grade = getKrNcavGrade(data.kiBS, data.kiChart);
-      const fairValue = calculateKrNcavValue(data.kiBS, data.kiChart);
-      const srimScore = getKrSRIMTargetPrice(data.kiBS, data.kiIS, data.kiChart);
+      const grade = isLoaded ? getKrNcavGrade(data.kiBS, data.kiChart) : undefined;
+      const fairValue = isLoaded ? calculateKrNcavValue(data.kiBS, data.kiChart) : 0;
+      const srimScore = isLoaded ? getKrSRIMTargetPrice(data.kiBS, data.kiIS, data.kiChart) : undefined;
       const stockTicker = (staticStockData.corpCodeJson as any)?.[name]?.stock_code ?? '';
       return { ncavRatio, pbr, per, eps, curPrice, grade, fairValue, srimScore, stockTicker };
     } else {
-      const ncavRatio = calculateUsNcavRatio(data.finnhubData, data.usDetail);
+      const ncavRatio = isLoaded ? calculateUsNcavRatio(data.finnhubData, data.usDetail) : 0;
       const pbr = Number(data?.usDetail?.output?.pbrx ?? 0);
       const per = Number(data?.usDetail?.output?.perx ?? 0);
       const eps = Number(data?.usDetail?.output?.epsx ?? 0);
       const curPrice = Number(data?.usDetail?.output?.last ?? 0);
-      const grade = getUsNcavGrade(data.finnhubData, data.usDetail);
-      const fairValue = calculateUsNcavValue(data.finnhubData, data.usDetail);
-      const srimScore = calculateUsSRIM(data.finnhubData, data.usDetail);
+      const grade = isLoaded ? getUsNcavGrade(data.finnhubData, data.usDetail) : undefined;
+      const fairValue = isLoaded ? calculateUsNcavValue(data.finnhubData, data.usDetail) : 0;
+      const srimScore = isLoaded ? calculateUsSRIM(data.finnhubData, data.usDetail) : undefined;
       return { ncavRatio, pbr, per, eps, curPrice, grade, fairValue, srimScore, stockTicker: '' };
     }
-  }, [isLoaded, krOrUs, data, name, staticStockData.corpCodeJson]);
+  }, [isPriceLoaded, isLoaded, krOrUs, data, name, staticStockData.corpCodeJson]);
 
   if (!hasMounted) return <div className="min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]" />;
 
@@ -465,7 +474,7 @@ function AnalyzeContent() {
             />
           </div>
 
-          {isLoaded && (
+          {isPriceLoaded && (
             <div className="flex items-center gap-1.5 shrink-0 animate-in fade-in duration-200">
               <button
                 onClick={handleToggleLike}
@@ -507,7 +516,7 @@ function AnalyzeContent() {
         </div>
 
         {/* 인기 종목 + 최근 검색 */}
-        {!isLoaded && (
+        {!isPriceLoaded && (
           <div className="border-t border-neutral-100 dark:border-[#35332e]/50 bg-[#faf9f7]/50 dark:bg-[#242320]/30">
             {popularStocks.length > 0 && (
               <div className="max-w-4xl mx-auto px-4 py-2 flex items-center gap-3">
@@ -552,9 +561,9 @@ function AnalyzeContent() {
           <SearchGuide />
         ) : (
           <>
-            {waitResponse && !isLoaded && <ResultSkeleton />}
+            {waitResponse && !isPriceLoaded && <ResultSkeleton />}
 
-            <div className={cn(!isLoaded ? 'hidden' : 'animate-in fade-in duration-400')}>
+            <div className={cn(!isPriceLoaded ? 'hidden' : 'animate-in fade-in duration-400')}>
 
               {/* 종목 카드 + 핵심 지표 — 최상단 */}
               <div className="grid grid-cols-1 lg:grid-cols-12 gap-5 mb-6">
@@ -646,7 +655,8 @@ function AnalyzeContent() {
                 )}
               </div>
 
-              {/* 상세 분석 섹션 */}
+              {/* 상세 분석 섹션 — 재무제표 포함 (isLoaded 이후 표시) */}
+              {isLoaded ? (
               <div className="space-y-6">
                 <div className="flex items-center gap-3">
                   <p className="text-[11px] font-bold text-neutral-400 uppercase tracking-widest font-mono shrink-0">Detail Analysis</p>
@@ -752,6 +762,14 @@ function AnalyzeContent() {
                   </div>
                 )}
               </div>
+              ) : (
+              <div className="mt-6 space-y-4 animate-pulse">
+                <div className="h-4 bg-neutral-200 dark:bg-[#35332e] rounded w-1/3" />
+                <div className="h-64 bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e]" />
+                <div className="h-48 bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e]" />
+                <div className="h-32 bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e]" />
+              </div>
+              )}
             </div>
           </>
         )}

--- a/cf-idiotquant/components/inquireBalanceResult.tsx
+++ b/cf-idiotquant/components/inquireBalanceResult.tsx
@@ -46,8 +46,11 @@ const getFieldValue = (item: any, key: string) => {
     const map: any = {
         name: item.prdt_name || item.ovrs_item_name || item.itms_nm,
         price: item.prpr || item.ovrs_now_pric1 || 0,
-        avg_price: item.pchs_avg_pric || item.pchs_avg_pric1 || 0,
-        qty: item.hldg_qty || item.cblc_qty13 || item.ccld_qty_smtl1 || 0,
+        // US presentBalance: avg_unpr3 / KR balance: pchs_avg_pric
+        avg_price: item.pchs_avg_pric || item.pchs_avg_pric1 || item.avg_unpr3 || 0,
+        // KR balance: hldg_qty / US presentBalance: cblc_qty13 (잔고수량)
+        // ccld_qty_smtl1은 체결수량합계(실행된 거래량)로 보유수량이 아님 — 폴백에서 제거
+        qty: item.hldg_qty || item.cblc_qty13 || 0,
         evlu_amt: item.evlu_amt || item.frcr_evlu_amt2 || 0,
         profit_rt: item.evlu_pfls_rt || item.evlu_pfls_rt1 || 0,
         pchs_amt: item.pchs_amt || item.frcr_pchs_amt || 0,


### PR DESCRIPTION
## Summary

### 1. 잔고 화면 보유수량·매입단가 오표시 수정 (`inquireBalanceResult.tsx`)

- **보유수량(`qty`) 오표시 수정**: `getFieldValue` 폴백 체인에서 `ccld_qty_smtl1`(체결수량합계) 제거
  - 해당 필드는 당일 실행된 거래량 합계로 **보유수량이 아님**
  - `cblc_qty13`(US 잔고수량)이 `""` 또는 미결제 상태 `"0"`일 때 엉뚱한 숫자로 폴백되던 근본 원인
  - 수정 후: `item.hldg_qty || item.cblc_qty13 || 0`

- **미국 매입단가(`avg_price`) 항상 0 표시 수정**: `avg_unpr3` 추가
  - US `presentBalance` API 응답에 `pchs_avg_pric`, `pchs_avg_pric1` 필드 없음
  - 올바른 필드 `avg_unpr3`(매입평균단가)가 누락되어 미국 잔고에서 매입단가가 항상 ₩0으로 표시되던 문제 해결

### 2. analyze 페이지 비로그인 주가 미표시 수정 (`analyze/page.tsx`)

- **근본 원인**: 기존 `isLoaded`가 가격 API와 재무제표 API(KR: `kiBS`, US: `finnhubData`) 둘 다 fulfilled 되어야 주가를 표시했음. 재무 API가 느리거나 실패하면 주가도 함께 숨겨짐.

- **수정**: `isPriceLoaded` 조건 분리
  - KR: `kiChart.state === 'fulfilled'` (차트+현재가만 확인)
  - US: `usSearchInfo.state === 'fulfilled' && usDetail.output.last !== ""` (가격 API 응답 확인)

- **동작 변화**:
  - 가격 API 응답 즉시 → StockCard + PBR/PER/EPS 카드 표시
  - NCAV·fair value·S-RIM은 재무 API 로드 후 점진적으로 채워짐 (`isLoaded` 이후)
  - 상세 분석 섹션(StockMetrics, ValuationSection, DelistingRisk, 재무제표)은 `isLoaded` 이후 렌더링, 그 전에는 스켈레톤 표시

## 영향 파일

- `cf-idiotquant/components/inquireBalanceResult.tsx`
- `cf-idiotquant/app/(analyze)/analyze/page.tsx`

## Test plan

- [ ] balance-kr 잔고 탭 → 보유수량이 실제 보유 주수와 일치하는지 확인
- [ ] balance-us 잔고 탭 → 보유수량 및 매입단가(`avg_unpr3`) 정상 표시 확인
- [ ] 모바일 카드뷰 및 데스크탑 테이블뷰 모두 확인
- [ ] 비로그인 상태에서 analyze 페이지 종목 검색 → StockCard·현재가·PBR/PER/EPS 즉시 표시 확인
- [ ] 재무 데이터 로드 완료 후 NCAV 업사이드 카드 채워지는지 확인
- [ ] 로그인 상태에서 기존과 동일하게 전체 분석 정상 표시 확인

https://claude.ai/code/session_01PnsUZLnieE8f23GUv391qA