### PR TITLE
balance-kr/us: 그룹 전체선택 · 상태 설명 · 잔고 그룹 배지 · 좋아요 지표

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
+++ b/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
@@ -587,6 +587,7 @@ function BalanceKr() {
             kakaoMemberList={kakaoMemberList}
             reqPostOrderCash={reqPostOrderCash}
             kiOrderCash={orderCashState}
+            capital={krCapital}
             onOrderResult={handleOrderResult}
           />
         </SectionPanel>

--- a/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
+++ b/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
@@ -632,6 +632,7 @@ function BalanceUs() {
             reqPostOrderCash={reqPostOrderUs}
             kakaoTotal={kakaoTotal}
             kakaoMemberList={kakaoMemberList}
+            capital={usCapital}
             onOrderResult={handleOrderResult}
           />
         </SectionPanel>

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -199,6 +199,7 @@ export default function StockListTable({
   const [newGroupName, setNewGroupName] = useState("");
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [picked, setPicked] = useState<Set<string>>(new Set());
+  const [showLegend, setShowLegend] = useState(false);
 
   // 관리자 여부 확인 (기존 로직 유지)
   const isMaster = useMemo(() =>
@@ -276,6 +277,12 @@ export default function StockListTable({
       next.has(ticker) ? next.delete(ticker) : next.add(ticker);
       return next;
     });
+  const pickMany = (tickers: string[], select: boolean) =>
+    setPicked(prev => {
+      const next = new Set(prev);
+      tickers.forEach(t => select ? next.add(t) : next.delete(t));
+      return next;
+    });
   const clearPick = () => setPicked(new Set());
 
   const doBulkMove = (groupId: string | null) => {
@@ -338,6 +345,30 @@ export default function StockListTable({
           <Info className="mt-0.5 h-2.5 w-2.5 shrink-0" />
           매매 흐름: <b className="font-bold text-neutral-500">자동매매 ON</b> → <b className="font-bold text-neutral-500">그룹 ON</b>(미지정·찜은 위 토글) → 위 조건 충족 + NCAV 상위 종목이 <b className="font-bold text-[#16a34a]">매매중</b>이 됩니다.
         </p>
+
+        {/* 상태 설명 토글 */}
+        <button
+          onClick={() => setShowLegend(v => !v)}
+          className="mt-2 inline-flex items-center gap-1 text-[10px] font-bold text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-200"
+        >
+          {showLegend ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />} 종목 상태 설명
+        </button>
+        {showLegend && (
+          <div className="mt-2 grid grid-cols-1 gap-1.5 rounded-lg border border-neutral-100 bg-[#fcfaf7] p-3 sm:grid-cols-2 dark:border-[#35332e] dark:bg-[#242320]">
+            {([
+              { s: { label: "매매중", tone: "active" as Tone }, d: "현재 자동매매 대상. 마지막 실행에서 활성 종목으로 선정됨." },
+              { s: { label: "대기", tone: "idle" as Tone }, d: "운용 목록엔 있으나 이번엔 미선정 (NCAV 상위 N 밖 / 조건 미달 / 다음 실행 대기)." },
+              { s: { label: "후보(찜)", tone: "idle" as Tone }, d: "좋아요 종목. 찜 그룹 자동매매 ON이면 다음 실행 때 후보로 합류 (아직 운용 목록 아님)." },
+              { s: { label: "제외", tone: "excluded" as Tone }, d: "속한 그룹(또는 찜)의 자동매매가 OFF라 매매에서 제외됨." },
+              { s: { label: "자동매매 OFF", tone: "off" as Tone }, d: "국가 자동매매가 꺼져 있어 어떤 종목도 매매되지 않음." },
+            ]).map((row, i) => (
+              <div key={i} className="flex items-start gap-2">
+                <StatusBadge status={row.s} />
+                <span className="text-[10px] leading-snug text-neutral-500 dark:text-neutral-400">{row.d}</span>
+              </div>
+            ))}
+          </div>
+        )}
       </section>
 
       {/* ===== 1. Global Token Control + 새 그룹 추가 (Master) ===== */}
@@ -446,6 +477,7 @@ export default function StockListTable({
         onToggleCollapse={() => toggleCollapse(LIKES_GROUP_ID)}
         picked={picked}
         onTogglePick={togglePick}
+        onPickMany={pickMany}
         doTokenPlusOne={doTokenPlusOne}
         doTokenMinusOne={doTokenMinusOne}
         openDetail={openDetail}
@@ -500,6 +532,7 @@ export default function StockListTable({
         onToggleCollapse={() => toggleCollapse("__unassigned__")}
         picked={picked}
         onTogglePick={togglePick}
+        onPickMany={pickMany}
         doTokenPlusOne={doTokenPlusOne}
         doTokenMinusOne={doTokenMinusOne}
         openDetail={openDetail}
@@ -583,6 +616,7 @@ interface GroupSectionProps {
   onToggleCollapse: () => void;
   picked: Set<string>;
   onTogglePick: (ticker: string) => void;
+  onPickMany?: (tickers: string[], select: boolean) => void;
   doTokenPlusOne: (val: number, sym: string) => void;
   doTokenMinusOne: (val: number, sym: string) => void;
   openDetail: (raw: any) => void;
@@ -591,11 +625,14 @@ interface GroupSectionProps {
 function GroupSection({
   sectionKey, title, subtitle, icon, accent, count, rows, isMaster, tradingActive, onToggleTrading,
   conditionChips, editing, editingName, onEditNameChange, onStartRename, onCommitRename, onDelete,
-  emptyText, collapsed, onToggleCollapse, picked, onTogglePick,
+  emptyText, collapsed, onToggleCollapse, picked, onTogglePick, onPickMany,
   doTokenPlusOne, doTokenMinusOne, openDetail,
 }: GroupSectionProps) {
   const showRefill = isMaster && rows.some(r => r.movable);
   const showCheck = isMaster && rows.some(r => r.movable);
+  const movableTickers = useMemo(() => rows.filter(r => r.movable).map(r => r.symbol), [rows]);
+  const allChecked = movableTickers.length > 0 && movableTickers.every(t => picked.has(t));
+  const someChecked = movableTickers.some(t => picked.has(t));
   const baseCols = 6; // 종목/상태/PER·PBR/BPS·EPS/시총/NCAV
   const colSpan = baseCols + 1 /*token*/ + (showCheck ? 1 : 0) + (showRefill ? 1 : 0);
 
@@ -682,7 +719,19 @@ function GroupSection({
           <table className="w-full text-left text-[12px] border-collapse">
             <thead className="bg-neutral-50/80 text-neutral-500 dark:bg-[#242320]/50 dark:text-neutral-400">
               <tr>
-                {showCheck && <th className="px-3 py-2.5 w-8"></th>}
+                {showCheck && (
+                  <th className="px-3 py-2.5 w-8">
+                    <input
+                      type="checkbox"
+                      aria-label="이 그룹 전체 선택"
+                      title="이 그룹 전체 선택"
+                      checked={allChecked}
+                      ref={(el) => { if (el) el.indeterminate = !allChecked && someChecked; }}
+                      onChange={() => onPickMany?.(movableTickers, !allChecked)}
+                      className="h-4 w-4 rounded border-neutral-300 text-[#16a34a] focus:ring-[#16a34a]"
+                    />
+                  </th>
+                )}
                 <th className="px-4 py-2.5 font-semibold uppercase tracking-wider">종목</th>
                 <th className="px-4 py-2.5 font-semibold uppercase tracking-wider text-center">상태</th>
                 <th className="px-4 py-2.5 font-semibold uppercase tracking-wider text-center">PER / PBR</th>

--- a/cf-idiotquant/components/inquireBalanceResult.tsx
+++ b/cf-idiotquant/components/inquireBalanceResult.tsx
@@ -15,7 +15,8 @@ import {
     X,
     Loader2,
     Search,
-    PlusCircle
+    PlusCircle,
+    FolderOpen
 } from "lucide-react";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -83,6 +84,7 @@ interface InquireBalanceResultProps {
     reqPostOrderCash?: any;
     kakaoTotal?: any;
     kakaoMemberList?: any;
+    capital?: any;
     onOrderResult?: (status: "success" | "error", message: string) => void;
 }
 
@@ -93,6 +95,22 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
 
     const isUs = !!props.kiBalance?.output3 || !!props.kiBalance?.output1?.[0]?.ovrs_item_name;
     const exRate = Number(props.kiBalance?.output2?.[0]?.frst_bltn_exrt || 0);
+
+    // 운용 종목(capital stock_list)의 ticker → 그룹 매핑 (잔고 종목에 그룹 배지 표시용)
+    const groupByTicker = useMemo(() => {
+        const map = new Map<string, { name: string; active: boolean; assigned: boolean }>();
+        const groups: any[] = props.capital?.groups ?? [];
+        const gmap = new Map(groups.map((g: any) => [g.id, g]));
+        for (const s of (props.capital?.stock_list ?? [])) {
+            const g: any = s.group_id ? gmap.get(s.group_id) : null;
+            if (g && g.id !== "__likes__") {
+                map.set(String(s.symbol), { name: g.name, active: g.is_trading_active !== false, assigned: true });
+            } else {
+                map.set(String(s.symbol), { name: "미지정", active: true, assigned: false });
+            }
+        }
+        return map;
+    }, [props.capital]);
 
     const evlu_smtl = Number(props.kiBalance?.output3?.evlu_amt_smtl ?? props.kiBalance?.output2?.[0]?.evlu_amt_smtl_amt ?? 0);
     const pchs_smtl = Number(props.kiBalance?.output3?.pchs_amt_smtl ?? props.kiBalance?.output2?.[0]?.pchs_amt_smtl_amt ?? 0);
@@ -334,10 +352,11 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
 
             {/* 테이블 섹션 */}
             <div className="overflow-hidden bg-white dark:bg-[#242320] rounded-[2rem] border border-neutral-200 dark:border-[#35332e] shadow-sm">
-                <SortableBalanceTable 
-                    inventoryData={props.kiBalance.output1 || []} 
-                    isUs={isUs} 
+                <SortableBalanceTable
+                    inventoryData={props.kiBalance.output1 || []}
+                    isUs={isUs}
                     onOpenOrder={handleOpenOrderModal}
+                    groupByTicker={groupByTicker}
                 />
             </div>
 
@@ -367,9 +386,24 @@ function SummaryItem({ label, value, subValue, colorClass = "dark:text-white" }:
     );
 }
 
-function SortableBalanceTable({ inventoryData, isUs, onOpenOrder }: { inventoryData: any[], isUs: boolean, onOpenOrder: (stock: any) => void }) {
+function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker }: { inventoryData: any[], isUs: boolean, onOpenOrder: (stock: any) => void, groupByTicker?: Map<string, { name: string; active: boolean; assigned: boolean }> }) {
     const [sortConfig, setSortConfig] = useState<any>({ key: "evlu_amt", direction: "desc" });
     const router = useRouter();
+
+    const renderGroupBadge = (item: any) => {
+        const ticker = String(item.pdno || item.ovrs_pdno || "");
+        const g = groupByTicker?.get(ticker);
+        if (!g) return null; // 운용 풀에 없는(자동매매 비대상) 보유 종목
+        return (
+            <span className={`mt-0.5 inline-flex w-fit items-center gap-0.5 rounded-full px-1.5 py-0.5 text-[9px] font-bold ${
+                g.assigned && g.active
+                    ? "bg-[#16a34a]/10 text-[#16a34a]"
+                    : "bg-neutral-100 text-neutral-400 dark:bg-[#35332e] dark:text-neutral-400"
+            }`}>
+                <FolderOpen className="w-2.5 h-2.5" /> {g.name}
+            </span>
+        );
+    };
     const goAnalyze = (item: any) => {
         // US: ticker code (AAPL), KR: stock name (삼성전자) — analyze page searches by name for KR
         const ticker = isUs
@@ -408,11 +442,12 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder }: { inventoryD
                     <div key={idx} className="p-4 space-y-3">
                         {/* 종목명 + 수익률 */}
                         <div className="flex items-start justify-between gap-2">
-                            <div>
+                            <div className="flex flex-col">
                                 <span className="font-black text-sm dark:text-neutral-100 leading-none block mb-0.5">
                                     {getFieldValue(item, "name")}
                                 </span>
                                 <span className="text-[10px] font-mono text-neutral-500">{item.pdno || item.ovrs_pdno}</span>
+                                {renderGroupBadge(item)}
                             </div>
                             <span className={`text-sm font-black font-mono shrink-0 ${isPositive ? "text-rose-500" : "text-[#f0fdf4]0"}`}>
                                 {isPositive ? "▲" : "▼"} {isPositive ? "+" : ""}{profitRt.toFixed(2)}%
@@ -502,6 +537,7 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder }: { inventoryD
                                                 {getFieldValue(item, "name")}
                                             </span>
                                             <span className="text-[10px] font-mono text-neutral-500">{item.pdno || item.ovrs_pdno}</span>
+                                            {renderGroupBadge(item)}
                                         </div>
                                     </td>
                                     <td className="p-4 text-right font-mono text-sm font-bold dark:text-neutral-300">


### PR DESCRIPTION
## Summary

balance-kr·balance-us 운용 종목 관리 후속 개선 4가지.

> 좋아요 지표를 채우는 백엔드 JOIN 수정은 동반 PR(idiotquant-worker)에 있습니다.

## Changes

### 1. 그룹 종목 전체 선택 (`components/balance/stockListTable.tsx`)
- 각 그룹/미지정 섹션 테이블 헤더에 **전체선택 체크박스** 추가 — 그룹 내 운용 종목을 한 번에 선택/해제
- 일부만 선택 시 `indeterminate` 표시. 선택 후 상단 작업 바에서 기존/새 그룹으로 일괄 이동

### 2. 종목 상태 설명 (legend)
- 요약 대시보드에 **"종목 상태 설명"** 토글 추가 — 가능한 상태와 의미를 안내:
  - **매매중**: 현재 자동매매 대상 (마지막 실행에서 활성 선정)
  - **대기**: 운용 목록엔 있으나 이번엔 미선정 (NCAV 상위 N 밖 / 조건 미달 / 다음 실행 대기)
  - **후보(찜)**: 좋아요 종목 — 찜 그룹 ON 시 다음 실행 때 후보로 합류 (아직 운용 목록 아님)
  - **제외**: 그룹(또는 찜) 자동매매 OFF 로 제외
  - **자동매매 OFF**: 국가 자동매매가 꺼져 전체 미동작

### 3. 잔고(보유) 종목 그룹 배지 (`components/inquireBalanceResult.tsx`)
- 잔고 표/카드의 각 보유 종목에 **소속 그룹 배지** 표시 (운용 풀 `group_id` → 그룹명, 미지정/비활성은 회색)
- balance-kr/us 가 `capital` 을 `InquireBalanceResult` 로 전달

### 4. 좋아요 종목 지표 표시
- 좋아요 섹션 PER/PBR/BPS/EPS 가 채워지도록 — 실제 원인(ticker/name 불일치) 은 동반 PR 백엔드에서 수정

## Test Plan
- [ ] 그룹 헤더 전체선택 체크박스로 그룹 종목 일괄 선택/이동
- [ ] "종목 상태 설명" 토글로 상태 의미 확인
- [ ] 잔고 종목에 그룹 배지 표시 (KR `pdno`, US `pdno/ovrs_pdno` 매칭)
- [ ] 좋아요 종목에 PER/PBR 표시 (동반 PR 배포 후)
- [ ] `npx tsc --noEmit` · `npm run build` 통과 (확인 완료)

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_