### PR TITLE
feat(backtest): 전략 필터 UI 통합 + 필터 조건 뷰어 반영

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -702,7 +702,7 @@ interface SnapshotEntry {
     pct: number;
 }
 
-function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, selectedDate, fallbackCandidates, currentLstnMap, splitAdjusted }: {
+function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, selectedDate, fallbackCandidates, currentLstnMap, splitAdjusted, filteredTickers }: {
     result: PortfolioResult | null;
     loading: boolean;
     strategy: string;
@@ -711,10 +711,18 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
     fallbackCandidates: { ticker: string; name: string; start_price: number; start_market_cap?: number }[];
     currentLstnMap: Map<string, number>;
     splitAdjusted: boolean;
+    filteredTickers: Set<string>;
 }) {
-    const effectiveCandidates = (result?.candidates?.length ?? 0) > 0
-        ? result!.candidates
-        : fallbackCandidates;
+    // portfolioResult.candidates 가 있으면 filteredTickers 로 교차 필터, 없으면 fallbackCandidates(이미 filteredList 기반)
+    const effectiveCandidates = useMemo(() => {
+        if ((result?.candidates?.length ?? 0) > 0) {
+            // 필터가 전체를 포함하는 경우(no-op) vs 일부를 제외하는 경우 모두 처리
+            return result!.candidates.filter(c => filteredTickers.has(c.ticker));
+        }
+        return fallbackCandidates;
+    }, [result, fallbackCandidates, filteredTickers]);
+
+    // 전체 후보 수는 원본 API 값 우선, fallback 시 filteredList 기준
     const effectiveCount = result?.candidate_count ?? effectiveCandidates.length;
 
     const snapshotData: SnapshotEntry[] = useMemo(() => {
@@ -1002,44 +1010,6 @@ function BacktestContent() {
             .finally(() => setLoadingPortfolio(false));
     }, [selectedDate, activeStrategy]);
 
-    // Fallback candidates from historicalList when portfolioResult has none
-    const fallbackCandidates = useMemo(() =>
-        historicalList
-            .filter(item => item.last_price > 0)
-            .map(item => ({ ticker: item.ticker, name: item.name, start_price: item.last_price, start_market_cap: item.market_cap })),
-    [historicalList]);
-
-    // Fetch prices for candidates missing from currentPriceMap
-    useEffect(() => {
-        const candidates = (portfolioResult?.candidates?.length ?? 0) > 0
-            ? portfolioResult!.candidates
-            : fallbackCandidates;
-        if (!candidates.length) return;
-        const missing = candidates.filter(c => !currentPriceMap.has(c.ticker)).slice(0, 50);
-        if (!missing.length) return;
-
-        Promise.all(
-            missing.map(c =>
-                getScanDailyByTicker(c.ticker, 1)
-                    .then((res: { data?: Record<string, unknown>[] }) => {
-                        const price = safeNum((res?.data?.[0] as any)?.last_price);
-                        return price > 0 ? [c.ticker, price] as [string, number] : null;
-                    })
-                    .catch(() => null)
-            )
-        ).then(results => {
-            const newPrices = results.filter((r): r is [string, number] => r !== null);
-            if (!newPrices.length) return;
-            setCurrentPriceMap(prev => {
-                const next = new Map(prev);
-                for (const [t, p] of newPrices) next.set(t, p);
-                return next;
-            });
-        });
-    // currentPriceMap 제외: 가격 업데이트 후 무한 루프 방지
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [portfolioResult, fallbackCandidates]);
-
     // Bar chart data (chronological order)
     const chartData = useMemo(() =>
         [...datesState.dates].reverse().map(d => ({ ...d, label: fmtDate(d.scan_date) })),
@@ -1051,7 +1021,7 @@ function BacktestContent() {
         && datesState.dates.length > 0
         && selectedDate === datesState.dates[0].scan_date;
 
-    // Filtered list
+    // Filtered list — 모든 필터 조건 적용
     const filteredList = useMemo(() => {
         let list = historicalList;
         if (searchQuery.trim()) {
@@ -1101,6 +1071,47 @@ function BacktestContent() {
         }
         return list;
     }, [historicalList, searchQuery, filterStrategies, filterStrategyMode, minMarketCap, excludeHoldings, excludeDeficit, excludeDelisted, filterNcav, filterReturn, filterPbr, filterPer, isLatestDate, currentPriceMap, splitAdjusted, currentLstnMap]);
+
+    // Fallback candidates — filteredList 기반으로 필터 조건 반영
+    const fallbackCandidates = useMemo(() =>
+        filteredList
+            .filter(item => item.last_price > 0)
+            .map(item => ({ ticker: item.ticker, name: item.name, start_price: item.last_price, start_market_cap: item.market_cap })),
+    [filteredList]);
+
+    // 필터 적용 ticker set (portfolioResult.candidates 교차 필터링에 사용)
+    const filteredTickers = useMemo(() => new Set(filteredList.map(i => i.ticker)), [filteredList]);
+
+    // Fetch prices for candidates missing from currentPriceMap
+    useEffect(() => {
+        const candidates = (portfolioResult?.candidates?.length ?? 0) > 0
+            ? portfolioResult!.candidates
+            : fallbackCandidates;
+        if (!candidates.length) return;
+        const missing = candidates.filter(c => !currentPriceMap.has(c.ticker)).slice(0, 50);
+        if (!missing.length) return;
+
+        Promise.all(
+            missing.map(c =>
+                getScanDailyByTicker(c.ticker, 1)
+                    .then((res: { data?: Record<string, unknown>[] }) => {
+                        const price = safeNum((res?.data?.[0] as any)?.last_price);
+                        return price > 0 ? [c.ticker, price] as [string, number] : null;
+                    })
+                    .catch(() => null)
+            )
+        ).then(results => {
+            const newPrices = results.filter((r): r is [string, number] => r !== null);
+            if (!newPrices.length) return;
+            setCurrentPriceMap(prev => {
+                const next = new Map(prev);
+                for (const [t, p] of newPrices) next.set(t, p);
+                return next;
+            });
+        });
+    // currentPriceMap 제외: 가격 업데이트 후 무한 루프 방지
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [portfolioResult, fallbackCandidates]);
 
     // Sorted table rows
     const sortedList = useMemo(() => {
@@ -1622,6 +1633,7 @@ function BacktestContent() {
                                 fallbackCandidates={fallbackCandidates}
                                 currentLstnMap={currentLstnMap}
                                 splitAdjusted={splitAdjusted}
+                                filteredTickers={filteredTickers}
                             />
                         </> /* end 스냅샷 탭 */
                         )}

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -138,6 +138,11 @@ const MKTCAP_PRESETS = [
     { label: '5000억+', value: 5_000 },
 ];
 
+// 상단 바에 노출하는 클라이언트 전용 추가 전략 (백엔드 4종 제외)
+const EXTRA_STRATEGY_PRESETS = STRATEGY_PRESETS_CLIENT.filter(
+    p => !['ncav', 'low_pbr', 'low_per', 's_rim'].includes(p.id)
+);
+
 const safeNum = (v: unknown): number => {
     const n = Number(v);
     return isNaN(n) ? 0 : n;
@@ -1243,6 +1248,57 @@ function BacktestContent() {
                             </button>
                         );
                     })}
+
+                    {/* 구분선 */}
+                    <div className="w-px h-5 bg-neutral-200 dark:bg-[#4a4641] mx-1 shrink-0" />
+
+                    {/* 클라이언트 전용 추가 전략 필터 */}
+                    {EXTRA_STRATEGY_PRESETS.map(preset => {
+                        const isActive = filterStrategies.has(preset.id);
+                        const count = strategyCounts[preset.id] ?? 0;
+                        return (
+                            <button
+                                key={preset.id}
+                                onClick={() => toggleStrategy(preset.id)}
+                                title={preset.hint}
+                                className={cn(
+                                    "shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-bold border transition-all whitespace-nowrap",
+                                    isActive
+                                        ? cn(STRATEGY_BADGE[preset.id], 'border-current shadow-sm')
+                                        : "border-neutral-200 dark:border-[#3a3834] text-neutral-600 dark:text-neutral-400 hover:border-neutral-300 dark:hover:border-neutral-600 bg-white dark:bg-[#242320]"
+                                )}
+                            >
+                                {preset.label}
+                                <span className="text-[10px] font-mono opacity-60">{count}</span>
+                            </button>
+                        );
+                    })}
+
+                    {/* AND / OR 토글 — 2개 이상 선택 시 */}
+                    {filterStrategies.size >= 2 && (
+                        <div className="flex rounded-lg border border-neutral-200 dark:border-[#3a3834] overflow-hidden shrink-0">
+                            {(['OR', 'AND'] as const).map(mode => (
+                                <button
+                                    key={mode}
+                                    onClick={() => setFilterStrategyMode(mode)}
+                                    className={cn(
+                                        "px-2 py-1 text-[10px] font-bold transition-colors",
+                                        filterStrategyMode === mode
+                                            ? "bg-[#16a34a] text-white"
+                                            : "text-neutral-400 dark:text-neutral-500 hover:text-neutral-600"
+                                    )}
+                                >{mode}</button>
+                            ))}
+                        </div>
+                    )}
+
+                    {/* 전략 초기화 */}
+                    {filterStrategies.size > 0 && (
+                        <button
+                            onClick={() => setFilterStrategies(new Set())}
+                            className="shrink-0 text-[10px] text-neutral-400 hover:text-[#16a34a] dark:hover:text-[#16a34a] px-1"
+                        >초기화</button>
+                    )}
                 </div>
             </div>
 
@@ -1314,55 +1370,6 @@ function BacktestContent() {
                             const resetAll = () => { setFilterStrategies(new Set()); setMinMarketCap(0); setExcludeHoldings(false); setExcludeDeficit(false); setExcludeDelisted(false); setSearchQuery(''); setFilterNcav('all'); setFilterReturn('all'); setFilterPbr('all'); setFilterPer('all'); };
                             return (
                             <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] shadow-sm overflow-hidden">
-                                {/* ── 전략 멀티선택 ── */}
-                                <div className="px-5 sm:px-6 pt-4 pb-3 border-b border-neutral-100 dark:border-[#35332e]">
-                                    <div className="flex items-center gap-2 flex-wrap">
-                                        <span className="text-[10px] font-extrabold text-neutral-400 uppercase tracking-wider shrink-0">전략</span>
-                                        {STRATEGY_PRESETS_CLIENT.map(preset => {
-                                            const isActive = filterStrategies.has(preset.id);
-                                            const count = strategyCounts[preset.id] ?? 0;
-                                            return (
-                                                <button
-                                                    key={preset.id}
-                                                    onClick={() => toggleStrategy(preset.id)}
-                                                    title={preset.hint}
-                                                    className={cn(
-                                                        "flex items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-bold border transition-all",
-                                                        isActive
-                                                            ? cn(STRATEGY_BADGE[preset.id], 'border-current')
-                                                            : "border-neutral-200 dark:border-[#35332e] text-neutral-500 dark:text-neutral-400 hover:border-neutral-300 dark:hover:border-neutral-500 bg-white dark:bg-transparent"
-                                                    )}
-                                                >
-                                                    {preset.label}
-                                                    <span className="text-[9px] font-mono opacity-70">{count}</span>
-                                                </button>
-                                            );
-                                        })}
-                                        {filterStrategies.size >= 2 && (
-                                            <div className="flex rounded-lg border border-neutral-200 dark:border-[#35332e] overflow-hidden">
-                                                {(['OR', 'AND'] as const).map(mode => (
-                                                    <button
-                                                        key={mode}
-                                                        onClick={() => setFilterStrategyMode(mode)}
-                                                        className={cn(
-                                                            "px-2 py-1 text-[10px] font-bold transition-colors",
-                                                            filterStrategyMode === mode
-                                                                ? "bg-[#16a34a] text-white"
-                                                                : "text-neutral-400 dark:text-neutral-500 hover:text-neutral-600"
-                                                        )}
-                                                    >{mode}</button>
-                                                ))}
-                                            </div>
-                                        )}
-                                        {filterStrategies.size > 0 && (
-                                            <button
-                                                onClick={() => setFilterStrategies(new Set())}
-                                                className="text-[10px] text-neutral-400 hover:text-[#16a34a] dark:hover:text-[#16a34a] ml-0.5"
-                                            >초기화</button>
-                                        )}
-                                    </div>
-                                </div>
-
                                 {/* ── 수치 필터 바 ── */}
                                 <div className="px-5 sm:px-6 py-3 flex flex-wrap items-center gap-2">
                                     {/* 검색 */}


### PR DESCRIPTION
## Summary

### 1. 전략 필터 UI를 상단 고정 바로 통합

- 필터 바에서 전략 멀티선택 섹션 제거
- 상단 고정 바(sticky top bar)에 구분선(`|`) 추가 후, 5개 클라이언트 전략 필터 버튼 추가:
  | 전략 | 조건 |
  |---|---|
  | 그레이엄 | PER × PBR < 22.5 |
  | 마법공식 | PER < 15 & ROE > 10% |
  | 퀄리티 | ROE > 15% & PBR < 2.0 |
  | NCAV근접 | NCAV 0.7~1.0 |
  | 균형가치 | PER 5~15 & PBR < 1.5 & EPS > 0 |
- 기존 4개 백엔드 전략(NCAV/저PBR/저PER/S-RIM)은 좌측 유지
- 2개 이상 선택 시 AND/OR 토글, 초기화 버튼도 상단 바에 표시
- 필터 바는 수치 필터(검색/NCAV/수익률/PBR/PER)와 고급 패널만 표시

### 2. 필터 조건을 스냅샷/포트폴리오 뷰어에 반영

- `fallbackCandidates`를 `historicalList` → `filteredList` 기반으로 변경
- `filteredTickers` Set 추가: 필터 적용 후 남은 ticker 집합
- `PortfolioSnapshotChart`에 `filteredTickers` prop 추가 → `portfolioResult.candidates`를 필터된 ticker와 교차하여 표시
- 필터 조건이 포트폴리오/스냅샷 탭의 종목 목록 및 수익률 계산에 반영됨

## Test plan

- [ ] 상단 바에서 전략 버튼 클릭 시 종목 목록 / 스냅샷 탭 필터 반영 확인
- [ ] 2개 이상 전략 선택 시 AND/OR 토글 상단 바에 표시 확인
- [ ] 전략 초기화 버튼 동작 확인
- [ ] 필터 바에 전략 섹션 없이 수치 필터만 표시 확인
- [ ] 필터 조건(전략/시가총액/제외 등) 변경 시 스냅샷 탭 종목 목록에 반영 확인
- [ ] 필터 바 "전체 초기화" 클릭 시 전략 필터도 함께 초기화 확인

https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM)_