### PR TITLE
screener/backtest: 상장폐지 의심 필터 제거 + 필터 결과·가독성 UI 개선

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1642,7 +1641,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2159,13 +2158,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/utils";
 import { safeNum } from "@/lib/utils/numbers";
 import { STRATEGY_LABEL, STRATEGY_BADGE, STRATEGY_PRESETS_CLIENT, MKTCAP_PRESETS } from "@/lib/constants/strategies";
 import type { StrategyPreset } from "@/lib/constants/strategies";
-import { Loader2, History, ChevronRight, TrendingUp, SlidersHorizontal, Info } from "lucide-react";
+import { Loader2, History, ChevronRight, TrendingUp, SlidersHorizontal, Info, X } from "lucide-react";
 import {
     BarChart, Bar, XAxis, YAxis,
     Tooltip as RTooltip, ResponsiveContainer, Cell,
@@ -1043,7 +1043,6 @@ function BacktestContent() {
     const [minMarketCap,        setMinMarketCap]        = useState(0);
     const [excludeHoldings,     setExcludeHoldings]     = useState(false);
     const [excludeDeficit,      setExcludeDeficit]      = useState(false);
-    const [excludeDelisted,     setExcludeDelisted]     = useState(false);
     const [filterOpen,          setFilterOpen]          = useState(false);
     const [loadingList,          setLoadingList]         = useState(false);
     const [loadingCurrentPrices, setLoadingCurrentPrices]= useState(false);
@@ -1179,9 +1178,6 @@ function BacktestContent() {
         if (minMarketCap > 0 && safeNum(item.market_cap) < minMarketCap) return false;
         if (excludeHoldings && item.name.includes('홀딩스')) return false;
         if (excludeDeficit && !(safeNum(item.eps) > 0)) return false;
-        // lstn_stcn 미수집(NULL)은 "모름"으로 통과시키고, 명시적 0(상장폐지 의심)만 제외.
-        // 과거 일자는 lstn_stcn 컬럼이 NULL이라 0과 혼동돼 전 종목이 가려지던 문제 방지.
-        if (excludeDelisted && item.lstn_stcn != null && safeNum(item.lstn_stcn) <= 0) return false;
         if (filterNcav !== 'all' && !(safeNum(item.ncav_ratio) >= parseFloat(filterNcav))) return false;
         if (applyReturn && filterReturn !== 'all') {
             const cur = currentPriceMap.get(item.ticker);
@@ -1192,7 +1188,7 @@ function BacktestContent() {
         if (filterPbr !== 'all' && !(safeNum(item.pbr) > 0 && safeNum(item.pbr) <= parseFloat(filterPbr))) return false;
         if (filterPer !== 'all' && !(safeNum(item.per) > 0 && safeNum(item.per) <= parseFloat(filterPer))) return false;
         return true;
-    }, [searchQuery, filterStrategies, filterStrategyMode, minMarketCap, excludeHoldings, excludeDeficit, excludeDelisted, filterNcav, filterReturn, filterPbr, filterPer, currentPriceMap, splitAdjusted, currentLstnMap]);
+    }, [searchQuery, filterStrategies, filterStrategyMode, minMarketCap, excludeHoldings, excludeDeficit, filterNcav, filterReturn, filterPbr, filterPer, currentPriceMap, splitAdjusted, currentLstnMap]);
 
     // Bar chart data (chronological).
     // 날짜별 리스트가 캐시되면 공통 필터 통과 종목 수를, 아직 미도착이면 서버 집계 합계(임시)를 표시.
@@ -1444,8 +1440,8 @@ function BacktestContent() {
                     <>
                         {/* ── 공통 필터 바 (뷰 탭 위) ── */}
                         {!loadingList && historicalList.length > 0 && (() => {
-                            const hasAnyFilter = filterStrategies.size > 0 || minMarketCap > 0 || excludeHoldings || excludeDeficit || excludeDelisted || searchQuery !== '' || filterNcav !== 'all' || filterReturn !== 'all' || filterPbr !== 'all' || filterPer !== 'all';
-                            const resetAll = () => { setFilterStrategies(new Set()); setMinMarketCap(0); setExcludeHoldings(false); setExcludeDeficit(false); setExcludeDelisted(false); setSearchQuery(''); setFilterNcav('all'); setFilterReturn('all'); setFilterPbr('all'); setFilterPer('all'); };
+                            const hasAnyFilter = filterStrategies.size > 0 || minMarketCap > 0 || excludeHoldings || excludeDeficit || searchQuery !== '' || filterNcav !== 'all' || filterReturn !== 'all' || filterPbr !== 'all' || filterPer !== 'all';
+                            const resetAll = () => { setFilterStrategies(new Set()); setMinMarketCap(0); setExcludeHoldings(false); setExcludeDeficit(false); setSearchQuery(''); setFilterNcav('all'); setFilterReturn('all'); setFilterPbr('all'); setFilterPer('all'); };
                             return (
                             <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] shadow-sm overflow-hidden">
                                 {/* ── 전략 필터 (전체 9종) ── */}
@@ -1575,16 +1571,16 @@ function BacktestContent() {
                                         onClick={() => setFilterOpen(o => !o)}
                                         className={cn(
                                             "flex items-center gap-1 px-2.5 py-1 rounded-lg border text-[10px] font-bold transition-all",
-                                            filterOpen || minMarketCap > 0 || excludeHoldings || excludeDeficit || excludeDelisted
+                                            filterOpen || minMarketCap > 0 || excludeHoldings || excludeDeficit
                                                 ? "bg-[#f0fdf4] dark:bg-[#052e16]/30 border-[#86efac] dark:border-[#166534] text-[#15803d] dark:text-[#16a34a]"
                                                 : "bg-white dark:bg-transparent border-neutral-200 dark:border-[#35332e] text-neutral-400 hover:border-neutral-300 dark:hover:border-neutral-500"
                                         )}
                                     >
                                         <SlidersHorizontal size={10} />
                                         고급
-                                        {(minMarketCap > 0 || excludeHoldings || excludeDeficit || excludeDelisted) && (
+                                        {(minMarketCap > 0 || excludeHoldings || excludeDeficit) && (
                                             <span className="w-3.5 h-3.5 flex items-center justify-center rounded-full bg-[#16a34a] text-white text-[8px] font-black">
-                                                {[minMarketCap > 0, excludeHoldings, excludeDeficit, excludeDelisted].filter(Boolean).length}
+                                                {[minMarketCap > 0, excludeHoldings, excludeDeficit].filter(Boolean).length}
                                             </span>
                                         )}
                                     </button>
@@ -1594,10 +1590,48 @@ function BacktestContent() {
                                         <button onClick={resetAll} className="text-[10px] text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 underline ml-0.5">전체 초기화</button>
                                     )}
 
-                                    {filteredList.length !== historicalList.length && (
-                                        <span className="text-[10px] text-neutral-400 ml-auto">{filteredList.length}/{historicalList.length}개</span>
-                                    )}
+                                    {/* 결과 종목 수 — 필터 적용 시 강조 */}
+                                    <div className={cn(
+                                        "ml-auto flex items-baseline gap-1 px-2.5 py-1 rounded-lg border",
+                                        hasAnyFilter
+                                            ? "bg-[#f0fdf4] dark:bg-[#052e16]/30 border-[#bbf7d0] dark:border-[#166534]/50"
+                                            : "bg-[#faf9f7] dark:bg-[#1a1915] border-neutral-200 dark:border-[#35332e]"
+                                    )}>
+                                        <span className={cn(
+                                            "text-sm font-black tabular-nums leading-none",
+                                            hasAnyFilter ? "text-[#15803d] dark:text-[#16a34a]" : "text-neutral-700 dark:text-neutral-200"
+                                        )}>{filteredList.length}</span>
+                                        <span className="text-[10px] font-bold text-neutral-400">개</span>
+                                        {filteredList.length !== historicalList.length && (
+                                            <span className="text-[10px] font-medium text-neutral-400 ml-0.5">/ {historicalList.length}</span>
+                                        )}
+                                    </div>
                                 </div>
+
+                                {/* ── 적용된 조건 칩 — 무엇이 걸려있는지 한눈에 ── */}
+                                {(() => {
+                                    const chips: { key: string; label: string; clear: () => void }[] = [];
+                                    if (searchQuery)        chips.push({ key: 'q',    label: `검색 "${searchQuery}"`, clear: () => setSearchQuery('') });
+                                    if (filterNcav !== 'all') chips.push({ key: 'ncav', label: `NCAV ≥${filterNcav}x`, clear: () => setFilterNcav('all') });
+                                    if (filterReturn !== 'all') chips.push({ key: 'ret', label: filterReturn === 'win' ? '수익' : '손실', clear: () => setFilterReturn('all') });
+                                    if (filterPbr !== 'all') chips.push({ key: 'pbr',  label: `PBR ≤${filterPbr}`, clear: () => setFilterPbr('all') });
+                                    if (filterPer !== 'all') chips.push({ key: 'per',  label: `PER ≤${filterPer}`, clear: () => setFilterPer('all') });
+                                    if (minMarketCap > 0)   chips.push({ key: 'cap',  label: `시총 ${MKTCAP_PRESETS.find(p => p.value === minMarketCap)?.label ?? `${minMarketCap}억+`}`, clear: () => setMinMarketCap(0) });
+                                    if (excludeHoldings)    chips.push({ key: 'hold', label: '홀딩스 제외', clear: () => setExcludeHoldings(false) });
+                                    if (excludeDeficit)     chips.push({ key: 'def',  label: '적자 제외',  clear: () => setExcludeDeficit(false) });
+                                    if (chips.length === 0) return null;
+                                    return (
+                                        <div className="px-5 sm:px-6 pb-3 -mt-0.5 flex items-center gap-1.5 flex-wrap">
+                                            <span className="text-[10px] text-neutral-400 font-medium">적용:</span>
+                                            {chips.map(c => (
+                                                <span key={c.key} className="inline-flex items-center gap-1 text-[10px] font-bold px-2 py-0.5 rounded-full bg-[#f0fdf4] dark:bg-[#052e16]/30 border border-[#bbf7d0] dark:border-[#166534]/50 text-[#15803d] dark:text-[#16a34a]">
+                                                    {c.label}
+                                                    <button onClick={c.clear} className="hover:opacity-60" title="제거"><X size={9} /></button>
+                                                </span>
+                                            ))}
+                                        </div>
+                                    );
+                                })()}
 
                                 {/* ── 고급 필터 확장 패널 ── */}
                                 {filterOpen && (
@@ -1625,7 +1659,6 @@ function BacktestContent() {
                                             {[
                                                 { label: '홀딩스', value: excludeHoldings, set: setExcludeHoldings },
                                                 { label: '적자 기업', value: excludeDeficit, set: setExcludeDeficit },
-                                                { label: '상장폐지 의심', value: excludeDelisted, set: setExcludeDelisted },
                                             ].map(opt => (
                                                 <label key={opt.label} className="flex items-center gap-1.5 cursor-pointer select-none">
                                                     <input type="checkbox" checked={opt.value} onChange={e => opt.set(e.target.checked)} className="rounded accent-[#16a34a]" />
@@ -1862,10 +1895,17 @@ function BacktestContent() {
                                 </p>
                                 {loadingList && <Loader2 size={13} className="animate-spin text-neutral-400" />}
                                 {!loadingList && historicalList.length > 0 && (
-                                    <span className="text-xs text-neutral-400 font-medium">
-                                        {filteredList.length !== historicalList.length
-                                            ? `${filteredList.length}/${historicalList.length}개`
-                                            : `${historicalList.length}개`}
+                                    <span className={cn(
+                                        "inline-flex items-baseline gap-1 px-2 py-0.5 rounded-md",
+                                        filteredList.length !== historicalList.length
+                                            ? "bg-[#f0fdf4] dark:bg-[#052e16]/30 text-[#15803d] dark:text-[#16a34a]"
+                                            : "text-neutral-400"
+                                    )}>
+                                        <span className="text-xs font-black tabular-nums">{filteredList.length}</span>
+                                        <span className="text-[10px] font-bold">개</span>
+                                        {filteredList.length !== historicalList.length && (
+                                            <span className="text-[10px] font-medium text-neutral-400">/ {historicalList.length}</span>
+                                        )}
                                     </span>
                                 )}
                                 {!isLatestDate && currentPriceMap.size > 0 && (

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1641,7 +1642,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2158,21 +2159,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -302,10 +302,6 @@ function ScreenerContent() {
     const [excludeDeficit, setExcludeDeficit] = useState(() =>
         searchParams.get('exclude')?.split(',').includes('deficit') ?? false
     );
-    const [excludeDelisted, setExcludeDelisted] = useState(() => {
-        const p = searchParams.get('exclude');
-        return p === null ? true : p.split(',').includes('delisted');
-    });
     const [filterOpen, setFilterOpen] = useState(false);
     const [showLikedOnly, setShowLikedOnly] = useState(() =>
         searchParams.get('filter') === 'liked'
@@ -350,7 +346,6 @@ function ScreenerContent() {
         const excludeList = [
             excludeHoldings ? 'holdings' : null,
             excludeDeficit ? 'deficit' : null,
-            excludeDelisted ? 'delisted' : null,
         ].filter(Boolean).join(',');
         if (excludeList) params.set('exclude', excludeList);
         if (minMarketCap > 0) params.set('mincap', String(minMarketCap));
@@ -369,7 +364,7 @@ function ScreenerContent() {
         } else {
             localStorage.removeItem('screener:filterMode');
         }
-    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludeDelisted, minMarketCap, showLikedOnly, router]);
+    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, minMarketCap, showLikedOnly, router]);
 
     const handleRefresh = useCallback(() => {
         dispatch(reqGetNcavDailyList("latest"));
@@ -409,7 +404,6 @@ function ScreenerContent() {
         setSearchQuery('');
         setExcludeHoldings(false);
         setExcludeDeficit(false);
-        setExcludeDelisted(true);
         setMinMarketCap(0);
         setShowLikedOnly(false);
         setDisplayCount(DAILY_PAGE_SIZE);
@@ -466,7 +460,6 @@ function ScreenerContent() {
             );
         }
 
-        if (excludeDelisted) list = list.filter(item => item.lstn_stcn == null || safeNum(item.lstn_stcn) !== 0);
         if (excludeHoldings) list = list.filter(item => !item.name?.includes("홀딩스"));
         if (excludeDeficit)  list = list.filter(item => safeNum(item.eps) > 0);
         if (minMarketCap > 0) list = list.filter(item => safeNum(item.market_cap) >= minMarketCap);
@@ -488,7 +481,7 @@ function ScreenerContent() {
         });
 
         return list;
-    }, [ncavDailyList.list, normalizedLikedList, showLikedOnly, activeStrategyIds, filterMode, searchQuery, excludeDelisted, excludeHoldings, excludeDeficit, minMarketCap, sortKey, sortOrder]);
+    }, [ncavDailyList.list, normalizedLikedList, showLikedOnly, activeStrategyIds, filterMode, searchQuery, excludeHoldings, excludeDeficit, minMarketCap, sortKey, sortOrder]);
 
     const visibleList = filteredList.slice(0, displayCount);
     const hasMore = filteredList.length > displayCount;
@@ -512,7 +505,8 @@ function ScreenerContent() {
 
     const activeFilterCount = [excludeHoldings, excludeDeficit, minMarketCap > 0].filter(Boolean).length;
     const isAllActive = activeStrategyIds.size === 0;
-    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || !excludeDelisted || minMarketCap > 0 || sortKey !== 'ncav_ratio' || sortOrder !== 'desc' || showLikedOnly;
+    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || minMarketCap > 0 || sortKey !== 'ncav_ratio' || sortOrder !== 'desc' || showLikedOnly;
+    const isFiltered = !showLikedOnly && filteredList.length !== ncavDailyList.list.length;
 
     return (
         <Tooltip.Provider delayDuration={300}>
@@ -627,7 +621,7 @@ function ScreenerContent() {
                         </div>
                     </div>
 
-                    {/* 둘째 줄: 관심 + 전략 안내 + 초기화 */}
+                    {/* 둘째 줄: 관심 + 결과 수 + 전략 안내 + 초기화 */}
                     <div className="flex items-center gap-2 pb-3">
                         {/* 관심 종목 필터 */}
                         <button
@@ -648,6 +642,25 @@ function ScreenerContent() {
                                 {likedTickers.size}
                             </span>
                         </button>
+
+                        {/* 결과 종목 수 (sticky — 스크롤해도 항상 보임) */}
+                        {!isLoading && (
+                            <div className={cn(
+                                "shrink-0 flex items-baseline gap-1 px-3 py-1.5 rounded-lg border transition-colors",
+                                isFiltered
+                                    ? "bg-[#f0fdf4] dark:bg-[#052e16]/30 border-[#bbf7d0] dark:border-[#166534]/50"
+                                    : "bg-[#faf9f7] dark:bg-[#242320] border-neutral-200 dark:border-[#3a3834]"
+                            )}>
+                                <span className={cn(
+                                    "text-sm font-black tabular-nums leading-none",
+                                    isFiltered ? "text-[#15803d] dark:text-[#16a34a]" : "text-neutral-700 dark:text-neutral-200"
+                                )}>{filteredList.length}</span>
+                                <span className="text-[10px] font-bold text-neutral-400">개</span>
+                                {isFiltered && (
+                                    <span className="text-[10px] font-medium text-neutral-400 ml-0.5">/ {ncavDailyList.list.length}</span>
+                                )}
+                            </div>
+                        )}
 
                         <div className="flex-1" />
 
@@ -728,6 +741,27 @@ function ScreenerContent() {
                             </span>
                         </div>
                     )}
+
+                    {/* 적용된 조건 칩 (검색·시가총액·제외) — 무엇이 걸려있는지 한눈에 */}
+                    {(() => {
+                        const chips: { key: string; label: string; clear: () => void }[] = [];
+                        if (searchQuery)     chips.push({ key: 'q',   label: `검색 "${searchQuery}"`, clear: () => { setSearchQuery(''); setDisplayCount(DAILY_PAGE_SIZE); } });
+                        if (minMarketCap > 0) chips.push({ key: 'cap', label: `시총 ${MKTCAP_PRESETS.find(p => p.value === minMarketCap)?.label ?? `${minMarketCap}억+`}`, clear: () => { setMinMarketCap(0); setDisplayCount(DAILY_PAGE_SIZE); } });
+                        if (excludeHoldings) chips.push({ key: 'hold', label: '홀딩스 제외', clear: () => setExcludeHoldings(false) });
+                        if (excludeDeficit)  chips.push({ key: 'def',  label: '적자 제외',  clear: () => setExcludeDeficit(false) });
+                        if (chips.length === 0) return null;
+                        return (
+                            <div className="pb-2.5 flex items-center gap-1.5 flex-wrap">
+                                <span className="text-[10px] text-neutral-400 font-medium">적용:</span>
+                                {chips.map(c => (
+                                    <span key={c.key} className="inline-flex items-center gap-1 text-[10px] font-bold px-2 py-0.5 rounded-full bg-[#f0fdf4] dark:bg-[#052e16]/30 border border-[#bbf7d0] dark:border-[#166534]/50 text-[#15803d] dark:text-[#16a34a]">
+                                        {c.label}
+                                        <button onClick={c.clear} className="hover:opacity-60" title="제거"><X size={9} /></button>
+                                    </span>
+                                ))}
+                            </div>
+                        );
+                    })()}
                 </div>
             </div>
 
@@ -858,15 +892,6 @@ function ScreenerContent() {
                                     className="rounded accent-[#16a34a]"
                                 />
                                 <span className="text-xs font-bold text-neutral-600 dark:text-neutral-400">적자 기업</span>
-                            </label>
-                            <label className="flex items-center gap-2 cursor-pointer select-none">
-                                <input
-                                    type="checkbox"
-                                    checked={excludeDelisted}
-                                    onChange={e => setExcludeDelisted(e.target.checked)}
-                                    className="rounded accent-[#16a34a]"
-                                />
-                                <span className="text-xs font-bold text-neutral-600 dark:text-neutral-400">상장폐지 의심</span>
                             </label>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

- **상장폐지 의심 필터 제거** (screener·backtest) — 관련 지표(`lstn_stcn`)가 안정적으로 저장되지 않아 실효가 없음
- **필터 결과 종목 수**가 잘 보이도록 결과 카운트 UI 강조
- **전략·필터 가독성** 및 **필터링 후 정보** UI 개선 (적용된 조건 칩)

## Changes

### 상장폐지 의심 필터 제거
- **screener** (`app/(screener)/screener/page.tsx`): `excludeDelisted` state·URL 동기화·필터 로직·체크박스 전부 제거
- **backtest** (`app/(backtest)/backtest/page.tsx`): `excludeDelisted` state·`matchesFilters` 판정(`lstn_stcn` NULL 처리 포함)·체크박스·고급 토글 카운트 제거
  - 직전 PR #466의 `lstn_stcn` NULL 처리는 필터 자체가 사라지면서 함께 제거됨 (supersede)

### 결과 종목 수 가독성
- **screener**: sticky 전략 바에 **항상 보이는 결과 수 pill** 추가 — 스크롤해도 `N개 / 전체M` 가 계속 보이고, 필터 적용 시 초록 강조
- **backtest**: 필터 바의 작던 `N/M개` 텍스트를 **강조 pill**로 교체 + 종목 탭 헤더 카운트도 동일 스타일로 강조

### 적용된 필터 가독성 (양 페이지)
- 현재 걸려 있는 조건(검색·NCAV·PBR·PER·시총·제외 등)을 **"적용:" 칩 목록**으로 표시, 각 칩 × 로 개별 해제 가능

## Test Plan
- [ ] screener/backtest 어디에도 "상장폐지 의심" 옵션이 없는지 확인
- [ ] 필터 적용 시 결과 종목 수 pill 이 강조되고 `N / M` 으로 보이는지 확인
- [ ] 적용 조건 칩이 표시되고 × 로 개별 해제되는지 확인
- [ ] `npx tsc --noEmit` · `npm run build` 통과

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_