### PR TITLE
feat: balance-us 좋아요 종목 지표(per/pbr/eps/bps) KIS price-detail 로 보강

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
+++ b/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
@@ -47,6 +47,7 @@ import {
   reqGetUsQuantRule, reqPostUsQuantRule, selectUsQuantRule,
 } from "@/lib/features/capital/capitalSlice";
 import { reqGetMyLikes, selectLikedList } from "@/lib/features/stockLikes/stockLikesSlice";
+import { getQuotationsPriceDetail } from "@/lib/features/koreaInvestmentUsMarket/koreaInvestmentUsMarketAPI";
 
 import InquireBalanceResult from "@/components/inquireBalanceResult";
 import QuantRuleEditor from "@/components/balance/quantRuleEditor";
@@ -194,6 +195,37 @@ function BalanceUs() {
   const likedListAll = useAppSelector(selectLikedList);
   const usLikedList = useMemo(() => (likedListAll ?? []).filter((l: any) => !!l.is_us), [likedListAll]);
   const isMaster = useMemo(() => session?.user?.name === process.env.NEXT_PUBLIC_MASTER, [session]);
+
+  // US 좋아요 종목은 stock_data_daily(KR 전용)에 없어 지표가 비어온다.
+  // KIS overseas price-detail 로 per/pbr/eps/bps 를 보강한다.
+  const [usLikeMetrics, setUsLikeMetrics] = useState<Record<string, { per?: number; pbr?: number; eps?: number; bps?: number }>>({});
+  const metricsFetchedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const tickers = new Set<string>();
+    (usLikedList ?? []).forEach((l: any) => { if (l?.ticker) tickers.add(String(l.ticker)); });
+    (usCapital?.stock_list ?? []).forEach((s: any) => { if (s?.group_id === "__likes__" && s?.symbol) tickers.add(String(s.symbol)); });
+    const todo = [...tickers].filter(t => !metricsFetchedRef.current.has(t));
+    if (todo.length === 0) return;
+    let cancelled = false;
+    const num = (v: any) => { const n = Number(v); return (v != null && v !== "" && Number.isFinite(n)) ? n : undefined; };
+    (async () => {
+      const limit = 3;
+      for (let i = 0; i < todo.length; i += limit) {
+        const batch = todo.slice(i, i + limit);
+        const results = await Promise.all(batch.map(async (t) => {
+          metricsFetchedRef.current.add(t);
+          try {
+            const res = await getQuotationsPriceDetail(t);
+            const o = res?.output ?? {};
+            return [t, { per: num(o.perx), pbr: num(o.pbrx), eps: num(o.epsx), bps: num(o.bpsx) }] as const;
+          } catch { return [t, {}] as const; }
+        }));
+        if (cancelled) return;
+        setUsLikeMetrics(prev => { const next = { ...prev }; for (const [t, m] of results) next[t] = m; return next; });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [usLikedList, usCapital]);
 
   const tradingStatus = useAppSelector(selectTradingStatus);
 
@@ -673,6 +705,7 @@ function BalanceUs() {
               onToggleLikesTrading={doToggleLikesTrading}
               countryTradingActive={tradingStatus.US === true}
               quantRule={usQuantRule.rule}
+              metricsOverride={usLikeMetrics}
             />
           </SectionPanel>
         )}

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -122,6 +122,8 @@ interface Props {
   // 자동매매 컨텍스트
   countryTradingActive?: boolean;
   quantRule?: QuantRule;
+  // 지표 보강 (예: US 좋아요 종목은 stock_data_daily 에 없어 KIS price-detail 로 보강)
+  metricsOverride?: Record<string, { per?: number | null; pbr?: number | null; bps?: number | null; eps?: number | null; marketCap?: number | null }>;
 }
 
 const tokenAmounts = [10000, 100000, 1000000];
@@ -187,6 +189,7 @@ export default function StockListTable({
   onToggleLikesTrading,
   countryTradingActive = false,
   quantRule,
+  metricsOverride,
 }: Props) {
   const stockList = data?.stock_list ?? [];
   const groups: StockGroup[] = data?.groups ?? [];
@@ -237,13 +240,26 @@ export default function StockListTable({
   }, [stockList, realGroups, countryTradingActive, likesActive]);
 
   // 좋아요 섹션 = 운용 중인 좋아요 종목(토큰/상태) + 아직 운용 풀에 없는 찜(읽기 전용 워치리스트)
+  // metricsOverride 로 비어있는 지표(US 등)를 보강한다.
   const likedRows = useMemo(() => {
     const poolSymbols = new Set(likesPoolRows.map(r => r.symbol));
+    const applyOverride = (row: DisplayRow): DisplayRow => {
+      const o = metricsOverride?.[row.symbol];
+      if (!o) return row;
+      return {
+        ...row,
+        per: row.per ?? o.per,
+        pbr: row.pbr ?? o.pbr,
+        bps: row.bps ?? o.bps,
+        eps: row.eps ?? o.eps,
+        marketCap: row.marketCap ?? o.marketCap,
+      };
+    };
     const watchlistRows = (likedList ?? [])
       .filter(lk => !poolSymbols.has(lk.ticker))
       .map(lk => normalizeLiked(lk, likesStatus(likesActive, countryTradingActive)));
-    return [...likesPoolRows, ...watchlistRows];
-  }, [likesPoolRows, likedList, likesActive, countryTradingActive]);
+    return [...likesPoolRows, ...watchlistRows].map(applyOverride);
+  }, [likesPoolRows, likedList, likesActive, countryTradingActive, metricsOverride]);
 
   // 요약 카운트
   const summary = useMemo(() => {


### PR DESCRIPTION
## 문제

balance-us 의 좋아요 종목에서 PER/PBR/EPS/BPS 가 비어 보였다.

원인: 좋아요 지표는 `stock_data_daily` JOIN 으로 채우는데, 이 테이블은 **KR NCAV 스캔 전용**이라 US 티커 데이터가 없다. 따라서 US 좋아요 종목은 워치리스트든 운용(`__likes__`)이든 지표가 NULL 로 내려온다.

## 해결 (프론트엔드, balance-us)

US 종목 밸류에이션은 KIS overseas **price-detail** 한 번으로 perx/pbrx/epsx/bpsx 를 받을 수 있고, 이미 analyze/search 페이지가 쓰는 경로다. 이를 재사용해 보강한다.

### `app/(balance-us)/balance-us/page.tsx`
- 좋아요 목록 + 운용 풀의 `__likes__` US 티커를 모아, 아직 안 받은 것만 **동시성 3 제한**으로 `getQuotationsPriceDetail(ticker)` 호출
- perx/pbrx/epsx/bpsx 를 숫자로 파싱해 `usLikeMetrics` 맵 구성 (이미 받은 티커는 ref 로 중복 호출 방지)
- `StockListTable` 에 `metricsOverride` 로 전달

### `components/balance/stockListTable.tsx`
- `metricsOverride?: Record<ticker, {per,pbr,bps,eps,marketCap}>` prop 추가
- 좋아요 섹션 행 생성 시 **비어있는 지표만** 보강값으로 채움(`row.per ?? override.per` …) — KR(이미 값 있음)·운용 종목엔 영향 없음

## 비고
- 백엔드 변경 없음. KR 좋아요는 기존 JOIN(#38) 그대로 동작.
- price-detail 은 종목당 1콜이라 좋아요가 매우 많으면 호출 수가 늘 수 있어 동시성 제한·중복 방지 적용.

## Test Plan
- [ ] balance-us 좋아요 섹션에서 US 종목 PER/PBR/EPS/BPS 표시
- [ ] 좋아요 많을 때도 과도한 동시 호출 없이 점진 채워짐
- [ ] balance-kr 좋아요(기존 JOIN) 회귀 없음
- [ ] `npx tsc --noEmit` · `npm run build` 통과 (확인 완료)

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_