### PR TITLE
feat(backtest): 날짜 표시에 요일 추가

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -178,8 +178,15 @@ function resolveAllStrategies(item: DailyItem): string[] {
     return Array.from(base);
 }
 
+const DAY_KOR = ['일', '월', '화', '수', '목', '금', '토'] as const;
+
+function getDayKor(yyyymmdd: string): string {
+    const d = new Date(+yyyymmdd.slice(0, 4), +yyyymmdd.slice(4, 6) - 1, +yyyymmdd.slice(6, 8));
+    return DAY_KOR[d.getDay()];
+}
+
 function fmtDate(yyyymmdd: string): string {
-    return `${yyyymmdd.slice(4, 6)}/${yyyymmdd.slice(6, 8)}`;
+    return `${yyyymmdd.slice(4, 6)}/${yyyymmdd.slice(6, 8)}(${getDayKor(yyyymmdd)})`;
 }
 
 // 날짜 간격이 있는 데이터를 선형 보간으로 채움 (차트 연속성 확보)
@@ -1302,12 +1309,12 @@ function BacktestContent() {
     }, [filteredList, currentPriceMap, splitAdjusted, currentLstnMap]);
 
     const formattedSelectedDate = selectedDate
-        ? `${selectedDate.slice(0, 4)}.${selectedDate.slice(4, 6)}.${selectedDate.slice(6, 8)}`
+        ? `${selectedDate.slice(0, 4)}.${selectedDate.slice(4, 6)}.${selectedDate.slice(6, 8)}(${getDayKor(selectedDate)})`
         : null;
 
     const latestScanDate = datesState.dates[0]?.scan_date;
     const formattedLatestDate = latestScanDate
-        ? `${latestScanDate.slice(0, 4)}.${latestScanDate.slice(4, 6)}.${latestScanDate.slice(6, 8)}`
+        ? `${latestScanDate.slice(0, 4)}.${latestScanDate.slice(4, 6)}.${latestScanDate.slice(6, 8)}(${getDayKor(latestScanDate)})`
         : null;
 
     // 시계열 부족 시 현재가 기준 보간 결과 (항상 차트 표시용)


### PR DESCRIPTION
## Summary

백테스트 페이지의 모든 날짜 표시에 요일을 추가합니다.

### 변경 내용

- `getDayKor(yyyymmdd)` 헬퍼 함수 + `DAY_KOR` 상수 추가
- `fmtDate`: `MM/DD` → `MM/DD(요일)` — 차트 X축 레이블 전체 적용
  - 히스토리 바 차트, 포트폴리오 시뮬레이션 차트, DrillDown 주가·수익률 차트
- `formattedSelectedDate`: `YYYY.MM.DD` → `YYYY.MM.DD(요일)` — 기준일 텍스트 표시
- `formattedLatestDate`: `YYYY.MM.DD` → `YYYY.MM.DD(요일)` — 헤더 "최신" 배지

### 표시 예시

| 위치 | 변경 전 | 변경 후 |
|---|---|---|
| 차트 X축 | `06/12` | `06/12(목)` |
| 헤더 배지 | `2026.06.12` | `2026.06.12(목)` |
| 기준일 텍스트 | `2026.06.12` | `2026.06.12(목)` |
| 종목 목록 헤더 | `2026.06.12 후보 종목` | `2026.06.12(목) 후보 종목` |

## Test plan

- [ ] 히스토리 바 차트 X축: `06/12(목)` 형태로 표시되는지 확인
- [ ] 포트폴리오 차트 X축: 동일 형태 확인
- [ ] DrillDown 주가·수익률 차트 X축: 동일 형태 확인
- [ ] 헤더 "최신" 배지: `2026.06.12(목)` 형태 확인
- [ ] 히스토리 차트 하단 "선택한 기준일" 텍스트: 요일 포함 확인
- [ ] 종목 목록 테이블 헤더 날짜: 요일 포함 확인

https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM)_