### PR TITLE
balance-kr/us: 운용 종목 그룹 관리 + 그룹별/좋아요 그룹 자동매매 토글

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
+++ b/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useEffect, useState, useCallback, useRef } from "react";
+import { Suspense, useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   LayoutDashboard, ChevronRight, MapPin,
@@ -33,8 +33,12 @@ import {
   reqPostKrCapitalTokenPlusAll, reqPostKrCapitalTokenPlusOne,
   selectKrCapital, selectKrCapitalTokenMinusAll,
   selectKrCapitalTokenMinusOne, selectKrCapitalTokenPlusAll,
-  selectKrCapitalTokenPlusOne
+  selectKrCapitalTokenPlusOne,
+  reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate,
+  reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup,
+  selectKrGroupOp,
 } from "@/lib/features/capital/capitalSlice";
+import { reqGetMyLikes, selectLikedList } from "@/lib/features/stockLikes/stockLikesSlice";
 
 import InquireBalanceResult from "@/components/inquireBalanceResult";
 import StockListTable from "@/components/balance/stockListTable";
@@ -195,6 +199,9 @@ function BalanceKr() {
   const krCapitalPlusOne = useAppSelector(selectKrCapitalTokenPlusOne);
   const krCapitalMinusAll = useAppSelector(selectKrCapitalTokenMinusAll);
   const krCapitalMinusOne = useAppSelector(selectKrCapitalTokenMinusOne);
+  const krGroupOp = useAppSelector(selectKrGroupOp);
+  const likedListAll = useAppSelector(selectLikedList);
+  const krLikedList = useMemo(() => (likedListAll ?? []).filter((l: any) => !l.is_us), [likedListAll]);
 
   const tradingStatus = useAppSelector(selectTradingStatus);
 
@@ -269,6 +276,7 @@ function BalanceKr() {
     dispatch(reqGetCapitalToken());
     dispatch(reqGetKakaoMemberList());
     dispatch(reqFetchTradingStatus("KR"));
+    dispatch(reqGetMyLikes());
   }, [session, status, dispatch, router]);
 
   useEffect(() => {
@@ -297,10 +305,25 @@ function BalanceKr() {
     return () => clearInterval(interval);
   }, [autoRefresh, balanceKey, dispatch]);
 
+  // 그룹 작업 완료 시 capital 재조회
+  useEffect(() => {
+    if (krGroupOp?.state === "fulfilled") {
+      dispatch(reqGetKrCapital(balanceKey));
+    }
+  }, [krGroupOp?.state]);
+
   const doTokenPlusAll = (num: number) => dispatch(reqPostKrCapitalTokenPlusAll({ key: balanceKey, num }));
   const doTokenPlusOne = (num: number, ticker: string) => ticker && dispatch(reqPostKrCapitalTokenPlusOne({ key: balanceKey, num, ticker }));
   const doTokenMinusAll = (num: number) => dispatch(reqPostKrCapitalTokenMinusAll({ key: balanceKey, num }));
   const doTokenMinusOne = (num: number, ticker: string) => ticker && dispatch(reqPostKrCapitalTokenMinusOne({ key: balanceKey, num, ticker }));
+
+  // 그룹 관리 핸들러
+  const doCreateGroup = (name: string) => dispatch(reqPostKrCapitalGroupCreate({ key: balanceKey, name }));
+  const doRenameGroup = (groupId: string, name: string) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { name } }));
+  const doToggleGroupTrading = (groupId: string, isActive: boolean) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { is_trading_active: isActive } }));
+  const doDeleteGroup = (groupId: string) => dispatch(reqPostKrCapitalGroupDelete({ key: balanceKey, groupId }));
+  const doMoveStock = (ticker: string, groupId: string | null) => dispatch(reqPostKrCapitalStockGroup({ key: balanceKey, ticker, groupId }));
+  const doToggleLikesTrading = (isActive: boolean) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId: "__likes__", updates: { is_trading_active: isActive } }));
 
   const summary = kiBalance.output2?.[0] || {};
   const totalEvalAmt = Number(summary.tot_evlu_amt || 0);
@@ -576,6 +599,13 @@ function BalanceKr() {
               doTokenMinusAll={doTokenMinusAll}
               doTokenMinusOne={doTokenMinusOne}
               session={session}
+              onCreateGroup={doCreateGroup}
+              onRenameGroup={doRenameGroup}
+              onToggleGroupTrading={doToggleGroupTrading}
+              onDeleteGroup={doDeleteGroup}
+              onMoveStock={doMoveStock}
+              likedList={krLikedList}
+              onToggleLikesTrading={doToggleLikesTrading}
             />
           </SectionPanel>
         )}

--- a/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
+++ b/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, Suspense, useRef } from "react";
+import { useState, useEffect, useCallback, Suspense, useRef, useMemo } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   Globe, ChevronRight, DollarSign, Building2,
@@ -40,8 +40,12 @@ import {
   reqPostUsCapitalTokenMinusAll, reqPostUsCapitalTokenMinusOne,
   selectUsCapital, selectUsCapitalTokenMinusAll,
   selectUsCapitalTokenPlusAll, selectUsCapitalTokenPlusOne,
-  selectUsCapitalTokenMinusOne
+  selectUsCapitalTokenMinusOne,
+  reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate,
+  reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup,
+  selectUsGroupOp,
 } from "@/lib/features/capital/capitalSlice";
+import { reqGetMyLikes, selectLikedList } from "@/lib/features/stockLikes/stockLikesSlice";
 
 import InquireBalanceResult from "@/components/inquireBalanceResult";
 import StockListTable from "@/components/balance/stockListTable";
@@ -183,6 +187,9 @@ function BalanceUs() {
   const usCapitalPlusOne = useAppSelector(selectUsCapitalTokenPlusOne);
   const usCapitalMinusAll = useAppSelector(selectUsCapitalTokenMinusAll);
   const usCapitalMinusOne = useAppSelector(selectUsCapitalTokenMinusOne);
+  const usGroupOp = useAppSelector(selectUsGroupOp);
+  const likedListAll = useAppSelector(selectLikedList);
+  const usLikedList = useMemo(() => (likedListAll ?? []).filter((l: any) => !!l.is_us), [likedListAll]);
 
   const tradingStatus = useAppSelector(selectTradingStatus);
 
@@ -247,6 +254,7 @@ function BalanceUs() {
     }
     dispatch(reqGetKakaoMemberList());
     dispatch(reqFetchTradingStatus("US"));
+    dispatch(reqGetMyLikes());
   }, [session, status, dispatch, router]);
 
   useEffect(() => {
@@ -277,10 +285,25 @@ function BalanceUs() {
     return () => clearInterval(interval);
   }, [autoRefresh, balanceKey, dispatch]);
 
+  // 그룹 작업 완료 시 capital 재조회
+  useEffect(() => {
+    if (usGroupOp?.state === "fulfilled") {
+      dispatch(reqGetUsCapital(balanceKey));
+    }
+  }, [usGroupOp?.state]);
+
   const doTokenPlusAll = (num: number) => dispatch(reqPostUsCapitalTokenPlusAll({ key: balanceKey, num }));
   const doTokenPlusOne = (num: number, ticker: string) => ticker && dispatch(reqPostUsCapitalTokenPlusOne({ key: balanceKey, num, ticker }));
   const doTokenMinusAll = (num: number) => dispatch(reqPostUsCapitalTokenMinusAll({ key: balanceKey, num }));
   const doTokenMinusOne = (num: number, ticker: string) => ticker && dispatch(reqPostUsCapitalTokenMinusOne({ key: balanceKey, num, ticker }));
+
+  // 그룹 관리 핸들러
+  const doCreateGroup = (name: string) => dispatch(reqPostUsCapitalGroupCreate({ key: balanceKey, name }));
+  const doRenameGroup = (groupId: string, name: string) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { name } }));
+  const doToggleGroupTrading = (groupId: string, isActive: boolean) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { is_trading_active: isActive } }));
+  const doDeleteGroup = (groupId: string) => dispatch(reqPostUsCapitalGroupDelete({ key: balanceKey, groupId }));
+  const doMoveStock = (ticker: string, groupId: string | null) => dispatch(reqPostUsCapitalStockGroup({ key: balanceKey, ticker, groupId }));
+  const doToggleLikesTrading = (isActive: boolean) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId: "__likes__", updates: { is_trading_active: isActive } }));
 
   const out2 = kiBalance?.output2?.[0];
   const out3 = kiBalance?.output3;
@@ -621,6 +644,13 @@ function BalanceUs() {
               doTokenMinusAll={doTokenMinusAll}
               doTokenMinusOne={doTokenMinusOne}
               session={session}
+              onCreateGroup={doCreateGroup}
+              onRenameGroup={doRenameGroup}
+              onToggleGroupTrading={doToggleGroupTrading}
+              onDeleteGroup={doDeleteGroup}
+              onMoveStock={doMoveStock}
+              likedList={usLikedList}
+              onToggleLikesTrading={doToggleLikesTrading}
             />
           </SectionPanel>
         )}

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -1,28 +1,48 @@
 "use client";
 
-import React, { useState, useMemo, useEffect } from "react";
-import { 
-  Key, 
-  Minus, 
-  Plus, 
-  Eye, 
-  Search, 
-  Info, 
-  Copy, 
-  X, 
-  BarChart3, 
-  Box, 
-  ClipboardCheck, 
-  Wallet, 
-  TrendingUp 
+import React, { useState, useMemo } from "react";
+import {
+  Key,
+  Minus,
+  Search,
+  Info,
+  Copy,
+  X,
+  BarChart3,
+  Box,
+  ClipboardCheck,
+  Wallet,
+  TrendingUp,
+  FolderOpen,
+  Heart,
+  Trash2,
+  Pencil,
+  Power,
+  Plus,
+  Check,
 } from "lucide-react";
-import { UsCapitalStockItem, KrUsCapitalType } from "@/lib/features/capital/capitalSlice";
+import { UsCapitalStockItem, KrUsCapitalType, StockGroup, LIKES_GROUP_ID } from "@/lib/features/capital/capitalSlice";
+import { LikedStockItem } from "@/lib/features/stockLikes/stockLikesSlice";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 /** Tailwind 클래스 병합 유틸리티 */
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+/** 그룹 섹션·찜 섹션이 공통으로 쓰는 정규화된 행 */
+interface DisplayRow {
+  symbol: string;
+  per?: number | string | null;
+  pbr?: number | string | null;
+  bps?: number | null;
+  eps?: number | null;
+  marketCap?: number | null;
+  ncavRatio?: number | string | null;
+  token?: number | null;
+  movable: boolean;        // 운용 종목(true) vs 찜 종목(읽기 전용, false)
+  raw: any;                // 상세 모달용
 }
 
 interface Props {
@@ -34,6 +54,58 @@ interface Props {
   doTokenMinusOne: (val: number, sym: string) => void;
   className?: string;
   session: any;
+  // 그룹 관리
+  onCreateGroup?: (name: string) => void;
+  onRenameGroup?: (groupId: string, name: string) => void;
+  onToggleGroupTrading?: (groupId: string, isActive: boolean) => void;
+  onDeleteGroup?: (groupId: string) => void;
+  onMoveStock?: (ticker: string, groupId: string | null) => void;
+  // 좋아요(찜) 그룹
+  likedList?: LikedStockItem[];
+  onToggleLikesTrading?: (isActive: boolean) => void;
+}
+
+const tokenAmounts = [10000, 100000, 1000000];
+
+function normalizeCapital(row: UsCapitalStockItem): DisplayRow {
+  return {
+    symbol: row.symbol,
+    per: row.condition?.per,
+    pbr: row.condition?.pbr,
+    bps: row.condition?.bps,
+    eps: row.condition?.eps,
+    marketCap: row.condition?.MarketCapitalization,
+    ncavRatio: row.ncavRatio,
+    token: row.token,
+    movable: true,
+    raw: row,
+  };
+}
+
+function normalizeLiked(lk: LikedStockItem): DisplayRow {
+  return {
+    symbol: lk.ticker,
+    per: lk.per,
+    pbr: lk.pbr,
+    bps: lk.bps,
+    eps: lk.eps,
+    marketCap: lk.market_cap,
+    ncavRatio: lk.ncav_ratio,
+    token: null,
+    movable: false,
+    raw: {
+      symbol: lk.ticker,
+      ncavRatio: lk.ncav_ratio != null ? String(lk.ncav_ratio) : undefined,
+      condition: {
+        AssetsCurrent: lk.current_assets,
+        LiabilitiesCurrent: lk.total_liabilities,
+        MarketCapitalization: lk.market_cap,
+        NetIncome: lk.net_income,
+        LastPrice: lk.last_price,
+        bps: lk.bps, eps: lk.eps, pbr: lk.pbr, per: lk.per,
+      },
+    },
+  };
 }
 
 export default function StockListTable({
@@ -44,29 +116,72 @@ export default function StockListTable({
   doTokenMinusOne,
   className = "",
   session,
+  onCreateGroup,
+  onRenameGroup,
+  onToggleGroupTrading,
+  onDeleteGroup,
+  onMoveStock,
+  likedList = [],
+  onToggleLikesTrading,
 }: Props) {
-  const rows = data?.stock_list ?? [];
-  const [selected, setSelected] = useState<UsCapitalStockItem | null>(null);
+  const stockList = data?.stock_list ?? [];
+  const groups: StockGroup[] = data?.groups ?? [];
+
+  const [selected, setSelected] = useState<any | null>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [newGroupName, setNewGroupName] = useState("");
 
   // 관리자 여부 확인 (기존 로직 유지)
   const isMaster = useMemo(() =>
     session?.user?.name === process.env.NEXT_PUBLIC_MASTER,
     [session]);
 
-  const tokenAmounts = [10000, 100000, 1000000];
+  // 실제(사용자) 그룹과 좋아요 그룹 분리
+  const realGroups = useMemo(() => groups.filter(g => g.id !== LIKES_GROUP_ID), [groups]);
+  const likesGroup = useMemo(() => groups.find(g => g.id === LIKES_GROUP_ID), [groups]);
+  const likesActive = likesGroup?.is_trading_active ?? false;
 
-  // 모달 닫기 처리
-  const closeModal = () => {
-    setIsOpen(false);
-    setSelected(null);
+  // 종목을 그룹별 버킷으로 분류
+  const { byGroup, unassigned } = useMemo(() => {
+    const groupIds = new Set(realGroups.map(g => g.id));
+    const byGroup = new Map<string, DisplayRow[]>();
+    realGroups.forEach(g => byGroup.set(g.id, []));
+    const unassigned: DisplayRow[] = [];
+    for (const s of stockList) {
+      const row = normalizeCapital(s);
+      if (s.group_id && groupIds.has(s.group_id)) byGroup.get(s.group_id)!.push(row);
+      else unassigned.push(row);
+    }
+    return { byGroup, unassigned };
+  }, [stockList, realGroups]);
+
+  const likedRows = useMemo(() => (likedList ?? []).map(normalizeLiked), [likedList]);
+
+  const closeModal = () => { setIsOpen(false); setSelected(null); };
+  const openDetail = (raw: any) => { setSelected(raw); setIsOpen(true); };
+
+  const startRename = (g: StockGroup) => { setEditingGroupId(g.id); setEditingName(g.name); };
+  const commitRename = () => {
+    if (editingGroupId && editingName.trim()) onRenameGroup?.(editingGroupId, editingName.trim());
+    setEditingGroupId(null);
+    setEditingName("");
   };
+  const commitCreate = () => {
+    if (newGroupName.trim()) onCreateGroup?.(newGroupName.trim());
+    setNewGroupName("");
+    setCreating(false);
+  };
+
+  const colCount = 6 + (isMaster ? 1 : 0) + (isMaster ? 1 : 0); // 종목/PER·PBR/BPS·EPS/시총/NCAV/Token + (Refill) + (그룹)
 
   return (
     <div className={cn("w-full space-y-6", className)}>
-      {/* 1. Global Token Control (Only for Master) */}
+      {/* 1. Global Token Control + 새 그룹 추가 (Master) */}
       {isMaster && (
-        <section className="overflow-hidden rounded-xl border border-red-200 bg-red-50/30 p-1 dark:border-red-900/30 dark:bg-red-900/10 animate-in fade-in slide-in-from-top-4 duration-700">
+        <section className="overflow-hidden rounded-xl border border-red-200 bg-red-50/30 p-1 dark:border-red-900/30 dark:bg-red-900/10">
           <div className="flex items-center justify-between px-4 py-3 border-b border-red-100 dark:border-red-900/20">
             <div className="flex items-center gap-2">
               <Key className="w-4 h-4 text-red-600" />
@@ -96,119 +211,109 @@ export default function StockListTable({
                 </div>
               ))}
             </div>
+            {/* 새 그룹 추가 */}
+            <div className="ml-auto flex items-center gap-2">
+              {creating ? (
+                <div className="flex items-center gap-1">
+                  <input
+                    autoFocus
+                    value={newGroupName}
+                    onChange={(e) => setNewGroupName(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === "Enter") commitCreate(); if (e.key === "Escape") { setCreating(false); setNewGroupName(""); } }}
+                    placeholder="그룹 이름"
+                    className="w-28 rounded-md border border-neutral-300 dark:border-[#4a4641] bg-white dark:bg-[#1a1915] px-2 py-1 text-xs"
+                  />
+                  <button onClick={commitCreate} className="rounded-md bg-[#16a34a] p-1.5 text-white hover:bg-[#15803d]">
+                    <Check className="w-3.5 h-3.5" />
+                  </button>
+                  <button onClick={() => { setCreating(false); setNewGroupName(""); }} className="rounded-md p-1.5 text-neutral-400 hover:bg-neutral-100 dark:hover:bg-[#35332e]">
+                    <X className="w-3.5 h-3.5" />
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setCreating(true)}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-[#16a34a]/40 bg-[#16a34a]/10 px-3 py-1.5 text-xs font-bold text-[#16a34a] hover:bg-[#16a34a]/20 transition-colors"
+                >
+                  <Plus className="w-3.5 h-3.5" /> 새 그룹
+                </button>
+              )}
+            </div>
           </div>
         </section>
       )}
 
-      {/* 2. Desktop View (Table) */}
-      <div className="relative overflow-x-auto rounded-xl border border-neutral-200 bg-white shadow-sm dark:border-[#35332e] dark:bg-[#1a1915]">
-        <table className="w-full text-left text-[12px] border-collapse">
-          <thead className="bg-neutral-50/80 text-neutral-500 dark:bg-[#242320]/50 dark:text-neutral-400">
-            <tr>
-              <th className="px-4 py-3 font-semibold uppercase tracking-wider">종목</th>
-              <th className="px-4 py-3 font-semibold uppercase tracking-wider text-center">PER / PBR</th>
-              <th className="px-4 py-3 font-semibold uppercase tracking-wider">BPS / EPS</th>
-              <th className="px-4 py-3 font-semibold uppercase tracking-wider">시가총액</th>
-              <th className="px-4 py-3 font-semibold uppercase tracking-wider text-center">NCAV 비율</th>
-              <th className="px-4 py-3 font-semibold uppercase tracking-wider text-right">Token</th>
-              {isMaster && <th className="px-4 py-3 font-semibold uppercase tracking-wider text-right">Refill</th>}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-neutral-100 dark:divide-[#35332e]">
-            {rows.length === 0 ? (
-              <tr>
-                <td colSpan={isMaster ? 7 : 6} className="py-20 text-center">
-                  <div className="flex flex-col items-center gap-2 opacity-40">
-                    <Search className="w-10 h-10" />
-                    <p className="text-sm">운용 종목이 없습니다.</p>
-                  </div>
-                </td>
-              </tr>
-            ) : (
-              rows.map((row, idx) => (
-                <tr key={`row-${idx}`} className="group hover:bg-[#f0fdf4]/30 dark:hover:bg-[#14532d]/10 transition-colors">
-                  <td className="px-4 py-3">
-                    <button
-                      onClick={() => { setSelected(row); setIsOpen(true); }}
-                      className="flex items-center gap-2 group/btn"
-                    >
-                      <div className="p-1.5 rounded-md bg-[#faf9f7] dark:bg-[#35332e] group-hover/btn:bg-[#f0fdf4]0 group-hover/btn:text-white transition-all">
-                        <TrendingUp className="w-3.5 h-3.5" />
-                      </div>
-                      <span className="font-bold text-sm text-neutral-900 dark:text-neutral-100 group-hover/btn:text-[#16a34a] transition-colors tracking-tight">
-                        {row.symbol}
-                      </span>
-                    </button>
-                  </td>
-                  <td className="px-4 py-3 text-center">
-                    <div className="flex flex-col items-center font-mono">
-                      <span className="text-neutral-700 dark:text-neutral-300">{row.condition?.per || "-"}</span>
-                      <span className="text-[10px] text-neutral-400">{row.condition?.pbr || "-"}</span>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 font-mono leading-tight">
-                    <div className="flex flex-col">
-                      <span className="font-bold text-neutral-700 dark:text-neutral-300">B: {row.condition?.bps?.toLocaleString()}</span>
-                      <span className="text-[10px] text-neutral-400">E: {row.condition?.eps?.toLocaleString()}</span>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 font-mono text-neutral-600 dark:text-neutral-400">
-                    ₩{(row.condition?.MarketCapitalization || 0).toLocaleString()}억
-                  </td>
-                  <td className="px-4 py-3 text-center">
-                    <span className={cn(
-                      "inline-block px-2 py-0.5 rounded text-[11px] font-bold font-mono transition-colors",
-                      Number(row.ncavRatio) > 1 
-                        ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400" 
-                        : "bg-[#faf9f7] text-neutral-500 dark:bg-[#35332e] dark:text-neutral-500"
-                    )}>
-                      {row.ncavRatio}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-right font-mono font-black text-[#16a34a] dark:text-[#16a34a]">
-                    {row.token?.toLocaleString()}
-                  </td>
-                  {isMaster && (
-                    <td className="px-4 py-3">
-                      <div className="flex justify-end gap-1.5">
-                        {tokenAmounts.map(amt => (
-                          <div key={`indiv-${amt}`} className="flex items-center rounded-md border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] overflow-hidden shadow-xs">
-                            <button
-                              onClick={() => doTokenPlusOne(amt, row.symbol)}
-                              className="px-2 py-1 hover:bg-[#f5f1eb] dark:hover:bg-[#35332e] text-[10px] font-bold border-r border-neutral-100 dark:border-[#35332e]"
-                            >
-                              {amt / 10000}만
-                            </button>
-                            <button
-                              onClick={() => doTokenMinusOne(amt, row.symbol)}
-                              className="px-1.5 py-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-950 transition-colors"
-                            >
-                              <Minus className="w-3 h-3" />
-                            </button>
-                          </div>
-                        ))}
-                      </div>
-                    </td>
-                  )}
-                </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+      {/* 2. 좋아요(찜) 그룹 섹션 — 예약 그룹 */}
+      <GroupSection
+        title="좋아요 종목"
+        icon={<Heart className="w-4 h-4 text-rose-500" />}
+        accent="rose"
+        count={likedRows.length}
+        rows={likedRows}
+        isMaster={isMaster}
+        tradingActive={likesActive}
+        onToggleTrading={isMaster && onToggleLikesTrading ? () => onToggleLikesTrading(!likesActive) : undefined}
+        emptyText="좋아요한 종목이 없습니다. 검색·분석 페이지에서 ♥ 를 눌러 추가하세요."
+        realGroups={realGroups}
+        onMoveStock={onMoveStock}
+        doTokenPlusOne={doTokenPlusOne}
+        doTokenMinusOne={doTokenMinusOne}
+        openDetail={openDetail}
+      />
 
-      {/* 3. Detail Analysis Dialog (Custom Tailwind Modal) */}
+      {/* 3. 사용자 그룹 섹션들 */}
+      {realGroups.map((g) => (
+        <GroupSection
+          key={g.id}
+          title={g.name}
+          icon={<FolderOpen className="w-4 h-4 text-[#16a34a]" />}
+          accent="green"
+          count={(byGroup.get(g.id) ?? []).length}
+          rows={byGroup.get(g.id) ?? []}
+          isMaster={isMaster}
+          tradingActive={g.is_trading_active !== false}
+          onToggleTrading={isMaster && onToggleGroupTrading ? () => onToggleGroupTrading(g.id, !(g.is_trading_active !== false)) : undefined}
+          editing={editingGroupId === g.id}
+          editingName={editingName}
+          onEditNameChange={setEditingName}
+          onStartRename={isMaster && onRenameGroup ? () => startRename(g) : undefined}
+          onCommitRename={commitRename}
+          onDelete={isMaster && onDeleteGroup ? () => {
+            if (window.confirm(`'${g.name}' 그룹을 삭제할까요? 소속 종목은 '미지정'으로 이동합니다.`)) onDeleteGroup(g.id);
+          } : undefined}
+          emptyText="이 그룹에 종목이 없습니다."
+          realGroups={realGroups}
+          currentGroupId={g.id}
+          onMoveStock={onMoveStock}
+          doTokenPlusOne={doTokenPlusOne}
+          doTokenMinusOne={doTokenMinusOne}
+          openDetail={openDetail}
+        />
+      ))}
+
+      {/* 4. 미지정 섹션 */}
+      <GroupSection
+        title="미지정"
+        icon={<FolderOpen className="w-4 h-4 text-neutral-400" />}
+        accent="neutral"
+        count={unassigned.length}
+        rows={unassigned}
+        isMaster={isMaster}
+        tradingActive={true}
+        emptyText="미지정 종목이 없습니다."
+        realGroups={realGroups}
+        currentGroupId={null}
+        onMoveStock={onMoveStock}
+        doTokenPlusOne={doTokenPlusOne}
+        doTokenMinusOne={doTokenMinusOne}
+        openDetail={openDetail}
+      />
+
+      {/* 상세 분석 모달 */}
       {isOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-          {/* Backdrop */}
-          <div 
-            className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-in fade-in duration-300" 
-            onClick={closeModal} 
-          />
-          
-          {/* Modal Content */}
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-in fade-in duration-300" onClick={closeModal} />
           <div className="relative w-full max-w-2xl overflow-hidden rounded-2xl bg-white shadow-2xl dark:bg-[#242320] animate-in zoom-in-95 duration-300">
-            {/* Header */}
             <div className="flex items-center justify-between border-b border-neutral-100 p-4 dark:border-[#35332e]">
               <div className="flex items-center gap-2">
                 <div className="rounded-lg bg-[#16a34a] p-1.5 text-white">
@@ -218,39 +323,17 @@ export default function StockListTable({
                   Strategy Analysis: <span className="text-[#16a34a]">{selected?.symbol}</span>
                 </h2>
               </div>
-              <button 
-                onClick={closeModal}
-                className="rounded-full p-2 text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#35332e] transition-colors"
-              >
+              <button onClick={closeModal} className="rounded-full p-2 text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#35332e] transition-colors">
                 <X className="h-5 w-5" />
               </button>
             </div>
-
-            {/* Body */}
             <div className="p-6">
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-                <StatItem
-                  label="유동자산"
-                  value={`${(selected?.condition?.AssetsCurrent || 0).toLocaleString()}억`}
-                  icon={<Box className="w-3.5 h-3.5" />}
-                />
-                <StatItem
-                  label="유동부채"
-                  value={`${(selected?.condition?.LiabilitiesCurrent || 0).toLocaleString()}억`}
-                  icon={<ClipboardCheck className="w-3.5 h-3.5" />}
-                />
-                <StatItem
-                  label="당기순이익"
-                  value={`${(selected?.condition?.NetIncome || 0).toLocaleString()}억`}
-                  icon={<Wallet className="w-3.5 h-3.5" />}
-                />
-                <StatItem
-                  label="현재가"
-                  value={`₩${Number(selected?.condition?.LastPrice || 0).toLocaleString()}`}
-                  icon={<TrendingUp className="w-3.5 h-3.5" />}
-                />
+                <StatItem label="유동자산" value={`${(selected?.condition?.AssetsCurrent || 0).toLocaleString()}억`} icon={<Box className="w-3.5 h-3.5" />} />
+                <StatItem label="유동부채" value={`${(selected?.condition?.LiabilitiesCurrent || 0).toLocaleString()}억`} icon={<ClipboardCheck className="w-3.5 h-3.5" />} />
+                <StatItem label="당기순이익" value={`${(selected?.condition?.NetIncome || 0).toLocaleString()}억`} icon={<Wallet className="w-3.5 h-3.5" />} />
+                <StatItem label="현재가" value={`₩${Number(selected?.condition?.LastPrice || 0).toLocaleString()}`} icon={<TrendingUp className="w-3.5 h-3.5" />} />
               </div>
-
               <div className="space-y-3">
                 <div className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.2em] text-neutral-400">
                   <Info className="w-3 h-3" />
@@ -260,22 +343,14 @@ export default function StockListTable({
                   <pre className="max-h-[300px] overflow-auto rounded-xl border border-neutral-200 bg-[#fcfaf7] p-4 font-mono text-[11px] leading-relaxed dark:border-[#35332e] dark:bg-[#1a1915] dark:text-neutral-400">
                     {JSON.stringify(selected, null, 2)}
                   </pre>
-                  <button 
-                    onClick={() => navigator.clipboard.writeText(JSON.stringify(selected))}
-                    className="absolute right-3 top-3 rounded-md bg-white p-2 shadow-sm border border-neutral-200 opacity-0 group-hover:opacity-100 hover:bg-[#f0fdf4] transition-all dark:bg-[#35332e] dark:border-[#4a4641]"
-                  >
+                  <button onClick={() => navigator.clipboard.writeText(JSON.stringify(selected))} className="absolute right-3 top-3 rounded-md bg-white p-2 shadow-sm border border-neutral-200 opacity-0 group-hover:opacity-100 hover:bg-[#f0fdf4] transition-all dark:bg-[#35332e] dark:border-[#4a4641]">
                     <Copy className="h-3.5 w-3.5 text-neutral-600 dark:text-neutral-300" />
                   </button>
                 </div>
               </div>
             </div>
-
-            {/* Footer */}
             <div className="flex justify-end gap-3 border-t border-neutral-100 bg-neutral-50/50 p-4 dark:border-[#35332e] dark:bg-[#242320]/50">
-              <button
-                onClick={closeModal}
-                className="rounded-lg bg-[#16a34a] px-8 py-2.5 text-sm font-bold text-white shadow-lg shadow-[#16a34a]/20 hover:bg-[#15803d] active:scale-95 transition-all"
-              >
+              <button onClick={closeModal} className="rounded-lg bg-[#16a34a] px-8 py-2.5 text-sm font-bold text-white shadow-lg shadow-[#16a34a]/20 hover:bg-[#15803d] active:scale-95 transition-all">
                 확인
               </button>
             </div>
@@ -283,6 +358,223 @@ export default function StockListTable({
         </div>
       )}
     </div>
+  );
+}
+
+// =========================================================================
+// 그룹 섹션
+// =========================================================================
+interface GroupSectionProps {
+  title: string;
+  icon: React.ReactNode;
+  accent: "rose" | "green" | "neutral";
+  count: number;
+  rows: DisplayRow[];
+  isMaster: boolean;
+  tradingActive: boolean;
+  onToggleTrading?: () => void;
+  editing?: boolean;
+  editingName?: string;
+  onEditNameChange?: (v: string) => void;
+  onStartRename?: () => void;
+  onCommitRename?: () => void;
+  onDelete?: () => void;
+  emptyText: string;
+  realGroups: StockGroup[];
+  currentGroupId?: string | null;
+  onMoveStock?: (ticker: string, groupId: string | null) => void;
+  doTokenPlusOne: (val: number, sym: string) => void;
+  doTokenMinusOne: (val: number, sym: string) => void;
+  openDetail: (raw: any) => void;
+}
+
+function GroupSection({
+  title, icon, accent, count, rows, isMaster, tradingActive, onToggleTrading,
+  editing, editingName, onEditNameChange, onStartRename, onCommitRename, onDelete,
+  emptyText, realGroups, currentGroupId, onMoveStock,
+  doTokenPlusOne, doTokenMinusOne, openDetail,
+}: GroupSectionProps) {
+  const showRefill = isMaster && rows.some(r => r.movable);
+  const showGroupSelect = isMaster && !!onMoveStock && rows.some(r => r.movable);
+  const baseCols = 6;
+  const colSpan = baseCols + (showRefill ? 1 : 0) + (showGroupSelect ? 1 : 0);
+
+  const accentBorder = accent === "rose" ? "border-rose-200 dark:border-rose-900/30"
+    : accent === "green" ? "border-[#16a34a]/20 dark:border-[#16a34a]/20"
+    : "border-neutral-200 dark:border-[#35332e]";
+
+  return (
+    <section className={cn("overflow-hidden rounded-xl border bg-white shadow-sm dark:bg-[#1a1915]", accentBorder)}>
+      {/* 헤더 */}
+      <div className="flex flex-wrap items-center gap-3 px-4 py-3 border-b border-neutral-100 dark:border-[#35332e] bg-neutral-50/60 dark:bg-[#242320]/40">
+        <div className="flex items-center gap-2 min-w-0">
+          {icon}
+          {editing ? (
+            <input
+              autoFocus
+              value={editingName}
+              onChange={(e) => onEditNameChange?.(e.target.value)}
+              onBlur={onCommitRename}
+              onKeyDown={(e) => { if (e.key === "Enter") onCommitRename?.(); }}
+              className="rounded-md border border-neutral-300 dark:border-[#4a4641] bg-white dark:bg-[#1a1915] px-2 py-0.5 text-sm font-bold"
+            />
+          ) : (
+            <h3 className="text-sm font-bold text-neutral-900 dark:text-neutral-100 truncate">{title}</h3>
+          )}
+          {onStartRename && !editing && (
+            <button onClick={onStartRename} className="text-neutral-300 hover:text-neutral-600 dark:hover:text-neutral-200">
+              <Pencil className="w-3.5 h-3.5" />
+            </button>
+          )}
+          <span className="px-2 py-0.5 text-[10px] font-mono font-bold bg-neutral-100 text-neutral-500 dark:bg-[#35332e] dark:text-neutral-400 rounded-full">
+            {count}종목
+          </span>
+        </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          {/* 자동매매 토글 */}
+          {onToggleTrading ? (
+            <button
+              onClick={onToggleTrading}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold transition-colors",
+                tradingActive
+                  ? "bg-[#16a34a] text-white hover:bg-[#15803d]"
+                  : "bg-neutral-200 text-neutral-500 hover:bg-neutral-300 dark:bg-[#35332e] dark:text-neutral-400"
+              )}
+            >
+              <Power className="w-3.5 h-3.5" />
+              자동매매 {tradingActive ? "ON" : "OFF"}
+            </button>
+          ) : (
+            <span className={cn(
+              "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold",
+              tradingActive ? "bg-[#16a34a]/10 text-[#16a34a]" : "bg-neutral-100 text-neutral-400 dark:bg-[#35332e]"
+            )}>
+              <Power className="w-3.5 h-3.5" />
+              자동매매 {tradingActive ? "ON" : "OFF"}
+            </span>
+          )}
+          {/* 삭제 */}
+          {onDelete && (
+            <button onClick={onDelete} className="rounded-lg p-1.5 text-neutral-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-950 transition-colors">
+              <Trash2 className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* 테이블 */}
+      <div className="relative overflow-x-auto">
+        <table className="w-full text-left text-[12px] border-collapse">
+          <thead className="bg-neutral-50/80 text-neutral-500 dark:bg-[#242320]/50 dark:text-neutral-400">
+            <tr>
+              <th className="px-4 py-2.5 font-semibold uppercase tracking-wider">종목</th>
+              <th className="px-4 py-2.5 font-semibold uppercase tracking-wider text-center">PER / PBR</th>
+              <th className="px-4 py-2.5 font-semibold uppercase tracking-wider">BPS / EPS</th>
+              <th className="px-4 py-2.5 font-semibold uppercase tracking-wider">시가총액</th>
+              <th className="px-4 py-2.5 font-semibold uppercase tracking-wider text-center">NCAV 비율</th>
+              <th className="px-4 py-2.5 font-semibold uppercase tracking-wider text-right">Token</th>
+              {showGroupSelect && <th className="px-4 py-2.5 font-semibold uppercase tracking-wider text-center">그룹</th>}
+              {showRefill && <th className="px-4 py-2.5 font-semibold uppercase tracking-wider text-right">Refill</th>}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-100 dark:divide-[#35332e]">
+            {rows.length === 0 ? (
+              <tr>
+                <td colSpan={colSpan} className="py-12 text-center">
+                  <div className="flex flex-col items-center gap-2 opacity-40">
+                    <Search className="w-8 h-8" />
+                    <p className="text-xs">{emptyText}</p>
+                  </div>
+                </td>
+              </tr>
+            ) : (
+              rows.map((row, idx) => (
+                <tr key={`${title}-${row.symbol}-${idx}`} className="group hover:bg-[#f0fdf4]/30 dark:hover:bg-[#14532d]/10 transition-colors">
+                  <td className="px-4 py-3">
+                    <button onClick={() => openDetail(row.raw)} className="flex items-center gap-2 group/btn">
+                      <div className="p-1.5 rounded-md bg-[#faf9f7] dark:bg-[#35332e] transition-all">
+                        <TrendingUp className="w-3.5 h-3.5" />
+                      </div>
+                      <span className="font-bold text-sm text-neutral-900 dark:text-neutral-100 group-hover/btn:text-[#16a34a] transition-colors tracking-tight">
+                        {row.symbol}
+                      </span>
+                    </button>
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <div className="flex flex-col items-center font-mono">
+                      <span className="text-neutral-700 dark:text-neutral-300">{row.per ?? "-"}</span>
+                      <span className="text-[10px] text-neutral-400">{row.pbr ?? "-"}</span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 font-mono leading-tight">
+                    <div className="flex flex-col">
+                      <span className="font-bold text-neutral-700 dark:text-neutral-300">B: {row.bps?.toLocaleString() ?? "-"}</span>
+                      <span className="text-[10px] text-neutral-400">E: {row.eps?.toLocaleString() ?? "-"}</span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 font-mono text-neutral-600 dark:text-neutral-400">
+                    ₩{(row.marketCap || 0).toLocaleString()}억
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <span className={cn(
+                      "inline-block px-2 py-0.5 rounded text-[11px] font-bold font-mono transition-colors",
+                      Number(row.ncavRatio) > 1
+                        ? "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
+                        : "bg-[#faf9f7] text-neutral-500 dark:bg-[#35332e] dark:text-neutral-500"
+                    )}>
+                      {row.ncavRatio ?? "-"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono font-black text-[#16a34a] dark:text-[#16a34a]">
+                    {row.movable ? (row.token?.toLocaleString() ?? 0) : "-"}
+                  </td>
+                  {showGroupSelect && (
+                    <td className="px-4 py-3 text-center">
+                      {row.movable ? (
+                        <select
+                          value={currentGroupId ?? ""}
+                          onChange={(e) => onMoveStock?.(row.symbol, e.target.value || null)}
+                          className="rounded-md border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] px-2 py-1 text-[11px]"
+                        >
+                          <option value="">미지정</option>
+                          {realGroups.map(g => (
+                            <option key={g.id} value={g.id}>{g.name}</option>
+                          ))}
+                        </select>
+                      ) : (
+                        <span className="text-neutral-300">-</span>
+                      )}
+                    </td>
+                  )}
+                  {showRefill && (
+                    <td className="px-4 py-3">
+                      {row.movable ? (
+                        <div className="flex justify-end gap-1.5">
+                          {tokenAmounts.map(amt => (
+                            <div key={`indiv-${amt}`} className="flex items-center rounded-md border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] overflow-hidden shadow-xs">
+                              <button onClick={() => doTokenPlusOne(amt, row.symbol)} className="px-2 py-1 hover:bg-[#f5f1eb] dark:hover:bg-[#35332e] text-[10px] font-bold border-r border-neutral-100 dark:border-[#35332e]">
+                                {amt / 10000}만
+                              </button>
+                              <button onClick={() => doTokenMinusOne(amt, row.symbol)} className="px-1.5 py-1 text-red-500 hover:bg-red-50 dark:hover:bg-red-950 transition-colors">
+                                <Minus className="w-3 h-3" />
+                              </button>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="block text-right text-neutral-300">-</span>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
   );
 }
 

--- a/cf-idiotquant/lib/features/capital/capitalAPI.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalAPI.tsx
@@ -73,3 +73,28 @@ export const postUsCapitalTokenMinusOne: any = async (key: string, num: number, 
     }
     return postKoreaInvestmentRequest(subUrl, additionalHeaders);
 }
+
+// ============================================================================
+// 종목 그룹 관리 API (KR / US)
+// ============================================================================
+type GroupUpdates = { name?: string; is_trading_active?: boolean };
+
+// KR
+export const postKrCapitalGroupCreate: any = async (key: string, name: string) =>
+    postKoreaInvestmentRequest(`/kr/capital/groups/create?kakao-id=${key}`, {}, { name });
+export const postKrCapitalGroupUpdate: any = async (key: string, groupId: string, updates: GroupUpdates) =>
+    postKoreaInvestmentRequest(`/kr/capital/groups/${groupId}/update?kakao-id=${key}`, {}, updates);
+export const postKrCapitalGroupDelete: any = async (key: string, groupId: string) =>
+    postKoreaInvestmentRequest(`/kr/capital/groups/${groupId}/delete?kakao-id=${key}`, {});
+export const postKrCapitalStockGroup: any = async (key: string, ticker: string, groupId: string | null) =>
+    postKoreaInvestmentRequest(`/kr/capital/stock/${ticker}/group?kakao-id=${key}`, {}, { group_id: groupId });
+
+// US
+export const postUsCapitalGroupCreate: any = async (key: string, name: string) =>
+    postKoreaInvestmentRequest(`/us/capital/groups/create?kakao-id=${key}`, {}, { name });
+export const postUsCapitalGroupUpdate: any = async (key: string, groupId: string, updates: GroupUpdates) =>
+    postKoreaInvestmentRequest(`/us/capital/groups/${groupId}/update?kakao-id=${key}`, {}, updates);
+export const postUsCapitalGroupDelete: any = async (key: string, groupId: string) =>
+    postKoreaInvestmentRequest(`/us/capital/groups/${groupId}/delete?kakao-id=${key}`, {});
+export const postUsCapitalStockGroup: any = async (key: string, ticker: string, groupId: string | null) =>
+    postKoreaInvestmentRequest(`/us/capital/stock/${ticker}/group?kakao-id=${key}`, {}, { group_id: groupId });

--- a/cf-idiotquant/lib/features/capital/capitalSlice.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalSlice.tsx
@@ -1,6 +1,9 @@
 import { PayloadAction } from "@reduxjs/toolkit";
 import { createAppSlice } from "@/lib/createAppSlice";
-import { getKrCapital, getUsCapital, postKrCapitalTokenMinusAll, postKrCapitalTokenMinusOne, postKrCapitalTokenPlusAll, postKrCapitalTokenPlusOne, postUsCapitalTokenMinusAll, postUsCapitalTokenMinusOne, postUsCapitalTokenPlusAll, postUsCapitalTokenPlusOne } from "./capitalAPI";
+import { getKrCapital, getUsCapital, postKrCapitalTokenMinusAll, postKrCapitalTokenMinusOne, postKrCapitalTokenPlusAll, postKrCapitalTokenPlusOne, postUsCapitalTokenMinusAll, postUsCapitalTokenMinusOne, postUsCapitalTokenPlusAll, postUsCapitalTokenPlusOne, postKrCapitalGroupCreate, postKrCapitalGroupUpdate, postKrCapitalGroupDelete, postKrCapitalStockGroup, postUsCapitalGroupCreate, postUsCapitalGroupUpdate, postUsCapitalGroupDelete, postUsCapitalStockGroup } from "./capitalAPI";
+
+/** 예약(가상) 그룹 id — 좋아요(찜) 종목 그룹 */
+export const LIKES_GROUP_ID = "__likes__";
 
 export interface StockCondition {
     AssetsCurrent: number;
@@ -15,6 +18,12 @@ export interface StockCondition {
     per: number;
 }
 
+export interface StockGroup {
+    id: string;
+    name: string;
+    is_trading_active: boolean;
+}
+
 export interface UsCapitalStockItem {
     symbol: string;
     key: string;
@@ -22,6 +31,8 @@ export interface UsCapitalStockItem {
     ncavRatio?: string;
     token?: number;
     action?: string;
+    group_id?: string | null;
+    name?: string;
 }
 
 export interface KrUsCapitalType {
@@ -30,6 +41,7 @@ export interface KrUsCapitalType {
     token_info: { token_per_stock: number; refill_stock_index: number };
     charge_info: { capital_charge_per_year: string; capital_charge_per_month: number; capital_charge_rate: number };
     stock_list: UsCapitalStockItem[];
+    groups?: StockGroup[];
     corp_scan_index: number;
     action: string;
     frst_bltn_exrt: number;
@@ -51,6 +63,8 @@ export interface CapitalType {
     usCapitalTokenPlusOne: CapitalTokenRefillType;
     usCapitalTokenMinusAll: CapitalTokenRefillType;
     usCapitalTokenMinusOne: CapitalTokenRefillType;
+    krGroupOp: CapitalTokenRefillType;
+    usGroupOp: CapitalTokenRefillType;
 }
 
 const initialState: CapitalType = {
@@ -119,6 +133,12 @@ const initialState: CapitalType = {
         state: "init"
     },
     usCapitalTokenMinusOne: {
+        state: "init"
+    },
+    krGroupOp: {
+        state: "init"
+    },
+    usGroupOp: {
         state: "init"
     }
 }
@@ -330,6 +350,74 @@ export const capitalSlice = createAppSlice({
                 }
             }
         ),
+
+        // ── 종목 그룹 관리 (KR) ──
+        reqPostKrCapitalGroupCreate: create.asyncThunk(
+            async ({ key, name }: { key?: string, name: string }) => postKrCapitalGroupCreate(key, name),
+            {
+                pending: (state) => { state.krGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
+                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+            }
+        ),
+        reqPostKrCapitalGroupUpdate: create.asyncThunk(
+            async ({ key, groupId, updates }: { key?: string, groupId: string, updates: { name?: string, is_trading_active?: boolean } }) => postKrCapitalGroupUpdate(key, groupId, updates),
+            {
+                pending: (state) => { state.krGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
+                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+            }
+        ),
+        reqPostKrCapitalGroupDelete: create.asyncThunk(
+            async ({ key, groupId }: { key?: string, groupId: string }) => postKrCapitalGroupDelete(key, groupId),
+            {
+                pending: (state) => { state.krGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
+                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+            }
+        ),
+        reqPostKrCapitalStockGroup: create.asyncThunk(
+            async ({ key, ticker, groupId }: { key?: string, ticker: string, groupId: string | null }) => postKrCapitalStockGroup(key, ticker, groupId),
+            {
+                pending: (state) => { state.krGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
+                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+            }
+        ),
+
+        // ── 종목 그룹 관리 (US) ──
+        reqPostUsCapitalGroupCreate: create.asyncThunk(
+            async ({ key, name }: { key?: string, name: string }) => postUsCapitalGroupCreate(key, name),
+            {
+                pending: (state) => { state.usGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
+                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+            }
+        ),
+        reqPostUsCapitalGroupUpdate: create.asyncThunk(
+            async ({ key, groupId, updates }: { key?: string, groupId: string, updates: { name?: string, is_trading_active?: boolean } }) => postUsCapitalGroupUpdate(key, groupId, updates),
+            {
+                pending: (state) => { state.usGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
+                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+            }
+        ),
+        reqPostUsCapitalGroupDelete: create.asyncThunk(
+            async ({ key, groupId }: { key?: string, groupId: string }) => postUsCapitalGroupDelete(key, groupId),
+            {
+                pending: (state) => { state.usGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
+                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+            }
+        ),
+        reqPostUsCapitalStockGroup: create.asyncThunk(
+            async ({ key, ticker, groupId }: { key?: string, ticker: string, groupId: string | null }) => postUsCapitalStockGroup(key, ticker, groupId),
+            {
+                pending: (state) => { state.usGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
+                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+            }
+        ),
     }),
     selectors: {
         selectKrCapital: (state) => state.krCapital,
@@ -342,10 +430,15 @@ export const capitalSlice = createAppSlice({
         selectUsCapitalTokenPlusOne: (state) => state.usCapitalTokenPlusOne,
         selectUsCapitalTokenMinusAll: (state) => state.usCapitalTokenMinusAll,
         selectUsCapitalTokenMinusOne: (state) => state.usCapitalTokenMinusOne,
+        selectKrGroupOp: (state) => state.krGroupOp,
+        selectUsGroupOp: (state) => state.usGroupOp,
     }
 });
 
 export const { reqGetKrCapital, reqPostKrCapitalTokenPlusAll, reqPostKrCapitalTokenPlusOne, reqPostKrCapitalTokenMinusAll, reqPostKrCapitalTokenMinusOne } = capitalSlice.actions;
 export const { selectKrCapital, selectKrCapitalTokenPlusAll, selectKrCapitalTokenPlusOne, selectKrCapitalTokenMinusAll, selectKrCapitalTokenMinusOne } = capitalSlice.selectors;
+export const { reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate, reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup } = capitalSlice.actions;
+export const { reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate, reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup } = capitalSlice.actions;
+export const { selectKrGroupOp, selectUsGroupOp } = capitalSlice.selectors;
 export const { reqGetUsCapital, reqPostUsCapitalTokenPlusAll, reqPostUsCapitalTokenPlusOne, reqPostUsCapitalTokenMinusAll, reqPostUsCapitalTokenMinusOne } = capitalSlice.actions;
 export const { selectUsCapital, selectUsCapitalTokenPlusAll, selectUsCapitalTokenPlusOne, selectUsCapitalTokenMinusAll, selectUsCapitalTokenMinusOne } = capitalSlice.selectors;


### PR DESCRIPTION
## Summary

balance-kr·balance-us 의 "NCAV 운용 종목 관리" 섹션을 **여러 그룹**으로 나눠 관리하고, **그룹별로 자동매매 포함 여부**를 토글할 수 있게 한다. 추가로 **좋아요(찜) 종목**도 별도 예약 그룹으로 묶어 자동매매 포함 여부를 설정할 수 있다.

> 백엔드 변경은 동반 PR(idiotquant-worker)에 있습니다. 데이터 모델은 `capital_tokens.state_json` 의 `groups` 배열 + 종목별 `group_id` 필드로, DB 스키마 마이그레이션 없이 처리됩니다.

## Changes

### `lib/features/capital/capitalSlice.tsx`
- `StockGroup` 인터페이스 추가, `UsCapitalStockItem.group_id?`, `KrUsCapitalType.groups?` 확장
- 그룹 CRUD thunk 추가 (KR/US 각각): `reqPostKrCapitalGroupCreate` / `…GroupUpdate` / `…GroupDelete` / `…StockGroup`

### `lib/features/capital/capitalAPI.tsx`
- 그룹 생성/수정/삭제 + 종목 그룹 이동 API 함수 추가 (기존 `postKoreaInvestmentRequest` 재사용)

### `components/balance/stockListTable.tsx`
- 단일 테이블 → **그룹 섹션** 구조로 재구성: 그룹별 헤더(이름 인라인 편집·종목수·자동매매 ON/OFF 토글·삭제), 종목 행에 그룹 이동 `select` 컬럼 (master 전용)
- "미지정" 섹션(그룹 없는 종목) + "새 그룹 추가" 인라인 입력
- **좋아요 종목 예약 섹션**(상단 고정): 찜 종목 읽기 전용 표시 + 자동매매 토글 (예약 그룹 `__likes__`)

### `app/(balance-kr)/balance-kr/page.tsx` · `app/(balance-us)/balance-us/page.tsx`
- 그룹 op 핸들러 + 완료 시 캐피탈 재조회·토스트 (기존 token op 패턴)
- `reqGetMyLikes()` 로 찜 목록 로드, 나라별(`is_us`) 필터해 테이블에 전달

## 동작
- 그룹 `is_trading_active: false` → 백엔드 `makeStockList` 가 해당 그룹 종목을 `inactive` 강제 (동반 PR)
- 좋아요 그룹 기본 OFF — 명시적으로 켜야 찜 종목이 자동매매 후보로 병합됨
- `groups` 없는 기존 데이터 → 전 종목 "미지정" 섹션, 자동매매 포함(기존 동작 유지)

## Test Plan
- [ ] balance-kr/us 에서 그룹 생성·이름변경·자동매매 토글·종목 이동·삭제 동작
- [ ] 좋아요 섹션에 찜 종목 표시 + 토글 동작
- [ ] 기존 데이터(groups 없음) 에서 정상 렌더 확인
- [ ] `npx tsc --noEmit` · `npm run build` 통과

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_