### PR TITLE
feat(backtest): 전략별 구간 수익률 바 차트 (PortfolioOverviewChart)

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -16,6 +16,7 @@ import {
     getScanDailyByTicker,
     getScanDailyAll,
     getPortfolioSimulation,
+    getPortfolioOverview,
 } from "@/lib/features/algorithmTrade/algorithmTradeAPI";
 import { cn } from "@/lib/utils";
 import { Loader2, History, ChevronRight, TrendingUp } from "lucide-react";
@@ -58,6 +59,13 @@ interface PortfolioResult {
     ticker_series?: TickerSeries[];
     summary: PortfolioSummary;
     note?: string;
+}
+
+interface OverviewItem {
+    date: string;
+    avg_pct: number;
+    candidate_count: number;
+    win_count: number;
 }
 
 interface DailyItem {
@@ -272,6 +280,110 @@ function DrillDown({ name, ticker, stockHistory, loading, onNavigate, entryDate,
                     </div>
                 </div>
             )}
+        </div>
+    );
+}
+
+// ─── Portfolio Overview Chart ─────────────────────────────────────────────────
+
+function PortfolioOverviewChart({ data, loading, strategy, selectedDate, onDateClick }: {
+    data: OverviewItem[];
+    loading: boolean;
+    strategy: string;
+    selectedDate: string | null;
+    onDateClick: (date: string) => void;
+}) {
+    const chartData = useMemo(() =>
+        data.map(d => ({
+            ...d,
+            label: fmtDate(d.date),
+            win_rate: d.candidate_count > 0 ? Math.round((d.win_count / d.candidate_count) * 100) : 0,
+        })),
+    [data]);
+
+    if (loading) {
+        return (
+            <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] p-5 flex items-center justify-center h-40">
+                <Loader2 size={20} className="animate-spin text-[#16a34a]/50" />
+            </div>
+        );
+    }
+
+    if (chartData.length === 0) return null;
+
+    const strategyLabel: Record<string, string> = {
+        ncav: 'NCAV', low_pbr: '저PBR', low_per: '저PER', s_rim: 'S-RIM', all: '전체',
+    };
+
+    const maxAbs = Math.max(...chartData.map(d => Math.abs(d.avg_pct)), 0.1);
+
+    return (
+        <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] shadow-sm overflow-hidden">
+            <div className="px-5 py-3.5 border-b border-neutral-100 dark:border-[#35332e] flex items-center gap-2">
+                <p className="text-sm font-black text-neutral-900 dark:text-white">구간별 수익률</p>
+                <span className="text-[10px] font-bold px-2 py-0.5 rounded bg-[#f0fdf4] dark:bg-[#052e16]/40 text-[#16a34a]">
+                    {strategyLabel[strategy] ?? strategy}
+                </span>
+                <span className="text-[10px] text-neutral-400 ml-1">기준일 매수 → 현재가 수익률</span>
+            </div>
+            <div className="px-5 pt-4 pb-3">
+                <ResponsiveContainer width="100%" height={160}>
+                    <BarChart data={chartData} margin={{ top: 16, right: 8, left: -16, bottom: 0 }}
+                        onClick={(e) => {
+                            const date = e?.activePayload?.[0]?.payload?.date;
+                            if (date) onDateClick(date);
+                        }}
+                        style={{ cursor: 'pointer' }}
+                    >
+                        <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" vertical={false} />
+                        <XAxis
+                            dataKey="label"
+                            tick={{ fontSize: 9, fill: '#9ca3af' }}
+                            axisLine={false}
+                            tickLine={false}
+                            interval="preserveStartEnd"
+                        />
+                        <YAxis
+                            tick={{ fontSize: 9, fill: '#9ca3af' }}
+                            axisLine={false}
+                            tickLine={false}
+                            width={40}
+                            domain={[-maxAbs * 1.2, maxAbs * 1.2]}
+                            tickFormatter={(v: number) => `${v >= 0 ? '+' : ''}${v.toFixed(1)}%`}
+                        />
+                        <ReferenceLine y={0} stroke="#d1d5db" strokeDasharray="4 2" />
+                        <RTooltip
+                            contentStyle={{ fontSize: 11, borderRadius: 8, border: '1px solid #e5e7eb', background: 'white' }}
+                            formatter={(v: unknown, _name: string, props: any) => {
+                                const n = Number(v);
+                                const p = props?.payload;
+                                return [
+                                    `${n >= 0 ? '+' : ''}${n.toFixed(2)}%  (${p?.candidate_count}종목, 승률 ${p?.win_rate}%)`,
+                                    '포트폴리오 수익률',
+                                ];
+                            }}
+                            labelFormatter={(label: string, payload: any[]) => {
+                                const d = payload?.[0]?.payload?.date;
+                                const isSelected = d === selectedDate;
+                                return `${label}${isSelected ? ' ★ 선택됨' : ''}`;
+                            }}
+                        />
+                        <Bar dataKey="avg_pct" radius={[3, 3, 0, 0]} maxBarSize={36}>
+                            {chartData.map((entry) => (
+                                <Cell
+                                    key={entry.date}
+                                    fill={entry.date === selectedDate
+                                        ? (entry.avg_pct >= 0 ? '#059669' : '#dc2626')
+                                        : (entry.avg_pct >= 0 ? '#4ade80' : '#fca5a5')}
+                                    stroke={entry.date === selectedDate ? (entry.avg_pct >= 0 ? '#047857' : '#b91c1c') : 'none'}
+                                    strokeWidth={entry.date === selectedDate ? 2 : 0}
+                                />
+                            ))}
+                        </Bar>
+                    </BarChart>
+                </ResponsiveContainer>
+                <p className="text-[10px] text-neutral-400 text-center mt-1">바를 클릭하면 해당 날짜를 기준일로 선택합니다</p>
+            </div>
         </div>
     );
 }
@@ -515,6 +627,8 @@ function BacktestContent() {
     const [loadingStock,         setLoadingStock]        = useState(false);
     const [portfolioResult,      setPortfolioResult]     = useState<PortfolioResult | null>(null);
     const [loadingPortfolio,     setLoadingPortfolio]    = useState(false);
+    const [overviewData,         setOverviewData]        = useState<OverviewItem[]>([]);
+    const [loadingOverview,      setLoadingOverview]     = useState(false);
 
     const dateInitialized      = useRef(false);
     const pricesLoaded         = useRef(false);
@@ -597,6 +711,18 @@ function BacktestContent() {
             .catch(() => {})
             .finally(() => setLoadingPortfolio(false));
     }, [selectedDate, activeStrategy]);
+
+    // 7. Fetch portfolio overview when strategy changes
+    useEffect(() => {
+        setLoadingOverview(true);
+        setOverviewData([]);
+        getPortfolioOverview(activeStrategy)
+            .then((res: { success?: boolean; data?: { daily?: OverviewItem[] } }) => {
+                if (res?.success && res.data?.daily) setOverviewData(res.data.daily);
+            })
+            .catch(() => {})
+            .finally(() => setLoadingOverview(false));
+    }, [activeStrategy]);
 
     // Bar chart data (chronological order)
     const chartData = useMemo(() =>
@@ -826,6 +952,18 @@ function BacktestContent() {
                                 ))}
                             </div>
                         )}
+
+                        {/* ── Portfolio Overview ── */}
+                        <PortfolioOverviewChart
+                            data={overviewData}
+                            loading={loadingOverview}
+                            strategy={activeStrategy}
+                            selectedDate={selectedDate}
+                            onDateClick={(date) => {
+                                setSelectedDate(date);
+                                setSelectedStock(null);
+                            }}
+                        />
 
                         {/* ── Portfolio Simulation ── */}
                         <PortfolioChart

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -362,7 +362,7 @@ function PortfolioOverviewChart({ data, loading, strategy, selectedDate, onDateC
                                     '포트폴리오 수익률',
                                 ];
                             }}
-                            labelFormatter={(label: string, payload: any[]) => {
+                            labelFormatter={(label: string, payload: readonly any[]) => {
                                 const d = payload?.[0]?.payload?.date;
                                 const isSelected = d === selectedDate;
                                 return `${label}${isSelected ? ' ★ 선택됨' : ''}`;

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -329,7 +329,7 @@ function PortfolioOverviewChart({ data, loading, strategy, selectedDate, onDateC
             <div className="px-5 pt-4 pb-3">
                 <ResponsiveContainer width="100%" height={160}>
                     <BarChart data={chartData} margin={{ top: 16, right: 8, left: -16, bottom: 0 }}
-                        onClick={(e) => {
+                        onClick={(e: any) => {
                             const date = e?.activePayload?.[0]?.payload?.date;
                             if (date) onDateClick(date);
                         }}

--- a/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeAPI.tsx
+++ b/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeAPI.tsx
@@ -69,6 +69,9 @@ export const getScanDailyAll = async (date: string) =>
 export const getPortfolioSimulation = async (startDate: string, strategy: string) =>
     getAlgorithmTradeRequest(`/scan/portfolio?start_date=${encodeURIComponent(startDate)}&strategy=${encodeURIComponent(strategy)}`);
 
+export const getPortfolioOverview = async (strategy: string) =>
+    getAlgorithmTradeRequest(`/scan/portfolio/overview?strategy=${encodeURIComponent(strategy)}`);
+
 async function getAlgorithmTradeRequest(subUrl: string, additionalHeaders?: AdditionalHeaders) {
     const url = `/api/proxy${subUrl}`;
     const options: RequestInit = {


### PR DESCRIPTION
## Summary

- `PortfolioOverviewChart` 컴포넌트 추가: 전략별 전체 스캔 날짜의 포트폴리오 수익률을 바 차트로 표시
- `getPortfolioOverview` API 함수 추가 (`algorithmTradeAPI.tsx`)
- 전략 탭 변경 시 자동 갱신 (useEffect #7)

### UI 구성

```
[구간별 수익률 바 차트]        ← 신규 (전략 변경 시 갱신)
  ├ 날짜별 막대: 양수 연초록, 음수 연빨강
  ├ 선택된 날짜 막대: 진한 색 + 테두리 강조
  ├ 바 클릭 → 기준일 선택 → 아래 시계열 차트 연동
  └ 툴팁: 수익률, 종목수, 승률 표시
[포트폴리오 수익률 추이 (시계열)]  ← 기존
[후보 종목 Table]
```

## Test plan

- [ ] 전략 탭 변경 시 구간 수익률 차트 자동 갱신 확인
- [ ] 바 클릭 → 해당 날짜가 기준일로 선택되고 시계열 차트 갱신 확인
- [ ] 선택된 날짜 막대 강조 표시 확인
- [ ] 양수/음수 수익률 색상 구분 확인

https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM)_