### PR TITLE
refactor(backtest): strategy=all 전체 fetch + UI 구조 개선

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -138,10 +138,6 @@ const MKTCAP_PRESETS = [
     { label: '5000억+', value: 5_000 },
 ];
 
-// 상단 바에 노출하는 클라이언트 전용 추가 전략 (백엔드 4종 제외)
-const EXTRA_STRATEGY_PRESETS = STRATEGY_PRESETS_CLIENT.filter(
-    p => !['ncav', 'low_pbr', 'low_per', 's_rim'].includes(p.id)
-);
 
 const safeNum = (v: unknown): number => {
     const n = Number(v);
@@ -902,7 +898,7 @@ function BacktestContent() {
     const datesState  = useAppSelector(selectNcavDailyDates);
 
     const [selectedDate,        setSelectedDate]        = useState<string | null>(null);
-    const [activeStrategy,      setActiveStrategy]      = useState<StrategyId>('ncav');
+    const [portfolioStrategy,   setPortfolioStrategy]   = useState<StrategyId>('ncav');
     const [historicalList,      setHistoricalList]      = useState<DailyItem[]>([]);
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
@@ -967,12 +963,12 @@ function BacktestContent() {
         }
     }, [datesState.state, datesState.dates]);
 
-    // 4. Fetch historical list when date or strategy changes
+    // 4. Fetch historical list when date changes (always fetch all strategies)
     useEffect(() => {
         if (!selectedDate) return;
         setLoadingList(true);
         setSelectedStock(null);
-        getScanDailyList(selectedDate, activeStrategy)
+        getScanDailyList(selectedDate, 'all')
             .then((res: { data?: Record<string, unknown>[] }) => {
                 const raw = res?.data ?? [];
                 setHistoricalList(raw.map(item => ({
@@ -982,7 +978,7 @@ function BacktestContent() {
             })
             .catch(() => setHistoricalList([]))
             .finally(() => setLoadingList(false));
-    }, [selectedDate, activeStrategy]);
+    }, [selectedDate]);
 
     // 5. Fetch individual stock history on drill-down
     useEffect(() => {
@@ -1002,25 +998,27 @@ function BacktestContent() {
             .finally(() => setLoadingStock(false));
     }, [selectedStock]);
 
-    // 6. Fetch portfolio simulation when date or strategy changes
+    // 6. Fetch portfolio simulation when date or portfolioStrategy changes
     useEffect(() => {
         if (!selectedDate) return;
         setPortfolioResult(null);
         setLoadingPortfolio(true);
-        getPortfolioSimulation(selectedDate, activeStrategy)
+        getPortfolioSimulation(selectedDate, portfolioStrategy)
             .then((res: { success?: boolean; data?: PortfolioResult }) => {
                 if (res?.success && res.data) setPortfolioResult(res.data);
             })
             .catch(() => {})
             .finally(() => setLoadingPortfolio(false));
-    }, [selectedDate, activeStrategy]);
+    }, [selectedDate, portfolioStrategy]);
 
-    // Bar chart data (chronological order)
+    // Bar chart data (chronological order, total_cnt = rough sum across strategies)
     const chartData = useMemo(() =>
-        [...datesState.dates].reverse().map(d => ({ ...d, label: fmtDate(d.scan_date) })),
+        [...datesState.dates].reverse().map(d => ({
+            ...d,
+            label: fmtDate(d.scan_date),
+            total_cnt: (d.ncav_cnt ?? 0) + (d.low_pbr_cnt ?? 0) + (d.low_per_cnt ?? 0) + (d.s_rim_cnt ?? 0),
+        })),
     [datesState.dates]);
-
-    const activeTab = STRATEGY_TABS.find(t => t.id === activeStrategy) ?? STRATEGY_TABS[0];
 
     const isLatestDate = selectedDate !== null
         && datesState.dates.length > 0
@@ -1221,36 +1219,6 @@ function BacktestContent() {
                 </div>
             </div>
 
-            {/* ── Strategy Tabs (sticky) ── */}
-            <div className="sticky top-0 z-30 bg-white/95 dark:bg-[#1f1e1b]/95 backdrop-blur-md border-b border-neutral-200 dark:border-[#3a3834]">
-                <div className="max-w-7xl mx-auto px-4 sm:px-6 py-3 flex items-center gap-1.5 overflow-x-auto no-scrollbar">
-                    {STRATEGY_TABS.map(tab => {
-                        const isActive = tab.id === activeStrategy;
-                        const latestCnt = datesState.dates[0]?.[tab.cntKey] ?? 0;
-                        return (
-                            <button
-                                key={tab.id}
-                                onClick={() => setActiveStrategy(tab.id)}
-                                className={cn(
-                                    "shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold border transition-all whitespace-nowrap shadow-sm",
-                                    isActive
-                                        ? tab.activeCls
-                                        : "border-neutral-200 dark:border-[#3a3834] text-neutral-600 dark:text-neutral-400 hover:border-neutral-300 dark:hover:border-neutral-600 bg-white dark:bg-[#242320]"
-                                )}
-                            >
-                                {tab.label}
-                                <span className={cn(
-                                    "text-[10px] font-black px-1.5 py-0.5 rounded-full",
-                                    isActive ? "bg-white/20 dark:bg-black/20" : "bg-[#faf9f7] dark:bg-[#4a4641] text-neutral-500"
-                                )}>
-                                    {latestCnt}
-                                </span>
-                            </button>
-                        );
-                    })}
-                </div>
-            </div>
-
             <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 space-y-6 pb-24">
 
                 {/* Loading state */}
@@ -1282,11 +1250,11 @@ function BacktestContent() {
                             const resetAll = () => { setFilterStrategies(new Set()); setMinMarketCap(0); setExcludeHoldings(false); setExcludeDeficit(false); setExcludeDelisted(false); setSearchQuery(''); setFilterNcav('all'); setFilterReturn('all'); setFilterPbr('all'); setFilterPer('all'); };
                             return (
                             <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] shadow-sm overflow-hidden">
-                                {/* ── 추가 전략 필터 ── */}
+                                {/* ── 전략 필터 (전체 9종) ── */}
                                 <div className="px-5 sm:px-6 pt-4 pb-3 border-b border-neutral-100 dark:border-[#35332e]">
                                     <div className="flex items-center gap-2 flex-wrap">
                                         <span className="text-[10px] font-extrabold text-neutral-400 uppercase tracking-wider shrink-0">전략</span>
-                                        {EXTRA_STRATEGY_PRESETS.map(preset => {
+                                        {STRATEGY_PRESETS_CLIENT.map(preset => {
                                             const isActive = filterStrategies.has(preset.id);
                                             const count = strategyCounts[preset.id] ?? 0;
                                             return (
@@ -1517,7 +1485,7 @@ function BacktestContent() {
                         {/* ── Bar Chart ── */}
                         <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] p-5 shadow-sm">
                             <p className="text-xs font-bold text-neutral-500 dark:text-neutral-400 uppercase tracking-wider mb-4">
-                                일별 후보 수 추이 — {activeTab.label}
+                                일별 후보 수 추이 (전략 합산)
                             </p>
                             <ResponsiveContainer width="100%" height={200}>
                                 <BarChart data={chartData} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
@@ -1536,7 +1504,7 @@ function BacktestContent() {
                                         labelFormatter={(label: string) => label}
                                     />
                                     <Bar
-                                        dataKey={activeTab.cntKey as string}
+                                        dataKey="total_cnt"
                                         radius={[3, 3, 0, 0]}
                                         cursor="pointer"
                                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -1545,7 +1513,7 @@ function BacktestContent() {
                                         {chartData.map(entry => (
                                             <Cell
                                                 key={entry.scan_date}
-                                                fill={entry.scan_date === selectedDate ? activeTab.barColor : '#d4c9b4'}
+                                                fill={entry.scan_date === selectedDate ? '#16a34a' : '#d4c9b4'}
                                             />
                                         ))}
                                     </Bar>
@@ -1597,15 +1565,33 @@ function BacktestContent() {
                         {/* ── 포트폴리오 탭 ── */}
                         {viewTab === 'portfolio' && (
                         <>
+                            {/* 포트폴리오 시뮬레이션 전략 선택 */}
+                            <div className="flex items-center gap-2 flex-wrap">
+                                <span className="text-[10px] font-extrabold text-neutral-400 uppercase tracking-wider shrink-0">시뮬레이션 전략</span>
+                                {STRATEGY_TABS.map(tab => (
+                                    <button
+                                        key={tab.id}
+                                        onClick={() => setPortfolioStrategy(tab.id)}
+                                        className={cn(
+                                            "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold border transition-all whitespace-nowrap",
+                                            portfolioStrategy === tab.id
+                                                ? tab.activeCls
+                                                : "border-neutral-200 dark:border-[#35332e] text-neutral-600 dark:text-neutral-400 hover:border-neutral-300 dark:hover:border-neutral-600 bg-white dark:bg-[#242320]"
+                                        )}
+                                    >
+                                        {tab.label}
+                                    </button>
+                                ))}
+                            </div>
                             <PortfolioOverviewChart
                                 result={portfolioResult}
                                 loading={loadingPortfolio}
-                                strategy={activeStrategy}
+                                strategy={portfolioStrategy}
                             />
                             <PortfolioChart
                                 result={portfolioResult}
                                 loading={loadingPortfolio}
-                                strategy={activeStrategy}
+                                strategy={portfolioStrategy}
                             />
                             {/* 시계열 데이터 부족 시 안내 (스냅샷과 구분) */}
                             {!loadingPortfolio && (portfolioResult?.time_series?.length ?? 0) < 2 && (portfolioResult?.candidate_count ?? 0) > 0 && (
@@ -1631,7 +1617,7 @@ function BacktestContent() {
                             <PortfolioSnapshotChart
                                 result={portfolioResult}
                                 loading={loadingPortfolio}
-                                strategy={activeStrategy}
+                                strategy={portfolioStrategy}
                                 currentPriceMap={currentPriceMap}
                                 selectedDate={selectedDate}
                                 fallbackCandidates={fallbackCandidates}
@@ -1671,7 +1657,7 @@ function BacktestContent() {
                                 </div>
                             ) : historicalList.length === 0 ? (
                                 <p className="text-center py-14 text-sm text-neutral-400">
-                                    해당 날짜의 {activeTab.label} 후보 데이터가 없습니다.
+                                    해당 날짜의 후보 데이터가 없습니다.
                                 </p>
                             ) : filteredList.length === 0 ? (
                                 <p className="text-center py-14 text-sm text-neutral-400">

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1248,57 +1248,6 @@ function BacktestContent() {
                             </button>
                         );
                     })}
-
-                    {/* 구분선 */}
-                    <div className="w-px h-5 bg-neutral-200 dark:bg-[#4a4641] mx-1 shrink-0" />
-
-                    {/* 클라이언트 전용 추가 전략 필터 */}
-                    {EXTRA_STRATEGY_PRESETS.map(preset => {
-                        const isActive = filterStrategies.has(preset.id);
-                        const count = strategyCounts[preset.id] ?? 0;
-                        return (
-                            <button
-                                key={preset.id}
-                                onClick={() => toggleStrategy(preset.id)}
-                                title={preset.hint}
-                                className={cn(
-                                    "shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-bold border transition-all whitespace-nowrap",
-                                    isActive
-                                        ? cn(STRATEGY_BADGE[preset.id], 'border-current shadow-sm')
-                                        : "border-neutral-200 dark:border-[#3a3834] text-neutral-600 dark:text-neutral-400 hover:border-neutral-300 dark:hover:border-neutral-600 bg-white dark:bg-[#242320]"
-                                )}
-                            >
-                                {preset.label}
-                                <span className="text-[10px] font-mono opacity-60">{count}</span>
-                            </button>
-                        );
-                    })}
-
-                    {/* AND / OR 토글 — 2개 이상 선택 시 */}
-                    {filterStrategies.size >= 2 && (
-                        <div className="flex rounded-lg border border-neutral-200 dark:border-[#3a3834] overflow-hidden shrink-0">
-                            {(['OR', 'AND'] as const).map(mode => (
-                                <button
-                                    key={mode}
-                                    onClick={() => setFilterStrategyMode(mode)}
-                                    className={cn(
-                                        "px-2 py-1 text-[10px] font-bold transition-colors",
-                                        filterStrategyMode === mode
-                                            ? "bg-[#16a34a] text-white"
-                                            : "text-neutral-400 dark:text-neutral-500 hover:text-neutral-600"
-                                    )}
-                                >{mode}</button>
-                            ))}
-                        </div>
-                    )}
-
-                    {/* 전략 초기화 */}
-                    {filterStrategies.size > 0 && (
-                        <button
-                            onClick={() => setFilterStrategies(new Set())}
-                            className="shrink-0 text-[10px] text-neutral-400 hover:text-[#16a34a] dark:hover:text-[#16a34a] px-1"
-                        >초기화</button>
-                    )}
                 </div>
             </div>
 
@@ -1327,49 +1276,60 @@ function BacktestContent() {
 
                 {!datesLoading && datesState.dates.length > 0 && (
                     <>
-                        {/* ── View Tabs ── */}
-                        <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'snapshot', 'stocks'] as const).map(tab => {
-                                const labels = { history: '히스토리', portfolio: '포트폴리오', snapshot: '스냅샷', stocks: '종목 목록' };
-                                return (
-                                    <button
-                                        key={tab}
-                                        onClick={() => setViewTab(tab)}
-                                        className={cn(
-                                            "px-4 pb-3 pt-1 text-sm font-bold border-b-2 transition-colors whitespace-nowrap",
-                                            viewTab === tab
-                                                ? "border-[#16a34a] text-[#16a34a]"
-                                                : "border-transparent text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
-                                        )}
-                                    >
-                                        {labels[tab]}
-                                    </button>
-                                );
-                            })}
-                            {/* 병합조정 토글 — 비최신일 + 현재가 로드됐을 때만 표시 */}
-                            {!isLatestDate && !loadingCurrentPrices && currentPriceMap.size > 0 && (
-                                <div className="ml-auto pb-2 flex items-center gap-1.5">
-                                    <button
-                                        onClick={() => setSplitAdjusted(p => !p)}
-                                        className={cn(
-                                            "text-[10px] font-bold px-2.5 py-1 rounded-lg border transition-colors",
-                                            splitAdjusted
-                                                ? "border-amber-400 text-amber-600 bg-amber-50 dark:bg-amber-950/30 dark:text-amber-400 dark:border-amber-500"
-                                                : "border-neutral-200 dark:border-[#35332e] text-neutral-400 hover:border-neutral-300"
-                                        )}
-                                    >
-                                        병합조정 {splitAdjusted ? 'ON' : 'OFF'}
-                                    </button>
-                                </div>
-                            )}
-                        </div>
-
-                        {/* ── 공통 필터 바 ── */}
+                        {/* ── 공통 필터 바 (뷰 탭 위) ── */}
                         {!loadingList && historicalList.length > 0 && (() => {
                             const hasAnyFilter = filterStrategies.size > 0 || minMarketCap > 0 || excludeHoldings || excludeDeficit || excludeDelisted || searchQuery !== '' || filterNcav !== 'all' || filterReturn !== 'all' || filterPbr !== 'all' || filterPer !== 'all';
                             const resetAll = () => { setFilterStrategies(new Set()); setMinMarketCap(0); setExcludeHoldings(false); setExcludeDeficit(false); setExcludeDelisted(false); setSearchQuery(''); setFilterNcav('all'); setFilterReturn('all'); setFilterPbr('all'); setFilterPer('all'); };
                             return (
                             <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] shadow-sm overflow-hidden">
+                                {/* ── 추가 전략 필터 ── */}
+                                <div className="px-5 sm:px-6 pt-4 pb-3 border-b border-neutral-100 dark:border-[#35332e]">
+                                    <div className="flex items-center gap-2 flex-wrap">
+                                        <span className="text-[10px] font-extrabold text-neutral-400 uppercase tracking-wider shrink-0">전략</span>
+                                        {EXTRA_STRATEGY_PRESETS.map(preset => {
+                                            const isActive = filterStrategies.has(preset.id);
+                                            const count = strategyCounts[preset.id] ?? 0;
+                                            return (
+                                                <button
+                                                    key={preset.id}
+                                                    onClick={() => toggleStrategy(preset.id)}
+                                                    title={preset.hint}
+                                                    className={cn(
+                                                        "flex items-center gap-1 px-2 py-1 rounded-lg text-[10px] font-bold border transition-all",
+                                                        isActive
+                                                            ? cn(STRATEGY_BADGE[preset.id], 'border-current')
+                                                            : "border-neutral-200 dark:border-[#35332e] text-neutral-500 dark:text-neutral-400 hover:border-neutral-300 dark:hover:border-neutral-500 bg-white dark:bg-transparent"
+                                                    )}
+                                                >
+                                                    {preset.label}
+                                                    <span className="text-[9px] font-mono opacity-70">{count}</span>
+                                                </button>
+                                            );
+                                        })}
+                                        {filterStrategies.size >= 2 && (
+                                            <div className="flex rounded-lg border border-neutral-200 dark:border-[#35332e] overflow-hidden">
+                                                {(['OR', 'AND'] as const).map(mode => (
+                                                    <button
+                                                        key={mode}
+                                                        onClick={() => setFilterStrategyMode(mode)}
+                                                        className={cn(
+                                                            "px-2 py-1 text-[10px] font-bold transition-colors",
+                                                            filterStrategyMode === mode
+                                                                ? "bg-[#16a34a] text-white"
+                                                                : "text-neutral-400 dark:text-neutral-500 hover:text-neutral-600"
+                                                        )}
+                                                    >{mode}</button>
+                                                ))}
+                                            </div>
+                                        )}
+                                        {filterStrategies.size > 0 && (
+                                            <button
+                                                onClick={() => setFilterStrategies(new Set())}
+                                                className="text-[10px] text-neutral-400 hover:text-[#16a34a] dark:hover:text-[#16a34a] ml-0.5"
+                                            >초기화</button>
+                                        )}
+                                    </div>
+                                </div>
                                 {/* ── 수치 필터 바 ── */}
                                 <div className="px-5 sm:px-6 py-3 flex flex-wrap items-center gap-2">
                                     {/* 검색 */}
@@ -1512,6 +1472,43 @@ function BacktestContent() {
                             </div>
                             );
                         })()}
+
+                        {/* ── View Tabs ── */}
+                        <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
+                            {(['history', 'portfolio', 'snapshot', 'stocks'] as const).map(tab => {
+                                const labels = { history: '히스토리', portfolio: '포트폴리오', snapshot: '스냅샷', stocks: '종목 목록' };
+                                return (
+                                    <button
+                                        key={tab}
+                                        onClick={() => setViewTab(tab)}
+                                        className={cn(
+                                            "px-4 pb-3 pt-1 text-sm font-bold border-b-2 transition-colors whitespace-nowrap",
+                                            viewTab === tab
+                                                ? "border-[#16a34a] text-[#16a34a]"
+                                                : "border-transparent text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
+                                        )}
+                                    >
+                                        {labels[tab]}
+                                    </button>
+                                );
+                            })}
+                            {/* 병합조정 토글 — 비최신일 + 현재가 로드됐을 때만 표시 */}
+                            {!isLatestDate && !loadingCurrentPrices && currentPriceMap.size > 0 && (
+                                <div className="ml-auto pb-2 flex items-center gap-1.5">
+                                    <button
+                                        onClick={() => setSplitAdjusted(p => !p)}
+                                        className={cn(
+                                            "text-[10px] font-bold px-2.5 py-1 rounded-lg border transition-colors",
+                                            splitAdjusted
+                                                ? "border-amber-400 text-amber-600 bg-amber-50 dark:bg-amber-950/30 dark:text-amber-400 dark:border-amber-500"
+                                                : "border-neutral-200 dark:border-[#35332e] text-neutral-400 hover:border-neutral-300"
+                                        )}
+                                    >
+                                        병합조정 {splitAdjusted ? 'ON' : 'OFF'}
+                                    </button>
+                                </div>
+                            )}
+                        </div>
 
                         {/* ── 히스토리 탭 ── */}
                         {viewTab === 'history' && (


### PR DESCRIPTION
## Summary

### 1. 전략 구분 없이 전체 데이터 fetch 후 클라이언트 필터 적용

- `activeStrategy` 제거 → 항상 `strategy=all`로 전체 데이터 한 번에 fetch
- 상단 고정 바(백엔드 전략 탭) 완전 제거
- 필터 바에 9개 전략 전체(NCAV / 저PBR / 저PER / S-RIM / 그레이엄 / 마법공식 / 퀄리티 / NCAV근접 / 균형가치) 클라이언트 필터 pills 표시
- 포트폴리오 탭에 별도 `portfolioStrategy` 선택기 추가 (시뮬레이션 API는 전략 파라미터 필요)
- 히스토리 바 차트: 4개 전략 합산 `total_cnt` 표시로 변경
- `EXTRA_STRATEGY_PRESETS` 상수 제거 (전략 구분 불필요)

### 2. 필터 바를 뷰 탭 위로 이동 + 전략 선택 중복 해소

- 필터 바를 뷰 탭(히스토리/포트폴리오/스냅샷/종목 목록) **위쪽**으로 이동
- 기존 상단 고정 바의 추가 전략 pills를 제거하고 필터 바 전략 섹션에 통합

## Before / After

| 항목 | 이전 | 이후 |
|---|---|---|
| 데이터 fetch | 전략별 개별 fetch | 항상 `strategy=all` 전체 fetch |
| 상단 고정 바 | 4개 백엔드 전략 탭 | 제거됨 |
| 전략 필터 | 상단 바(4개) + 필터 바(5개) 이중 구조 | 필터 바에 9개 통합 |
| 필터 바 위치 | 뷰 탭 아래 | 뷰 탭 위로 이동 |
| 포트폴리오 시뮬레이션 | activeStrategy 사용 | 별도 portfolioStrategy 선택기 |

## Test plan

- [ ] 날짜 선택 시 전략 구분 없이 모든 종목 한 번에 로드되는지 확인
- [ ] 필터 바 전략 pills 9개 모두 표시 확인
- [ ] 전략 pill 선택 → 해당 전략 조건 종목만 필터링 확인
- [ ] 필터 바가 뷰 탭 위에 위치하는지 확인
- [ ] 포트폴리오 탭 진입 시 시뮬레이션 전략 선택기(NCAV/저PBR/저PER/S-RIM) 표시 확인
- [ ] 포트폴리오 전략 변경 시 시뮬레이션 데이터 갱신 확인
- [ ] 히스토리 바 차트에 4개 전략 합산 후보 수 표시 확인

https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM)_