### PR TITLE
fix(search): KR 코드 없을 때 US 티커로 폴백 — 오버라이드 country 미설정 방어

### DIFF
--- a/cf-idiotquant/app/(search)/search/hooks/useStockSearch.ts
+++ b/cf-idiotquant/app/(search)/search/hooks/useStockSearch.ts
@@ -126,7 +126,7 @@ export function useStockSearch() {
                 const overrides = await loadKrOverrides();
                 code = overrides.get(stockName);
             }
-            if (code) {
+            if (code && /^\d{6}$/.test(code)) {
                 dispatch(reqGetInquirePrice({ PDNO: code }));
                 dispatch(reqGetInquireDailyItemChartPrice({
                     PDNO: code,
@@ -136,6 +136,17 @@ export function useStockSearch() {
                 dispatch(reqGetBalanceSheet({ PDNO: code }));
                 dispatch(reqGetIncomeStatement({ PDNO: code }));
                 setWaitResponse(true);
+            } else {
+                // 유효한 6자리 KR 코드가 없으면 US 티커로 폴백 (오버라이드 country 미설정 등)
+                setKrOrUs("US");
+                const ticker = upper;
+                dispatch(reqGetQuotationsSearchInfo({ PDNO: ticker }));
+                dispatch(reqGetQuotationsPriceDetail({ PDNO: ticker }));
+                dispatch(reqGetOverseasPriceQuotationsDailyPrice({
+                    PDNO: ticker,
+                    FID_INPUT_DATE_1: new Date().toISOString().split('T')[0].replaceAll("-", "")
+                }));
+                dispatch(reqGetFinnhubUsFinancialsReported(ticker));
             }
         } else {
             setKrOrUs("US");


### PR DESCRIPTION
## Summary

- `useStockSearch.ts`의 KR 경로에서 찾은 `code`가 6자리 숫자가 아닐 경우(예: `"SPCX"`) KR API 호출을 차단하고 US API로 폴백
- D1 ticker_name_overrides에 `country='KR'`로 잘못 저장된 US 티커(SPCX 등)에 대해서도 US 주식 데이터가 정상 표시됨

## 변경 내용

`useStockSearch.ts`의 KR 분기:

```typescript
// 변경 전
if (code) {
    dispatch(reqGetInquirePrice({ PDNO: code }));
    // ...
}

// 변경 후
if (code && /^\d{6}$/.test(code)) {
    dispatch(reqGetInquirePrice({ PDNO: code }));
    // ...KR API 호출
    setWaitResponse(true);
} else {
    // 유효한 6자리 KR 코드가 없으면 US 티커로 폴백
    setKrOrUs("US");
    dispatch(reqGetQuotationsSearchInfo({ PDNO: ticker }));
    dispatch(reqGetQuotationsPriceDetail({ PDNO: ticker }));
    dispatch(reqGetOverseasPriceQuotationsDailyPrice({ ... }));
    dispatch(reqGetFinnhubUsFinancialsReported(ticker));
}
```

## 관련 변경

- Worker 레포 PR #34: `overseas/quotations.js` — 정적 리스트 미등재 US 종목 거래소 자동 감지 (NAS→NYS→AMS)
- PR #460: `loadUsOverrides()` — D1 US 오버라이드 검색 지원
- PR #461: `analyze/page.tsx` — `country=all` 오버라이드 fetch 수정

## Test plan

- [ ] SPCX(D1에 country='US' 저장)를 search 페이지에서 검색 시 US 주식 데이터 표시 확인
- [ ] KR 종목(삼성전자, 005930 등) 검색이 기존대로 동작하는지 확인
- [ ] 유효하지 않은 종목명 입력 시 결과 없음 처리 확인

https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM

---
_Generated by [Claude Code](https://claude.ai/code/session_016eDGzSwDE4qEMipUQ891WM)_