### PR TITLE
fix(analyze): US 오버라이드 종목 검색 차단 해제 (country=all)

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -92,7 +92,7 @@ const loadStaticStockData = (): Promise<StaticStockData> => {
     import('@/public/data/validCorpCodeArray.json'),
     import('@/public/data/validCorpNameArray.json'),
     import('@/public/data/validCorpCode.json'),
-    fetch('/api/proxy/ticker-map?source=overrides&limit=500')
+    fetch('/api/proxy/ticker-map?source=overrides&country=all&limit=500')
       .then(r => r.json())
       .catch(() => ({ success: false, data: [] })),
   ]).then(([nasdaq, nyse, amex, corpCode, corpName, corpCodeData, overrides]) => {


### PR DESCRIPTION
## Summary

- `analyze/page.tsx`의 `loadStaticStockData()`에서 오버라이드 fetch 시 `country` 파라미터 누락으로 백엔드가 기본값 `'KR'`을 사용해 US 종목(SPCX 등)이 `allTickers`에서 제외되는 버그 수정
- `handleSearch` 검증 단계에서 "지원하지 않는 종목" 토스트가 표시되며 검색이 차단되던 문제 해결
- fetch URL에 `country=all` 추가: `/api/proxy/ticker-map?source=overrides&country=all&limit=500`

## Root Cause

백엔드 `tickerMap.js`의 GET 핸들러는 `country` 파라미터가 없을 때 `'KR'`로 기본값 설정:
```js
const country = url.searchParams.get('country') || 'KR';
```
`buildOverridesList`에서 `country !== 'all'`이면 해당 country가 아닌 종목은 건너뜀 → SPCX (country='US')가 응답에서 누락.

`handleSearch`가 `allTickers`에 없는 종목을 차단하므로 `onSearch`까지 도달하지 못함.

## Test plan

- [ ] 분析 페이지에서 SPCX 검색 시 "지원하지 않는 종목" 토스트가 더 이상 뜨지 않는지 확인
- [ ] SPCX 검색 결과가 정상적으로 표시되는지 확인
- [ ] KR 종목 검색이 기존대로 동작하는지 확인

https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM)_