### PR TITLE
fix(search): US ticker-map D1 오버라이드 검색 지원

### DIFF
--- a/cf-idiotquant/app/(search)/search/hooks/useStockSearch.ts
+++ b/cf-idiotquant/app/(search)/search/hooks/useStockSearch.ts
@@ -25,6 +25,26 @@ function loadKrOverrides(): Promise<Map<string, string>> {
     return _krOverridePromise;
 }
 
+// US ticker-map override 캐시 (ticker 집합 — 정적 JSON에 없는 종목 보완)
+let _usOverrideSet: Set<string> | null = null;
+let _usOverridePromise: Promise<Set<string>> | null = null;
+function loadUsOverrides(): Promise<Set<string>> {
+    if (_usOverrideSet) return Promise.resolve(_usOverrideSet);
+    if (_usOverridePromise) return _usOverridePromise;
+    _usOverridePromise = fetch('/api/proxy/ticker-map?source=overrides&country=US&limit=500')
+        .then(r => r.json())
+        .then(json => {
+            const set = new Set<string>();
+            for (const e of (json.data ?? [])) {
+                if (e.ticker) set.add(e.ticker.toUpperCase());
+            }
+            _usOverrideSet = set;
+            return set;
+        })
+        .catch(() => new Set<string>());
+    return _usOverridePromise;
+}
+
 // Redux Actions
 import {
     reqGetInquirePrice,
@@ -88,7 +108,9 @@ export function useStockSearch() {
     const onSearch = useCallback(async (stockName: string) => {
         if (!stockName) return;
 
-        const isUs = us_tickers.includes(stockName.toUpperCase());
+        const upper = stockName.toUpperCase();
+        const usOverrides = await loadUsOverrides();
+        const isUs = us_tickers.includes(upper) || usOverrides.has(upper);
         dispatch(addKrMarketHistory(stockName));
         setName(stockName);
 
@@ -117,7 +139,7 @@ export function useStockSearch() {
             }
         } else {
             setKrOrUs("US");
-            const ticker = stockName.toUpperCase();
+            const ticker = upper;
             dispatch(reqGetQuotationsSearchInfo({ PDNO: ticker }));
             dispatch(reqGetQuotationsPriceDetail({ PDNO: ticker }));
             dispatch(reqGetOverseasPriceQuotationsDailyPrice({


### PR DESCRIPTION
## Summary

종목명 매핑 관리(admin ticker-map)에서 US 종목을 오버라이드로 추가해도 검색 페이지에서 동작하지 않던 버그를 수정합니다.

### 근본 원인

`useStockSearch.ts`의 US/KR 판정 로직이 빌드 타임에 import된 정적 JSON(nasdaq/nyse/amex)만 체크:

```typescript
// 변경 전: 정적 JSON만 체크 → D1 오버라이드 무시
const isUs = us_tickers.includes(stockName.toUpperCase());
```

D1에 SPCX 같은 종목을 US 오버라이드로 추가해도 JSON에 없으면 KR로 잘못 분류되어 US API 미호출.

### 수정 내용

- `loadUsOverrides()` 함수 추가: KR 오버라이드와 동일한 패턴으로 `/ticker-map?source=overrides&country=US`에서 ticker 목록을 캐시 로드
- `isUs` 판정에 D1 US 오버라이드 포함:

```typescript
// 변경 후: 정적 JSON + D1 오버라이드 모두 체크
const usOverrides = await loadUsOverrides();
const isUs = us_tickers.includes(upper) || usOverrides.has(upper);
```

- 첫 검색 시 1회 fetch 후 모듈 캐시(`_usOverrideSet`)에 보관 — 이후 검색은 네트워크 없이 즉시 처리

## Test plan

- [ ] admin ticker-map에서 SPCX(country=US)로 추가 후 검색 페이지에서 `SPCX` 검색 → US API 호출되어 미국 주식 데이터 표시 확인
- [ ] 기존 nasdaq/nyse/amex JSON에 있는 종목(AAPL 등) 검색 → 기존과 동일하게 동작 확인
- [ ] KR 종목 검색에 영향 없음 확인

https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM)_