### PR TITLE
feat(backtest): 구간별 수익률 차트 보간 데이터 시각화

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -506,20 +506,22 @@ function DrillDown({ name, ticker, stockHistory, loading, onNavigate, entryDate,
 
 // ─── Portfolio Overview Chart ─────────────────────────────────────────────────
 
-function PortfolioOverviewChart({ result, loading, strategy }: {
+function PortfolioOverviewChart({ result, loading, strategy, synthetic }: {
     result: PortfolioResult | null;
     loading: boolean;
     strategy: string;
+    synthetic?: boolean;
 }) {
-    const chartData = useMemo(() =>
-        (result?.time_series ?? []).map(d => ({
-            label: fmtDate(d.date),
+    const chartData = useMemo(() => {
+        const raw = (result?.time_series ?? []).map(d => ({
             date: d.date,
             pct: d.portfolio_pct,
             covered: d.covered,
             win_rate: d.covered > 0 ? Math.round((d.win_count / d.covered) * 100) : 0,
-        })),
-    [result]);
+        }));
+        const data = synthetic ? fillDateGaps(raw, ['pct', 'win_rate']) : raw;
+        return data.map(d => ({ ...d, label: fmtDate(d.date) }));
+    }, [result, synthetic]);
 
     if (loading) {
         return (
@@ -571,6 +573,13 @@ function PortfolioOverviewChart({ result, loading, strategy }: {
                             formatter={(v: unknown, _name: string, props: any) => {
                                 const n = Number(v);
                                 const p = props?.payload;
+                                const estimatedTag = p?.estimated ? ' (추정)' : '';
+                                if (p?.estimated) {
+                                    return [
+                                        `${n >= 0 ? '+' : ''}${n.toFixed(2)}%${estimatedTag}`,
+                                        '포트폴리오 누적 수익률',
+                                    ];
+                                }
                                 return [
                                     `${n >= 0 ? '+' : ''}${n.toFixed(2)}%  (${p?.covered}종목, 승률 ${p?.win_rate}%)`,
                                     '포트폴리오 누적 수익률',
@@ -583,6 +592,7 @@ function PortfolioOverviewChart({ result, loading, strategy }: {
                                 <Cell
                                     key={entry.date}
                                     fill={entry.pct >= 0 ? '#4ade80' : '#fca5a5'}
+                                    fillOpacity={(entry as any).estimated ? 0.35 : 1}
                                 />
                             ))}
                         </Bar>
@@ -1761,6 +1771,7 @@ function BacktestContent() {
                                         result={augmentedPortfolioResult}
                                         loading={false}
                                         strategy={portfolioStrategy}
+                                        synthetic={(portfolioResult?.time_series?.length ?? 0) < 2}
                                     />
                                     <PortfolioChart
                                         result={augmentedPortfolioResult}


### PR DESCRIPTION
## Summary

스캔 데이터가 부족한 경우(`time_series < 2`), `PortfolioOverviewChart`(구간별 수익률 바 차트)에 `fillDateGaps`를 적용하여 시작~종료 2포인트 사이를 일별 보간 막대로 채워 표시합니다.

### 변경 내용

- `PortfolioOverviewChart`에 `synthetic?: boolean` prop 추가
- `synthetic=true`일 때 `fillDateGaps(raw, ['pct', 'win_rate'])`로 일별 보간 막대 생성
- 보간된 추정 막대는 `fillOpacity: 0.35`로 반투명 표시 (실데이터 막대와 시각적으로 구분)
- 툴팁: 추정 막대 hover 시 `(추정)` 태그 표시, 실데이터 막대는 기존대로 종목 수·승률 포함
- `portfolioResult.time_series.length < 2`인 경우에만 `synthetic=true` 전달 → 실측 데이터 충분 시 기존 동작 그대로 유지

### 시각적 구분

| 막대 종류 | 색상 | 투명도 | 툴팁 |
|---|---|---|---|
| 실측 데이터 | 초록/빨강 | 100% | 수익률 + 종목수 + 승률 |
| 보간 추정치 | 초록/빨강 | 35% | 수익률 + (추정) |

## Test plan

- [ ] 최근 날짜(이후 스캔 없음) 선택 → 구간별 수익률 차트에 일별 막대 표시 확인
- [ ] 추정 막대(시작·종료 사이)가 반투명으로 표시되는지 확인
- [ ] 시작/종료 막대(실데이터)가 불투명으로 표시되는지 확인
- [ ] 추정 막대 hover 시 툴팁에 `(추정)` 표시 확인
- [ ] 오래된 날짜(`time_series >= 2`) 선택 시 기존 동작 그대로 유지 확인 (보간 없음)

https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM)_