### PR TITLE
fix: 좋아요 운용 종목을 '미지정' 대신 '좋아요' 섹션에서 관리 (재생성)

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -212,12 +212,20 @@ export default function StockListTable({
   const likesActive = likesGroup?.is_trading_active ?? false;
 
   // 종목을 그룹별 버킷으로 분류 + 상태 계산
-  const { byGroup, unassigned } = useMemo(() => {
+  // group_id === "__likes__" 인 운용 종목은 '미지정'이 아니라 좋아요 섹션으로 보낸다.
+  const { byGroup, unassigned, likesPoolRows } = useMemo(() => {
     const gmap = new Map(realGroups.map(g => [g.id, g]));
     const byGroup = new Map<string, DisplayRow[]>();
     realGroups.forEach(g => byGroup.set(g.id, []));
     const unassigned: DisplayRow[] = [];
+    const likesPoolRows: DisplayRow[] = [];
     for (const s of stockList) {
+      if (s.group_id === LIKES_GROUP_ID) {
+        // 좋아요 그룹 운용 종목 (토큰·상태 보유) → 좋아요 섹션에서 관리
+        const status = capitalStatus(s.action, likesActive, countryTradingActive);
+        likesPoolRows.push(normalizeCapital(s, status));
+        continue;
+      }
       const g = s.group_id ? gmap.get(s.group_id) : null;
       const groupActive = g ? g.is_trading_active !== false : true;
       const status = capitalStatus(s.action, groupActive, countryTradingActive);
@@ -225,28 +233,33 @@ export default function StockListTable({
       if (s.group_id && gmap.has(s.group_id)) byGroup.get(s.group_id)!.push(row);
       else unassigned.push(row);
     }
-    return { byGroup, unassigned };
-  }, [stockList, realGroups, countryTradingActive]);
+    return { byGroup, unassigned, likesPoolRows };
+  }, [stockList, realGroups, countryTradingActive, likesActive]);
 
-  const likedRows = useMemo(
-    () => (likedList ?? []).map(lk => normalizeLiked(lk, likesStatus(likesActive, countryTradingActive))),
-    [likedList, likesActive, countryTradingActive]
-  );
+  // 좋아요 섹션 = 운용 중인 좋아요 종목(토큰/상태) + 아직 운용 풀에 없는 찜(읽기 전용 워치리스트)
+  const likedRows = useMemo(() => {
+    const poolSymbols = new Set(likesPoolRows.map(r => r.symbol));
+    const watchlistRows = (likedList ?? [])
+      .filter(lk => !poolSymbols.has(lk.ticker))
+      .map(lk => normalizeLiked(lk, likesStatus(likesActive, countryTradingActive)));
+    return [...likesPoolRows, ...watchlistRows];
+  }, [likesPoolRows, likedList, likesActive, countryTradingActive]);
 
   // 요약 카운트
   const summary = useMemo(() => {
     let active = 0, idle = 0, excluded = 0;
     const gmap = new Map(realGroups.map(g => [g.id, g]));
     for (const s of stockList) {
-      const g = s.group_id ? gmap.get(s.group_id) : null;
-      const groupActive = g ? g.is_trading_active !== false : true;
+      let groupActive: boolean;
+      if (s.group_id === LIKES_GROUP_ID) groupActive = likesActive;
+      else { const g = s.group_id ? gmap.get(s.group_id) : null; groupActive = g ? g.is_trading_active !== false : true; }
       const st = capitalStatus(s.action, groupActive, countryTradingActive);
       if (st.tone === "active") active++;
       else if (st.tone === "excluded") excluded++;
       else if (st.tone === "idle") idle++;
     }
     return { active, idle, excluded, total: stockList.length };
-  }, [stockList, realGroups, countryTradingActive]);
+  }, [stockList, realGroups, countryTradingActive, likesActive]);
 
   const conditionChips = useMemo(() => formatConditions(quantRule), [quantRule]);
 


### PR DESCRIPTION
## 배경

동반 백엔드 PR(idiotquant-worker #39, **머지됨**)은 좋아요 해제·OFF 시 `__likes__` 종목을 운용 풀에서 정리한다. 이 프론트엔드 변경은 그 짝으로, 운용 중인 좋아요 종목을 **'미지정'이 아니라 '좋아요' 섹션**에서 보여준다. (직전 PR #474가 머지되지 않고 닫혀 재생성 — 현재 백엔드만 머지되어 프론트와 짝이 어긋난 상태)

## 문제

좋아요 그룹 자동매매가 켜지면 백엔드가 좋아요 종목을 `group_id: "__likes__"` 로 운용 풀에 병합하는데, 프론트 버킷팅이 **실제 그룹만** 인식해 이 종목들이 **'미지정' 섹션**으로 떨어졌다.

## 변경 (`components/balance/stockListTable.tsx`)

- `group_id === "__likes__"` 운용 종목을 '미지정'이 아니라 **좋아요 섹션**으로 분류
- 좋아요 섹션 = **운용 중 좋아요 종목**(토큰/상태/Refill/선택) + **아직 운용 전 찜**(읽기전용, 중복 제거)
- 요약 카운트도 `__likes__` 항목을 **좋아요 그룹 토글 기준**으로 집계 (이전엔 미지정 취급되어 항상 활성으로 잘못 계산)

## Test Plan
- [ ] 좋아요 그룹 ON 후 매매 시작된 좋아요 종목이 '좋아요 종목' 섹션에 표시 (미지정 아님)
- [ ] 좋아요 섹션 운용 종목의 토큰/상태/Refill/선택 동작
- [ ] 요약 카운트(매매중/대기/제외) 정확
- [ ] `npx tsc --noEmit` · `npm run build` 통과 (확인 완료)

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_