### PR TITLE
home 온보딩 개선 + 카카오 로그인 세션 1일로 단축

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -5,9 +5,10 @@ import { useSession } from "next-auth/react";
 import Link from "next/link";
 import {
   Search, Calculator, Filter, Lock, ArrowRight,
-  TrendingUp, ChevronRight, Loader2, BarChart3, Zap,
+  TrendingUp, ChevronRight, Loader2, BarChart3, Zap, Layers,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { STRATEGY_PRESETS_CLIENT, STRATEGY_BADGE } from "@/lib/constants/strategies";
 
 interface PreviewStock {
   ticker: string;
@@ -142,6 +143,22 @@ function StockRow({ item, index }: { item: PreviewStock; index: number }) {
         <p className="text-[10px] text-neutral-400 font-mono">{item.ticker}</p>
       </div>
 
+      {/* PBR · PER — sm 이상에서만 노출 (모바일은 NCAV에 집중) */}
+      <div className="hidden sm:flex items-center gap-4 shrink-0">
+        <div className="text-right min-w-[40px]">
+          <p className="text-xs font-bold font-mono tabular-nums text-neutral-600 dark:text-neutral-300">
+            {item.pbr > 0 ? item.pbr.toFixed(2) : "—"}
+          </p>
+          <p className="text-[9px] text-neutral-400 font-bold uppercase tracking-wider">PBR</p>
+        </div>
+        <div className="text-right min-w-[40px]">
+          <p className="text-xs font-bold font-mono tabular-nums text-neutral-600 dark:text-neutral-300">
+            {item.per > 0 ? item.per.toFixed(1) : "—"}
+          </p>
+          <p className="text-[9px] text-neutral-400 font-bold uppercase tracking-wider">PER</p>
+        </div>
+      </div>
+
       <div className="shrink-0 text-right min-w-[52px]">
         <p className={cn(
           "text-sm font-black font-mono tabular-nums",
@@ -226,7 +243,7 @@ export default function HomePage() {
           </h1>
 
           <p className="text-sm sm:text-[15px] text-neutral-500 dark:text-neutral-400 font-medium leading-relaxed mb-7">
-            NCAV·저PBR·저PER — 매일 2,000종목을<br className="hidden sm:block" />
+            9가지 가치투자 전략으로 매일 2,000여 종목을<br className="hidden sm:block" />
             알고리즘이 대신 분석합니다.
           </p>
 
@@ -322,7 +339,9 @@ export default function HomePage() {
             {/* Column headers */}
             <div className="px-4 py-2 bg-[#fcfaf7] dark:bg-[#1f1e1b] border-b border-neutral-100 dark:border-[#35332e] flex items-center justify-between">
               <span className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider">종목</span>
-              <span className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider">NCAV 비율</span>
+              <span className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider">
+                <span className="hidden sm:inline">PBR · PER · </span>NCAV
+              </span>
             </div>
 
             {preview.loading ? (
@@ -383,6 +402,46 @@ export default function HomePage() {
                 )}
               </>
             )}
+          </div>
+        </div>
+      </section>
+
+      {/* ── STRATEGIES ───────────────────────────────────────────── */}
+      <section className="py-10 px-5 md:py-14 border-t border-neutral-100 dark:border-[#3a3834]">
+        <div className="max-w-3xl mx-auto">
+          <div className="flex items-center justify-between mb-5 gap-3">
+            <div>
+              <div className="flex items-center gap-2 mb-1">
+                <Layers size={13} className="text-[#16a34a]" strokeWidth={2.5} />
+                <h2 className="text-base font-black text-neutral-900 dark:text-neutral-50">9가지 퀀트 전략</h2>
+              </div>
+              <p className="text-[11px] text-neutral-400 break-keep">
+                검증된 가치투자 전략으로 매일 종목을 선별합니다. 카드를 눌러 바로 탐색하세요.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+            {STRATEGY_PRESETS_CLIENT.map(s => (
+              <Link
+                key={s.id}
+                href={isLoggedIn ? `/screener?strategies=${s.id}&mincap=500` : "/login"}
+                className="group p-4 rounded-2xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] hover:border-[#16a34a]/50 dark:hover:border-[#16a34a]/40 hover:shadow-sm transition-all"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <span className={cn(
+                    "text-[11px] font-extrabold px-2 py-0.5 rounded",
+                    STRATEGY_BADGE[s.id] ?? "bg-neutral-100 text-neutral-500"
+                  )}>
+                    {s.label}
+                  </span>
+                  <ChevronRight size={13} className="text-neutral-300 dark:text-neutral-600 group-hover:text-[#16a34a] group-hover:translate-x-0.5 transition-all" />
+                </div>
+                <p className="text-[11px] text-neutral-500 dark:text-neutral-400 leading-relaxed break-keep">
+                  {s.hint}
+                </p>
+              </Link>
+            ))}
           </div>
         </div>
       </section>

--- a/cf-idiotquant/auth.config.ts
+++ b/cf-idiotquant/auth.config.ts
@@ -15,6 +15,8 @@ export const authConfig = {
     },
     session: {
         strategy: "jwt", // 🚀 DB 없이 토큰 방식으로 세션 관리
+        maxAge: 60 * 60 * 24, // 1일 — 이후 재로그인 필요 (기본값 30일에서 변경)
+        updateAge: 60 * 60 * 24, // 1일 주기 갱신 (세션이 하루 안에서 무한 연장되지 않도록 maxAge와 동일하게)
     },
     callbacks: {
         async jwt({ token, user }) {


### PR DESCRIPTION
## Summary

- **온보딩(홈) 페이지 개선** — 9가지 퀀트 전략 쇼케이스 + 미리보기 지표 강화
- **카카오 로그인 세션 만료를 1일로 단축** (기본 30일 → 1일)

## Changes

### `app/(home)/page.tsx`
- "오늘의 발굴 종목" 미리보기 행에 **PBR·PER** 지표 추가 (이미 fetch하던 데이터 활용, `sm` 이상에서 노출 — 모바일은 NCAV에 집중)
- **9가지 퀀트 전략 쇼케이스 섹션** 추가 — 기존 `STRATEGY_PRESETS_CLIENT` 재사용, 각 전략 카드를 누르면 해당 전략으로 스크리너 딥링크(`/screener?strategies=<id>&mincap=500`), 비로그인 시 `/login`
- 히어로 카피를 "9가지 가치투자 전략" 기준으로 정리

### `auth.config.ts`
- NextAuth JWT 세션 `maxAge`를 **1일**(`60*60*24`)로 설정 — 미들웨어가 `req.auth`(JWT 세션)로 인증을 판정하므로 이 값이 실제 재로그인 주기를 결정
- `updateAge`도 1일로 두어 하루 안에서 세션이 무한 연장되지 않도록 함

## 참고
- `app/(login)/login/callback/route.ts`의 별도 `authToken` 쿠키(1시간, 워커 백엔드용)는 NextAuth 세션과 무관하여 이번 변경에 미포함

## Test Plan
- [ ] 홈에서 미리보기 행에 PBR·PER 가 보이고(sm+), 9가지 전략 카드가 스크리너로 딥링크되는지 확인
- [ ] 로그인 후 1일 경과 시 재로그인이 요구되는지 확인
- [ ] `npx tsc --noEmit` · `npm run build` 통과

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_