### PR TITLE
fix(backtest): 상장폐지 의심 필터가 lstn_stcn NULL을 전부 제외하던 문제 수정

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1179,7 +1179,9 @@ function BacktestContent() {
         if (minMarketCap > 0 && safeNum(item.market_cap) < minMarketCap) return false;
         if (excludeHoldings && item.name.includes('홀딩스')) return false;
         if (excludeDeficit && !(safeNum(item.eps) > 0)) return false;
-        if (excludeDelisted && !(safeNum(item.lstn_stcn) > 0)) return false;
+        // lstn_stcn 미수집(NULL)은 "모름"으로 통과시키고, 명시적 0(상장폐지 의심)만 제외.
+        // 과거 일자는 lstn_stcn 컬럼이 NULL이라 0과 혼동돼 전 종목이 가려지던 문제 방지.
+        if (excludeDelisted && item.lstn_stcn != null && safeNum(item.lstn_stcn) <= 0) return false;
         if (filterNcav !== 'all' && !(safeNum(item.ncav_ratio) >= parseFloat(filterNcav))) return false;
         if (applyReturn && filterReturn !== 'all') {
             const cur = currentPriceMap.get(item.ticker);

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1639,7 +1640,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2156,21 +2157,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1640,7 +1639,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2157,13 +2156,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }


### PR DESCRIPTION
## Summary

backtest 페이지 고급 필터의 **"상장폐지 의심 제외"** 를 켜면 과거 일자에서 전 종목이 가려지던 문제를 수정한다.

## 원인

- 필터 판정(`page.tsx`)이 `lstn_stcn`(상장주식수)이 **0보다 큰 행만** 남겼다.
- `lstn_stcn` 컬럼은 백엔드 마이그레이션 `0005_add_lstn_stcn.sql`(2026-06-11)로 `DEFAULT NULL` 추가되어, 그 이전 수집 데이터(대부분의 과거 일자)는 전부 **NULL** 이다.
- `safeNum(NULL) === 0` 이라 "값 없음(NULL)"이 "상장폐지(0)"와 구분되지 않아, 필터를 켜면 NULL 행이 모두 제외되어 전 종목이 사라졌다.

## 변경

```diff
- if (excludeDelisted && !(safeNum(item.lstn_stcn) > 0)) return false;
+ // NULL(미수집)은 통과, 명시적 0(상장폐지 의심)만 제외
+ if (excludeDelisted && item.lstn_stcn != null && safeNum(item.lstn_stcn) <= 0) return false;
```

- `lstn_stcn`이 NULL/미수집이면 "모름"으로 통과
- 명시적으로 `0`인 행(상장폐지 의심)만 제외 — 마이그레이션 정의(`lstn_stcn = 0 이면 상장폐지 의심`)와 일치

## 결과

- 데이터가 채워진 최근 일자: 의도대로 상장폐지 의심 종목만 제외
- 과거 일자: 전 종목이 가려지던 현상 해소 (단, lstn_stcn 데이터 부재로 이 필터의 실효는 최근 일자에 한정)

## Test Plan
- [ ] 과거 일자 + "상장폐지 의심 제외" ON → 종목이 정상 표시되는지 확인
- [ ] 최신 일자에서 lstn_stcn=0 종목만 제외되는지 확인
- [ ] `npx tsc --noEmit` 통과

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_