### PR TITLE
balance-kr/us: 자동매매 트레이딩 조건(quant_rule) 조회·수정 UI

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
+++ b/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   LayoutDashboard, ChevronRight, MapPin,
   Clock, Wallet, Coins, Percent,
-  Database, User, PieChart, BarChart3, ClipboardList, Power,
+  Database, User, PieChart, BarChart3, ClipboardList, Power, SlidersHorizontal,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 
@@ -37,11 +37,13 @@ import {
   reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate,
   reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup,
   selectKrGroupOp,
+  reqGetKrQuantRule, reqPostKrQuantRule, selectKrQuantRule,
 } from "@/lib/features/capital/capitalSlice";
 import { reqGetMyLikes, selectLikedList } from "@/lib/features/stockLikes/stockLikesSlice";
 
 import InquireBalanceResult from "@/components/inquireBalanceResult";
 import StockListTable from "@/components/balance/stockListTable";
+import QuantRuleEditor from "@/components/balance/quantRuleEditor";
 import { PortfolioChartSection } from "@/components/balance/portfolioChart";
 import { SectionNav, type NavSection } from "@/components/balance/sectionNav";
 import {
@@ -200,8 +202,10 @@ function BalanceKr() {
   const krCapitalMinusAll = useAppSelector(selectKrCapitalTokenMinusAll);
   const krCapitalMinusOne = useAppSelector(selectKrCapitalTokenMinusOne);
   const krGroupOp = useAppSelector(selectKrGroupOp);
+  const krQuantRule = useAppSelector(selectKrQuantRule);
   const likedListAll = useAppSelector(selectLikedList);
   const krLikedList = useMemo(() => (likedListAll ?? []).filter((l: any) => !l.is_us), [likedListAll]);
+  const isMaster = useMemo(() => session?.user?.name === process.env.NEXT_PUBLIC_MASTER, [session]);
 
   const tradingStatus = useAppSelector(selectTradingStatus);
 
@@ -279,6 +283,17 @@ function BalanceKr() {
     dispatch(reqGetMyLikes());
   }, [session, status, dispatch, router]);
 
+  // 트레이딩 조건(quant_rule) 로드
+  useEffect(() => {
+    if (balanceKey && balanceKey !== "undefined") dispatch(reqGetKrQuantRule(balanceKey));
+  }, [balanceKey, dispatch]);
+
+  // 조건 저장 결과 토스트
+  useEffect(() => {
+    if (krQuantRule?.saveState === "fulfilled") addToast("success", "트레이딩 조건이 저장되었습니다.");
+    else if (krQuantRule?.saveState === "rejected") addToast("error", "조건 저장에 실패했습니다.");
+  }, [krQuantRule?.saveState]);
+
   useEffect(() => {
     if (krCapital.state === "init" && balanceKey) {
       dispatch(reqGetKrCapital(balanceKey));
@@ -324,6 +339,7 @@ function BalanceKr() {
   const doDeleteGroup = (groupId: string) => dispatch(reqPostKrCapitalGroupDelete({ key: balanceKey, groupId }));
   const doMoveStock = (ticker: string, groupId: string | null) => dispatch(reqPostKrCapitalStockGroup({ key: balanceKey, ticker, groupId }));
   const doToggleLikesTrading = (isActive: boolean) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId: "__likes__", updates: { is_trading_active: isActive } }));
+  const doSaveQuantRule = (rule: any) => dispatch(reqPostKrQuantRule({ key: balanceKey, rule }));
 
   const summary = kiBalance.output2?.[0] || {};
   const totalEvalAmt = Number(summary.tot_evlu_amt || 0);
@@ -361,6 +377,7 @@ function BalanceKr() {
     { id: "section-portfolio", label: "포트폴리오", icon: <PieChart size={13} /> },
     { id: "section-balance", label: "잔고", icon: <BarChart3 size={13} /> },
     ...(hasCapital ? [{ id: "section-stocks", label: "종목관리", icon: <Database size={13} /> }] : []),
+    ...(hasCapital ? [{ id: "section-conditions", label: "트레이딩 조건", icon: <SlidersHorizontal size={13} /> }] : []),
     { id: "section-orders", label: "주문내역", icon: <ClipboardList size={13} /> },
   ];
 
@@ -611,6 +628,32 @@ function BalanceKr() {
         )}
 
         </div>{/* /section-stocks mobile tab */}
+
+        {/* 트레이딩 조건 설정 (모바일 탭: section-conditions) */}
+        <div className={cn(mobileTab !== "section-conditions" && "hidden md:block")}>
+        {hasCapital && (
+          <SectionPanel id="section-conditions">
+            <SectionHeader
+              icon={<SlidersHorizontal size={16} />}
+              title="자동매매 트레이딩 조건"
+              subtitle="백엔드 quant rule(NCAV 비율·필터·활성 종목 수 등) 조회 및 수정"
+              badge={
+                krQuantRule.state === "pending"
+                  ? <span className="text-[10px] font-mono text-amber-500 bg-amber-50 dark:bg-amber-950/20 px-2 py-0.5 rounded-full border border-amber-200 dark:border-amber-800 animate-pulse">로딩 중</span>
+                  : krQuantRule.is_override
+                  ? <span className="text-[10px] font-mono text-[#16a34a] bg-[#f0fdf4] dark:bg-[#14532d]/30 px-2 py-0.5 rounded-full">계좌 전용</span>
+                  : <span className="text-[10px] font-mono text-neutral-500 dark:text-neutral-400 bg-[#faf9f7] dark:bg-[#242320] px-2 py-0.5 rounded-full">기본값</span>
+              }
+            />
+            <QuantRuleEditor
+              data={krQuantRule}
+              isMaster={isMaster}
+              onSave={doSaveQuantRule}
+            />
+          </SectionPanel>
+        )}
+
+        </div>{/* /section-conditions mobile tab */}
 
         {/* 주문 내역 (모바일 탭: section-orders) */}
         <div className={cn(mobileTab !== "section-orders" && "hidden md:block")}>

--- a/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
+++ b/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
@@ -6,7 +6,7 @@ import {
   Globe, ChevronRight, DollarSign, Building2,
   Wallet, TrendingUp, BarChart3, RefreshCw,
   Clock, AlertCircle, Database,
-  ArrowDownRight, PieChart, ClipboardList, TrendingDown, Power,
+  ArrowDownRight, PieChart, ClipboardList, TrendingDown, Power, SlidersHorizontal,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 
@@ -44,10 +44,12 @@ import {
   reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate,
   reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup,
   selectUsGroupOp,
+  reqGetUsQuantRule, reqPostUsQuantRule, selectUsQuantRule,
 } from "@/lib/features/capital/capitalSlice";
 import { reqGetMyLikes, selectLikedList } from "@/lib/features/stockLikes/stockLikesSlice";
 
 import InquireBalanceResult from "@/components/inquireBalanceResult";
+import QuantRuleEditor from "@/components/balance/quantRuleEditor";
 import StockListTable from "@/components/balance/stockListTable";
 import { PortfolioChartSection } from "@/components/balance/portfolioChart";
 import { SectionNav, type NavSection } from "@/components/balance/sectionNav";
@@ -188,8 +190,10 @@ function BalanceUs() {
   const usCapitalMinusAll = useAppSelector(selectUsCapitalTokenMinusAll);
   const usCapitalMinusOne = useAppSelector(selectUsCapitalTokenMinusOne);
   const usGroupOp = useAppSelector(selectUsGroupOp);
+  const usQuantRule = useAppSelector(selectUsQuantRule);
   const likedListAll = useAppSelector(selectLikedList);
   const usLikedList = useMemo(() => (likedListAll ?? []).filter((l: any) => !!l.is_us), [likedListAll]);
+  const isMaster = useMemo(() => session?.user?.name === process.env.NEXT_PUBLIC_MASTER, [session]);
 
   const tradingStatus = useAppSelector(selectTradingStatus);
 
@@ -257,6 +261,17 @@ function BalanceUs() {
     dispatch(reqGetMyLikes());
   }, [session, status, dispatch, router]);
 
+  // 트레이딩 조건(quant_rule) 로드
+  useEffect(() => {
+    if (balanceKey && balanceKey !== "undefined") dispatch(reqGetUsQuantRule(balanceKey));
+  }, [balanceKey, dispatch]);
+
+  // 조건 저장 결과 토스트
+  useEffect(() => {
+    if (usQuantRule?.saveState === "fulfilled") addToast("success", "트레이딩 조건이 저장되었습니다.");
+    else if (usQuantRule?.saveState === "rejected") addToast("error", "조건 저장에 실패했습니다.");
+  }, [usQuantRule?.saveState]);
+
   useEffect(() => {
     if (!balanceKey || balanceKey === "undefined") return;
     if (searchParams.get("key") !== balanceKey) {
@@ -304,6 +319,7 @@ function BalanceUs() {
   const doDeleteGroup = (groupId: string) => dispatch(reqPostUsCapitalGroupDelete({ key: balanceKey, groupId }));
   const doMoveStock = (ticker: string, groupId: string | null) => dispatch(reqPostUsCapitalStockGroup({ key: balanceKey, ticker, groupId }));
   const doToggleLikesTrading = (isActive: boolean) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId: "__likes__", updates: { is_trading_active: isActive } }));
+  const doSaveQuantRule = (rule: any) => dispatch(reqPostUsQuantRule({ key: balanceKey, rule }));
 
   const out2 = kiBalance?.output2?.[0];
   const out3 = kiBalance?.output3;
@@ -359,6 +375,7 @@ function BalanceUs() {
     { id: "section-portfolio", label: "포트폴리오", icon: <PieChart size={13} /> },
     { id: "section-balance", label: "잔고", icon: <BarChart3 size={13} /> },
     ...(hasCapital ? [{ id: "section-stocks", label: "종목관리", icon: <Database size={13} /> }] : []),
+    ...(hasCapital ? [{ id: "section-conditions", label: "트레이딩 조건", icon: <SlidersHorizontal size={13} /> }] : []),
     { id: "section-orders", label: "해외주문", icon: <ClipboardList size={13} /> },
   ];
 
@@ -656,6 +673,32 @@ function BalanceUs() {
         )}
 
         </div>{/* /section-stocks mobile tab */}
+
+        {/* 트레이딩 조건 설정 (모바일 탭: section-conditions) */}
+        <div className={cn(mobileTab !== "section-conditions" && "hidden md:block")}>
+        {hasCapital && (
+          <SectionPanel id="section-conditions">
+            <SectionHeader
+              icon={<SlidersHorizontal size={16} />}
+              title="자동매매 트레이딩 조건"
+              subtitle="백엔드 quant rule(NCAV 비율·필터·활성 종목 수 등) 조회 및 수정"
+              badge={
+                usQuantRule.state === "pending"
+                  ? <span className="text-[10px] font-mono text-amber-500 bg-amber-50 dark:bg-amber-950/20 px-2 py-0.5 rounded-full border border-amber-200 dark:border-amber-800 animate-pulse">로딩 중</span>
+                  : usQuantRule.is_override
+                  ? <span className="text-[10px] font-mono text-[#16a34a] bg-[#f0fdf4] dark:bg-[#14532d]/30 px-2 py-0.5 rounded-full">계좌 전용</span>
+                  : <span className="text-[10px] font-mono text-neutral-500 dark:text-neutral-400 bg-[#faf9f7] dark:bg-[#242320] px-2 py-0.5 rounded-full">기본값</span>
+              }
+            />
+            <QuantRuleEditor
+              data={usQuantRule}
+              isMaster={isMaster}
+              onSave={doSaveQuantRule}
+            />
+          </SectionPanel>
+        )}
+
+        </div>{/* /section-conditions mobile tab */}
 
         {/* 주문 내역 (모바일 탭: section-orders) */}
         <div className={cn(mobileTab !== "section-orders" && "hidden md:block")}>

--- a/cf-idiotquant/components/balance/quantRuleEditor.tsx
+++ b/cf-idiotquant/components/balance/quantRuleEditor.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import { SlidersHorizontal, Save, RotateCcw, Info, Lock, CheckCircle2 } from "lucide-react";
+import { QuantRule, QuantRuleState } from "@/lib/features/capital/capitalSlice";
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+interface Props {
+  data?: QuantRuleState;
+  isMaster: boolean;
+  onSave: (rule: QuantRule) => void;
+  className?: string;
+}
+
+// 기본 표시 순서 (백엔드 desc 가 비어 있어도 최소한의 폴백)
+const FALLBACK_ORDER = [
+  "ncav_ratio", "active_count", "portfolio_weight",
+  "max_pbr", "min_pbr", "min_per", "min_eps", "min_bps",
+  "exclude_call_warrants", "exclude_key_word",
+];
+
+function ruleToDraft(rule: QuantRule): Record<string, string | boolean> {
+  const d: Record<string, string | boolean> = {};
+  for (const [k, v] of Object.entries(rule ?? {})) {
+    if (Array.isArray(v)) d[k] = v.join(", ");
+    else if (typeof v === "boolean") d[k] = v;
+    else d[k] = v == null ? "" : String(v);
+  }
+  return d;
+}
+
+export default function QuantRuleEditor({ data, isMaster, onSave, className = "" }: Props) {
+  const rule = data?.rule ?? {};
+  const desc = data?.desc ?? {};
+  const saving = data?.saveState === "pending";
+
+  const [draft, setDraft] = useState<Record<string, string | boolean>>(() => ruleToDraft(rule));
+  const [dirty, setDirty] = useState(false);
+
+  // 서버에서 새 rule 이 도착하면(저장 후/최초 로드) draft 동기화 — 단, 편집 중이면 보존
+  useEffect(() => {
+    if (!dirty) setDraft(ruleToDraft(rule));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(rule)]);
+
+  // 저장 성공 시 dirty 해제
+  useEffect(() => {
+    if (data?.saveState === "fulfilled") setDirty(false);
+  }, [data?.saveState]);
+
+  // 표시할 필드 키 (desc 우선, 없으면 폴백 + rule 의 키)
+  const fieldKeys = useMemo(() => {
+    const keys = Object.keys(desc);
+    if (keys.length > 0) return keys;
+    const set = new Set([...FALLBACK_ORDER, ...Object.keys(rule)]);
+    return Array.from(set);
+  }, [desc, rule]);
+
+  const metaFor = (k: string) => desc[k] ?? inferMeta(k);
+
+  const setField = (k: string, v: string | boolean) => {
+    setDraft(prev => ({ ...prev, [k]: v }));
+    setDirty(true);
+  };
+
+  const handleReset = () => {
+    if (!data?.default) return;
+    setDraft(ruleToDraft(data.default));
+    setDirty(true);
+  };
+
+  const handleSave = () => {
+    const out: QuantRule = {};
+    for (const k of fieldKeys) {
+      const meta = metaFor(k);
+      const v = draft[k];
+      if (meta.type === "boolean") out[k] = !!v;
+      else if (meta.type === "string[]") {
+        out[k] = String(v ?? "").split(",").map(s => s.trim()).filter(Boolean);
+      } else if (meta.type === "int") {
+        const n = Math.trunc(Number(v));
+        out[k] = Number.isFinite(n) ? Math.max(0, n) : 0;
+      } else {
+        const n = Number(v);
+        out[k] = Number.isFinite(n) ? n : 0;
+      }
+    }
+    onSave(out);
+  };
+
+  const noAccount = data && data.state === "fulfilled" && !data.has_account;
+
+  return (
+    <div className={cn("w-full space-y-4", className)}>
+      {/* 헤더 */}
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-neutral-200 bg-white px-4 py-3 dark:border-[#35332e] dark:bg-[#1a1915]">
+        <div className="flex items-center gap-2">
+          <div className="rounded-lg bg-[#16a34a]/10 p-1.5 text-[#16a34a]">
+            <SlidersHorizontal className="h-4 w-4" />
+          </div>
+          <div className="flex flex-col">
+            <span className="text-sm font-bold text-neutral-900 dark:text-neutral-100">트레이딩 조건 (quant rule)</span>
+            <span className="text-[11px] text-neutral-400">
+              {data?.is_override ? "계좌 전용 조건 적용 중" : "전역 기본값 적용 중 (저장 시 계좌 전용으로 전환)"}
+            </span>
+          </div>
+        </div>
+        {!isMaster && (
+          <span className="inline-flex items-center gap-1 rounded-md bg-neutral-100 px-2 py-1 text-[10px] font-bold text-neutral-400 dark:bg-[#35332e]">
+            <Lock className="h-3 w-3" /> 읽기 전용
+          </span>
+        )}
+      </div>
+
+      {noAccount && (
+        <div className="rounded-xl border border-amber-200 bg-amber-50/60 px-4 py-3 text-xs text-amber-700 dark:border-amber-900/40 dark:bg-amber-900/10 dark:text-amber-400">
+          이 계좌에는 자동매매 계정(trading_account)이 없어 조건을 저장할 수 없습니다. 표시값은 전역 기본값입니다.
+        </div>
+      )}
+
+      {/* 필드 그리드 */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {fieldKeys.map((k) => {
+          const meta = metaFor(k);
+          const val = draft[k];
+          return (
+            <div key={k} className="rounded-xl border border-neutral-200 bg-white p-3 dark:border-[#35332e] dark:bg-[#1a1915]">
+              <div className="mb-1.5 flex items-center justify-between gap-2">
+                <span className="text-xs font-bold text-neutral-800 dark:text-neutral-200">{meta.label}</span>
+                <code className="text-[9px] text-neutral-300 dark:text-neutral-600">{k}</code>
+              </div>
+              <p className="mb-2 flex items-start gap-1 text-[10px] leading-tight text-neutral-400">
+                <Info className="mt-0.5 h-2.5 w-2.5 shrink-0" />
+                {meta.desc}
+              </p>
+              {meta.type === "boolean" ? (
+                <button
+                  type="button"
+                  disabled={!isMaster}
+                  onClick={() => setField(k, !val)}
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-bold transition-colors",
+                    val
+                      ? "bg-[#16a34a] text-white"
+                      : "bg-neutral-200 text-neutral-500 dark:bg-[#35332e] dark:text-neutral-400",
+                    !isMaster && "cursor-not-allowed opacity-60"
+                  )}
+                >
+                  {val ? "사용함" : "사용 안 함"}
+                </button>
+              ) : meta.type === "string[]" ? (
+                <input
+                  type="text"
+                  disabled={!isMaster}
+                  value={String(val ?? "")}
+                  onChange={(e) => setField(k, e.target.value)}
+                  placeholder="쉼표로 구분 (예: 홀딩스, 지주)"
+                  className="w-full rounded-lg border border-neutral-200 bg-[#fcfaf7] px-3 py-1.5 font-mono text-xs text-neutral-800 outline-none focus:border-[#16a34a] disabled:opacity-60 dark:border-[#35332e] dark:bg-[#242320] dark:text-neutral-200"
+                />
+              ) : (
+                <input
+                  type="number"
+                  step={meta.step ?? (meta.type === "int" ? 1 : 0.1)}
+                  disabled={!isMaster}
+                  value={String(val ?? "")}
+                  onChange={(e) => setField(k, e.target.value)}
+                  className="w-full rounded-lg border border-neutral-200 bg-[#fcfaf7] px-3 py-1.5 font-mono text-sm font-bold text-neutral-800 outline-none focus:border-[#16a34a] disabled:opacity-60 dark:border-[#35332e] dark:bg-[#242320] dark:text-neutral-200"
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 액션 */}
+      {isMaster && (
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {data?.saveState === "fulfilled" && !dirty && (
+            <span className="inline-flex items-center gap-1 text-xs font-bold text-[#16a34a]">
+              <CheckCircle2 className="h-3.5 w-3.5" /> 저장됨
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={handleReset}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-neutral-200 bg-white px-3 py-2 text-xs font-bold text-neutral-500 transition-colors hover:bg-neutral-50 dark:border-[#35332e] dark:bg-[#242320] dark:text-neutral-400"
+          >
+            <RotateCcw className="h-3.5 w-3.5" /> 기본값으로
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving || !dirty || noAccount}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-lg bg-[#16a34a] px-5 py-2 text-xs font-bold text-white shadow-sm transition-all hover:bg-[#15803d] active:scale-95",
+              (saving || !dirty || noAccount) && "cursor-not-allowed opacity-50"
+            )}
+          >
+            <Save className="h-3.5 w-3.5" /> {saving ? "저장 중…" : "조건 저장"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// desc 가 비어 있을 때 키 이름으로 최소 메타 추론
+function inferMeta(k: string): { label: string; desc: string; type: "number" | "int" | "boolean" | "string[]"; step?: number } {
+  if (k === "exclude_key_word") return { label: "제외 키워드", desc: "종목명에 포함되면 제외 (쉼표 구분)", type: "string[]" };
+  if (k.startsWith("exclude_")) return { label: k, desc: "", type: "boolean" };
+  if (k === "active_count") return { label: "활성 종목 수", desc: "NCAV 상위 N개만 자동매매", type: "int", step: 1 };
+  return { label: k, desc: "", type: "number", step: 0.1 };
+}

--- a/cf-idiotquant/lib/features/capital/capitalAPI.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalAPI.tsx
@@ -98,3 +98,17 @@ export const postUsCapitalGroupDelete: any = async (key: string, groupId: string
     postKoreaInvestmentRequest(`/us/capital/groups/${groupId}/delete?kakao-id=${key}`, {});
 export const postUsCapitalStockGroup: any = async (key: string, ticker: string, groupId: string | null) =>
     postKoreaInvestmentRequest(`/us/capital/stock/${ticker}/group?kakao-id=${key}`, {}, { group_id: groupId });
+
+// ============================================================================
+// 계좌별 트레이딩 조건 (quant_rule) API (KR / US)
+// 백엔드는 인증된 user.id 기준으로 trading_accounts.quant_rule_json 을 조회/수정한다.
+// (kakao-id 쿼리는 무시되지만 일관성을 위해 전달)
+// ============================================================================
+export const getKrQuantRule: any = async (key: string) =>
+    getKoreaInvestmentRequest(`/kr/capital/quant-rule?kakao-id=${key}`, {});
+export const postKrQuantRule: any = async (key: string, rule: object) =>
+    postKoreaInvestmentRequest(`/kr/capital/quant-rule?kakao-id=${key}`, {}, { rule });
+export const getUsQuantRule: any = async (key: string) =>
+    getKoreaInvestmentRequest(`/us/capital/quant-rule?kakao-id=${key}`, {});
+export const postUsQuantRule: any = async (key: string, rule: object) =>
+    postKoreaInvestmentRequest(`/us/capital/quant-rule?kakao-id=${key}`, {}, { rule });

--- a/cf-idiotquant/lib/features/capital/capitalSlice.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalSlice.tsx
@@ -1,9 +1,51 @@
 import { PayloadAction } from "@reduxjs/toolkit";
 import { createAppSlice } from "@/lib/createAppSlice";
-import { getKrCapital, getUsCapital, postKrCapitalTokenMinusAll, postKrCapitalTokenMinusOne, postKrCapitalTokenPlusAll, postKrCapitalTokenPlusOne, postUsCapitalTokenMinusAll, postUsCapitalTokenMinusOne, postUsCapitalTokenPlusAll, postUsCapitalTokenPlusOne, postKrCapitalGroupCreate, postKrCapitalGroupUpdate, postKrCapitalGroupDelete, postKrCapitalStockGroup, postUsCapitalGroupCreate, postUsCapitalGroupUpdate, postUsCapitalGroupDelete, postUsCapitalStockGroup } from "./capitalAPI";
+import { getKrCapital, getUsCapital, postKrCapitalTokenMinusAll, postKrCapitalTokenMinusOne, postKrCapitalTokenPlusAll, postKrCapitalTokenPlusOne, postUsCapitalTokenMinusAll, postUsCapitalTokenMinusOne, postUsCapitalTokenPlusAll, postUsCapitalTokenPlusOne, postKrCapitalGroupCreate, postKrCapitalGroupUpdate, postKrCapitalGroupDelete, postKrCapitalStockGroup, postUsCapitalGroupCreate, postUsCapitalGroupUpdate, postUsCapitalGroupDelete, postUsCapitalStockGroup, getKrQuantRule, postKrQuantRule, getUsQuantRule, postUsQuantRule } from "./capitalAPI";
 
 /** 예약(가상) 그룹 id — 좋아요(찜) 종목 그룹 */
 export const LIKES_GROUP_ID = "__likes__";
+
+/** 트레이딩 조건 (quant_rule) */
+export interface QuantRule {
+    ncav_ratio?: number;
+    max_pbr?: number;
+    min_pbr?: number;
+    min_per?: number;
+    min_eps?: number;
+    min_bps?: number;
+    portfolio_weight?: number;
+    active_count?: number;
+    exclude_call_warrants?: boolean;
+    exclude_key_word?: string[];
+    [key: string]: any;
+}
+
+export interface QuantRuleFieldMeta {
+    label: string;
+    desc: string;
+    type: "number" | "int" | "boolean" | "string[]";
+    step?: number;
+}
+
+export interface QuantRuleState {
+    state: "init" | "pending" | "fulfilled" | "rejected";
+    saveState: "init" | "pending" | "fulfilled" | "rejected";
+    has_account: boolean;
+    is_override: boolean;
+    rule: QuantRule;
+    default: QuantRule;
+    desc: Record<string, QuantRuleFieldMeta>;
+}
+
+const initialQuantRuleState: QuantRuleState = {
+    state: "init",
+    saveState: "init",
+    has_account: false,
+    is_override: false,
+    rule: {},
+    default: {},
+    desc: {},
+};
 
 export interface StockCondition {
     AssetsCurrent: number;
@@ -65,6 +107,8 @@ export interface CapitalType {
     usCapitalTokenMinusOne: CapitalTokenRefillType;
     krGroupOp: CapitalTokenRefillType;
     usGroupOp: CapitalTokenRefillType;
+    krQuantRule: QuantRuleState;
+    usQuantRule: QuantRuleState;
 }
 
 const initialState: CapitalType = {
@@ -140,7 +184,9 @@ const initialState: CapitalType = {
     },
     usGroupOp: {
         state: "init"
-    }
+    },
+    krQuantRule: { ...initialQuantRuleState },
+    usQuantRule: { ...initialQuantRuleState }
 }
 
 export const capitalSlice = createAppSlice({
@@ -418,6 +464,72 @@ export const capitalSlice = createAppSlice({
                 rejected: (state) => { state.usGroupOp.state = "rejected"; },
             }
         ),
+
+        // ── 계좌별 트레이딩 조건 (quant_rule) ──
+        reqGetKrQuantRule: create.asyncThunk(
+            async (key?: string) => getKrQuantRule(key),
+            {
+                pending: (state) => { state.krQuantRule.state = "pending"; },
+                fulfilled: (state, action) => {
+                    const p = action.payload ?? {};
+                    state.krQuantRule = {
+                        ...state.krQuantRule,
+                        state: "fulfilled",
+                        has_account: !!p.has_account,
+                        is_override: !!p.is_override,
+                        rule: p.rule ?? {},
+                        default: p.default ?? {},
+                        desc: p.desc ?? {},
+                    };
+                },
+                rejected: (state) => { state.krQuantRule.state = "rejected"; },
+            }
+        ),
+        reqPostKrQuantRule: create.asyncThunk(
+            async ({ key, rule }: { key?: string, rule: QuantRule }) => postKrQuantRule(key, rule),
+            {
+                pending: (state) => { state.krQuantRule.saveState = "pending"; },
+                fulfilled: (state, action) => {
+                    const p = action.payload ?? {};
+                    state.krQuantRule.saveState = p.success === false ? "rejected" : "fulfilled";
+                    if (p.rule) state.krQuantRule.rule = p.rule;
+                    if (p.is_override != null) state.krQuantRule.is_override = !!p.is_override;
+                },
+                rejected: (state) => { state.krQuantRule.saveState = "rejected"; },
+            }
+        ),
+        reqGetUsQuantRule: create.asyncThunk(
+            async (key?: string) => getUsQuantRule(key),
+            {
+                pending: (state) => { state.usQuantRule.state = "pending"; },
+                fulfilled: (state, action) => {
+                    const p = action.payload ?? {};
+                    state.usQuantRule = {
+                        ...state.usQuantRule,
+                        state: "fulfilled",
+                        has_account: !!p.has_account,
+                        is_override: !!p.is_override,
+                        rule: p.rule ?? {},
+                        default: p.default ?? {},
+                        desc: p.desc ?? {},
+                    };
+                },
+                rejected: (state) => { state.usQuantRule.state = "rejected"; },
+            }
+        ),
+        reqPostUsQuantRule: create.asyncThunk(
+            async ({ key, rule }: { key?: string, rule: QuantRule }) => postUsQuantRule(key, rule),
+            {
+                pending: (state) => { state.usQuantRule.saveState = "pending"; },
+                fulfilled: (state, action) => {
+                    const p = action.payload ?? {};
+                    state.usQuantRule.saveState = p.success === false ? "rejected" : "fulfilled";
+                    if (p.rule) state.usQuantRule.rule = p.rule;
+                    if (p.is_override != null) state.usQuantRule.is_override = !!p.is_override;
+                },
+                rejected: (state) => { state.usQuantRule.saveState = "rejected"; },
+            }
+        ),
     }),
     selectors: {
         selectKrCapital: (state) => state.krCapital,
@@ -432,6 +544,8 @@ export const capitalSlice = createAppSlice({
         selectUsCapitalTokenMinusOne: (state) => state.usCapitalTokenMinusOne,
         selectKrGroupOp: (state) => state.krGroupOp,
         selectUsGroupOp: (state) => state.usGroupOp,
+        selectKrQuantRule: (state) => state.krQuantRule,
+        selectUsQuantRule: (state) => state.usQuantRule,
     }
 });
 
@@ -440,5 +554,7 @@ export const { selectKrCapital, selectKrCapitalTokenPlusAll, selectKrCapitalToke
 export const { reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate, reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup } = capitalSlice.actions;
 export const { reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate, reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup } = capitalSlice.actions;
 export const { selectKrGroupOp, selectUsGroupOp } = capitalSlice.selectors;
+export const { reqGetKrQuantRule, reqPostKrQuantRule, reqGetUsQuantRule, reqPostUsQuantRule } = capitalSlice.actions;
+export const { selectKrQuantRule, selectUsQuantRule } = capitalSlice.selectors;
 export const { reqGetUsCapital, reqPostUsCapitalTokenPlusAll, reqPostUsCapitalTokenPlusOne, reqPostUsCapitalTokenMinusAll, reqPostUsCapitalTokenMinusOne } = capitalSlice.actions;
 export const { selectUsCapital, selectUsCapitalTokenPlusAll, selectUsCapitalTokenPlusOne, selectUsCapitalTokenMinusAll, selectUsCapitalTokenMinusOne } = capitalSlice.selectors;


### PR DESCRIPTION
## Summary

balance-kr·balance-us 에 **자동매매 트레이딩 조건(quant_rule)을 조회·수정**하는 UI를 추가한다. 지금까지 `trading_accounts.quant_rule_json` 은 `wrangler d1 execute` CLI 로만 바꿀 수 있었는데, 이제 페이지에서 직접 본다/고친다.

> 백엔드 엔드포인트는 동반 PR(idiotquant-worker)에 있습니다. 편집 범위는 **계좌별 override(trading_accounts.quant_rule_json)** 이며, override 가 없으면 전역 기본값을 표시하고 저장 시 계좌 전용으로 전환됩니다.

## Changes

### `components/balance/quantRuleEditor.tsx` (신규)
- 백엔드가 내려주는 `desc` 메타데이터(label/설명/타입)로 필드를 동적 렌더 — 숫자·정수·불리언·키워드 배열(쉼표 구분)
- `master` 만 편집 가능(그 외 읽기 전용), "기본값으로" 리셋 + "조건 저장" 버튼, 저장 상태 표시

### `lib/features/capital/capitalSlice.tsx`
- `QuantRule`·`QuantRuleState` 타입 + `reqGet/Post {Kr,Us}QuantRule` thunk·selector 추가

### `lib/features/capital/capitalAPI.tsx`
- `get/post {kr,us}/capital/quant-rule` API 함수 추가

### `app/(balance-kr)/balance-kr/page.tsx` · `app/(balance-us)/balance-us/page.tsx`
- "트레이딩 조건" 섹션 + 네비게이션 항목 추가, 마운트 시 조건 로드, 저장 결과 토스트

## Test Plan
- [ ] balance-kr/us "트레이딩 조건" 섹션에서 현재 조건이 보이는지 (계좌 전용/기본값 배지)
- [ ] master 가 값 수정 후 저장 → 토스트 + 재조회 반영, 비-master 는 읽기 전용
- [ ] `npx tsc --noEmit` · `npm run build` 통과 (확인 완료)

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_