### PR TITLE
fix(backtest): PortfolioSnapshotChart 데이터 없음 케이스 개선

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -593,16 +593,22 @@ interface SnapshotEntry {
     pct: number;
 }
 
-function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, selectedDate }: {
+function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, selectedDate, fallbackCandidates }: {
     result: PortfolioResult | null;
     loading: boolean;
     strategy: string;
     currentPriceMap: Map<string, number>;
     selectedDate: string | null;
+    fallbackCandidates: { ticker: string; name: string; start_price: number }[];
 }) {
+    const effectiveCandidates = (result?.candidates?.length ?? 0) > 0
+        ? result!.candidates
+        : fallbackCandidates;
+    const effectiveCount = result?.candidate_count ?? effectiveCandidates.length;
+
     const snapshotData: SnapshotEntry[] = useMemo(() => {
-        if (!result?.candidates?.length) return [];
-        return result.candidates
+        if (!effectiveCandidates.length) return [];
+        return effectiveCandidates
             .map(c => {
                 const cur = currentPriceMap.get(c.ticker);
                 if (!cur || c.start_price <= 0) return null;
@@ -616,7 +622,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
             })
             .filter((x): x is SnapshotEntry => x !== null)
             .sort((a, b) => b.pct - a.pct);
-    }, [result, currentPriceMap]);
+    }, [effectiveCandidates, currentPriceMap]);
 
     const strategyLabel: Record<string, string> = {
         ncav: 'NCAV', low_pbr: '저PBR', low_per: '저PER', s_rim: 'S-RIM', all: '전체',
@@ -630,7 +636,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
         );
     }
 
-    if (!result || result.candidate_count === 0) {
+    if (effectiveCandidates.length === 0) {
         return (
             <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] p-5 flex items-center justify-center h-36">
                 <p className="text-xs text-neutral-400">{result?.note ?? "포트폴리오 시뮬레이션 데이터가 없습니다."}</p>
@@ -644,7 +650,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
                 <Loader2 size={16} className="animate-spin text-[#16a34a]/50 shrink-0" />
                 <div>
                     <p className="text-xs font-bold text-neutral-600 dark:text-neutral-400">
-                        {result.candidate_count}개 후보 — 최근 스캔 가격 로딩 중
+                        {effectiveCount}개 후보 — 최근 스캔 가격 로딩 중
                     </p>
                     <p className="text-[10px] text-neutral-400 mt-0.5">이후 스캔 사이클 완료 시 수익률이 표시됩니다</p>
                 </div>
@@ -683,7 +689,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
                         <p className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider">커버</p>
                         <p className="text-lg font-black font-mono tabular-nums">
                             {snapshotData.length}
-                            <span className="text-xs text-neutral-400">/{result.candidate_count}</span>
+                            <span className="text-xs text-neutral-400">/{effectiveCount}</span>
                         </p>
                     </div>
                 </div>
@@ -744,11 +750,11 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
             <div className="px-5 pb-4 grid grid-cols-3 gap-2">
                 <div className="bg-[#faf9f7] dark:bg-[#1a1915] rounded-xl p-3 text-center">
                     <p className="text-[9px] font-bold text-neutral-400 uppercase tracking-wider">후보 수</p>
-                    <p className="text-xs font-black mt-0.5">{result.candidate_count}개</p>
+                    <p className="text-xs font-black mt-0.5">{effectiveCount}개</p>
                 </div>
                 <div className="bg-[#faf9f7] dark:bg-[#1a1915] rounded-xl p-3 text-center">
                     <p className="text-[9px] font-bold text-neutral-400 uppercase tracking-wider">커버</p>
-                    <p className="text-xs font-black mt-0.5">{snapshotData.length}개 ({Math.round(snapshotData.length / result.candidate_count * 100)}%)</p>
+                    <p className="text-xs font-black mt-0.5">{snapshotData.length}개 ({Math.round(snapshotData.length / effectiveCount * 100)}%)</p>
                 </div>
                 <div className="bg-[#faf9f7] dark:bg-[#1a1915] rounded-xl p-3 text-center">
                     <p className="text-[9px] font-bold text-neutral-400 uppercase tracking-wider">승률</p>
@@ -866,6 +872,44 @@ function BacktestContent() {
             .catch(() => {})
             .finally(() => setLoadingPortfolio(false));
     }, [selectedDate, activeStrategy]);
+
+    // Fallback candidates from historicalList when portfolioResult has none
+    const fallbackCandidates = useMemo(() =>
+        historicalList
+            .filter(item => item.last_price > 0)
+            .map(item => ({ ticker: item.ticker, name: item.name, start_price: item.last_price })),
+    [historicalList]);
+
+    // Fetch prices for candidates missing from currentPriceMap
+    useEffect(() => {
+        const candidates = (portfolioResult?.candidates?.length ?? 0) > 0
+            ? portfolioResult!.candidates
+            : fallbackCandidates;
+        if (!candidates.length) return;
+        const missing = candidates.filter(c => !currentPriceMap.has(c.ticker)).slice(0, 50);
+        if (!missing.length) return;
+
+        Promise.all(
+            missing.map(c =>
+                getScanDailyByTicker(c.ticker, 1)
+                    .then((res: { data?: Record<string, unknown>[] }) => {
+                        const price = safeNum((res?.data?.[0] as any)?.last_price);
+                        return price > 0 ? [c.ticker, price] as [string, number] : null;
+                    })
+                    .catch(() => null)
+            )
+        ).then(results => {
+            const newPrices = results.filter((r): r is [string, number] => r !== null);
+            if (!newPrices.length) return;
+            setCurrentPriceMap(prev => {
+                const next = new Map(prev);
+                for (const [t, p] of newPrices) next.set(t, p);
+                return next;
+            });
+        });
+    // currentPriceMap 제외: 가격 업데이트 후 무한 루프 방지
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [portfolioResult, fallbackCandidates]);
 
     // Bar chart data (chronological order)
     const chartData = useMemo(() =>
@@ -1117,6 +1161,7 @@ function BacktestContent() {
                                 strategy={activeStrategy}
                                 currentPriceMap={currentPriceMap}
                                 selectedDate={selectedDate}
+                                fallbackCandidates={fallbackCandidates}
                             />
                         )}
 


### PR DESCRIPTION
## Summary

- **portfolioResult null/후보 없음 → historicalList fallback**: `/scan/portfolio` API가 실패하거나 해당 날짜의 전략 후보가 0개일 때, `historicalList`(기준일 스캔 결과)를 `fallbackCandidates`로 사용하여 종목별 수익률 스냅샷을 표시
- **currentPriceMap 보충**: `portfolioResult` 또는 `fallbackCandidates` 변경 시, `currentPriceMap`에 없는 후보 ticker를 `/scan/daily/ticker/:ticker?limit=1`로 개별 조회하여 가격 데이터 보완 (최대 50개 병렬)
- **empty state 조건 변경**: "포트폴리오 시뮬레이션 데이터가 없습니다" 표시 조건을 `effectiveCandidates.length === 0`으로 수정 — portfolio API 실패 시에도 historicalList에 종목이 있으면 스냅샷 표시

## 근본 원인

1. **포트폴리오 API 실패 시** (`!result || candidate_count === 0`) → historicalList에 종목이 있어도 즉시 "데이터 없음" 메시지 표시
2. **currentPriceMap 커버리지 부족** → 역사적 NCAV 후보가 오늘 스캔에서 PER/PBR=0으로 스킵되면 `currentPriceMap`에 없어 가격 계산 불가

## 동작 분기 (변경 후)

| 상황 | 기존 | 변경 후 |
|---|---|---|
| portfolioResult=null | "데이터가 없습니다" | historicalList 후보 + currentPriceMap 표시 |
| candidate_count=0 | "데이터가 없습니다" | historicalList 후보 + currentPriceMap 표시 |
| 후보 있으나 currentPriceMap 미보유 | "가격 로딩 중" 스피너 무한 | 개별 ticker 조회 후 가격 보충 → 스냅샷 표시 |
| 진정한 데이터 없음 (historicalList도 빈 경우) | "데이터가 없습니다" | "데이터가 없습니다" (동일) |

## Test plan

- [ ] 포트폴리오 API 실패 날짜 선택 → "데이터 없음" 대신 historicalList 기준 스냅샷 표시 확인
- [ ] candidate_count=0인 날짜에서 historicalList 후보 기반 표시 확인
- [ ] currentPriceMap에 없는 종목이 포함된 경우, `/scan/daily/ticker/:ticker` 개별 조회 후 수익률 표시 확인
- [ ] 기존 정상 동작(time_series >= 2) 변경 없음 확인
- [ ] `npx tsc --noEmit` 타입 오류 없음 확인

https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM)_