### PR TITLE
fix: 좋아요 선택이 그룹까지 번지던 문제 + KR 좋아요 per/pbr 보강

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
+++ b/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
@@ -40,6 +40,7 @@ import {
   reqGetKrQuantRule, reqPostKrQuantRule, selectKrQuantRule,
 } from "@/lib/features/capital/capitalSlice";
 import { reqGetMyLikes, selectLikedList } from "@/lib/features/stockLikes/stockLikesSlice";
+import { getInquirePrice } from "@/lib/features/koreaInvestment/koreaInvestmentAPI";
 
 import InquireBalanceResult from "@/components/inquireBalanceResult";
 import StockListTable from "@/components/balance/stockListTable";
@@ -215,6 +216,46 @@ function BalanceKr() {
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   const { toasts, addToast, removeToast } = useToast();
+
+  // 좋아요 종목 중 stock_data_daily JOIN 이 비어(per/pbr 등 없음) 오는 경우
+  // KIS 국내 inquire-price 로 per/pbr/eps/bps 를 보강한다. (US 의 price-detail 보강과 동일 패턴)
+  const [krLikeMetrics, setKrLikeMetrics] = useState<Record<string, { per?: number; pbr?: number; eps?: number; bps?: number }>>({});
+  const krMetricsFetchedRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    const isCode = (t: string) => /^\d{6}$/.test(t); // inquire-price 는 6자리 종목코드만 가능
+    const need = new Set<string>();
+    (krLikedList ?? []).forEach((l: any) => {
+      if (l?.ticker && isCode(String(l.ticker)) && (l.per == null || l.pbr == null)) need.add(String(l.ticker));
+    });
+    (krCapital?.stock_list ?? []).forEach((s: any) => {
+      if (s?.group_id === "__likes__" && s?.symbol && isCode(String(s.symbol))) {
+        const c = s.condition ?? {};
+        if (c.per == null || c.pbr == null) need.add(String(s.symbol));
+      }
+    });
+    const todo = [...need].filter(t => !krMetricsFetchedRef.current.has(t));
+    if (todo.length === 0) return;
+    let cancelled = false;
+    const num = (v: any) => { const n = Number(v); return (v != null && v !== "" && Number.isFinite(n)) ? n : undefined; };
+    (async () => {
+      const limit = 3;
+      for (let i = 0; i < todo.length; i += limit) {
+        const batch = todo.slice(i, i + limit);
+        const results = await Promise.all(batch.map(async (t) => {
+          krMetricsFetchedRef.current.add(t);
+          try {
+            const res = await getInquirePrice(t, balanceKey);
+            const o = res?.output ?? {};
+            return [t, { per: num(o.per), pbr: num(o.pbr), eps: num(o.eps), bps: num(o.bps) }] as const;
+          } catch { return [t, {}] as const; }
+        }));
+        if (cancelled) return;
+        setKrLikeMetrics(prev => { const next = { ...prev }; for (const [t, m] of results) next[t] = m; return next; });
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [krLikedList, krCapital, balanceKey]);
 
   const fetchOrderHistory = useCallback((key: string) => {
     if (!key || key === "undefined") return;
@@ -628,6 +669,7 @@ function BalanceKr() {
               likedList={krLikedList}
               countryTradingActive={tradingStatus.KR === true}
               quantRule={krQuantRule.rule}
+              metricsOverride={krLikeMetrics}
             />
           </SectionPanel>
         )}

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -38,6 +38,10 @@ function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/** 선택 상태 키: 섹션별로 독립 선택되도록 (section + symbol) 형태로 보관 */
+const PICK_SEP = "::";
+const pickKey = (section: string, symbol: string) => `${section}${PICK_SEP}${symbol}`;
+
 type Tone = "active" | "idle" | "excluded" | "off";
 interface EffStatus { label: string; tone: Tone; }
 
@@ -300,35 +304,44 @@ export default function StockListTable({
       next.has(key) ? next.delete(key) : next.add(key);
       return next;
     });
-  const togglePick = (ticker: string) =>
+  // 선택은 섹션별로 독립적이다. 같은 종목이 좋아요·그룹에 동시에 나타나도
+  // 한 섹션에서 고른 게 다른 섹션까지 선택되지 않도록 키에 섹션을 포함한다.
+  const togglePick = (section: string, ticker: string) =>
     setPicked(prev => {
       const next = new Set(prev);
-      next.has(ticker) ? next.delete(ticker) : next.add(ticker);
+      const k = pickKey(section, ticker);
+      next.has(k) ? next.delete(k) : next.add(k);
       return next;
     });
-  const pickMany = (tickers: string[], select: boolean) =>
+  const pickMany = (section: string, tickers: string[], select: boolean) =>
     setPicked(prev => {
       const next = new Set(prev);
-      tickers.forEach(t => select ? next.add(t) : next.delete(t));
+      tickers.forEach(t => { const k = pickKey(section, t); select ? next.add(k) : next.delete(k); });
       return next;
     });
   const clearPick = () => setPicked(new Set());
 
+  // 선택된 키에서 종목(symbol)만 추출(섹션 간 중복 제거) — 일괄 작업용
+  const pickedSymbols = useMemo(
+    () => Array.from(new Set(Array.from(picked).map(k => k.split(PICK_SEP)[1]))),
+    [picked]
+  );
+
   const doBulkMove = (groupId: string | null) => {
-    const tickers = Array.from(picked);
+    const tickers = pickedSymbols;
     if (tickers.length === 0) return;
     if (onBulkMove) onBulkMove(tickers, groupId);
     else tickers.forEach(t => onMoveStock?.(t, groupId)); // 폴백
     clearPick();
   };
   const doCopyToGroup = (groupId: string | null) => {
-    const tickers = Array.from(picked);
+    const tickers = pickedSymbols;
     if (tickers.length === 0) return;
     onCopyLikes?.(tickers, groupId);
     clearPick();
   };
   const doCreateGroupFromPicked = () => {
-    const tickers = Array.from(picked);
+    const tickers = pickedSymbols;
     if (tickers.length === 0) return;
     const name = window.prompt(`선택한 ${tickers.length}개 종목으로 만들 그룹 이름을 입력하세요`);
     if (name && name.trim()) {
@@ -474,7 +487,7 @@ export default function StockListTable({
       {isMaster && picked.size > 0 && (
         <div className="sticky top-2 z-20 flex flex-wrap items-center gap-2 rounded-xl border border-[#16a34a]/40 bg-[#f0fdf4] px-3 py-2.5 shadow-md dark:border-[#16a34a]/40 dark:bg-[#14532d]/30 sm:px-4">
           <span className="inline-flex items-center gap-1 text-xs font-bold text-[#16a34a]">
-            <ArrowRightLeft className="w-3.5 h-3.5" /> {picked.size}개 선택
+            <ArrowRightLeft className="w-3.5 h-3.5" /> {pickedSymbols.length}개 선택
           </span>
           <button onClick={clearPick} className="rounded-md p-1 text-neutral-400 hover:bg-white/60 dark:hover:bg-[#1a1915] sm:order-last sm:ml-auto">
             <X className="w-4 h-4" />
@@ -670,8 +683,8 @@ interface GroupSectionProps {
   collapsed: boolean;
   onToggleCollapse: () => void;
   picked: Set<string>;
-  onTogglePick: (ticker: string) => void;
-  onPickMany?: (tickers: string[], select: boolean) => void;
+  onTogglePick: (section: string, ticker: string) => void;
+  onPickMany?: (section: string, tickers: string[], select: boolean) => void;
   doTokenPlusOne: (val: number, sym: string) => void;
   doTokenMinusOne: (val: number, sym: string) => void;
   openDetail: (raw: any) => void;
@@ -686,8 +699,10 @@ function GroupSection({
   const showRefill = isMaster && rows.some(r => r.movable);
   const showCheck = isMaster && rows.length > 0; // 모든 행 선택 가능(좋아요는 복사용)
   const selectableTickers = useMemo(() => rows.map(r => r.symbol), [rows]);
-  const allChecked = selectableTickers.length > 0 && selectableTickers.every(t => picked.has(t));
-  const someChecked = selectableTickers.some(t => picked.has(t));
+  // 선택 여부는 이 섹션 키 기준으로만 판단(다른 섹션의 동일 종목과 분리)
+  const isPicked = (sym: string) => picked.has(pickKey(sectionKey, sym));
+  const allChecked = selectableTickers.length > 0 && selectableTickers.every(isPicked);
+  const someChecked = selectableTickers.some(isPicked);
   const baseCols = 6; // 종목/상태/PER·PBR/BPS·EPS/시총/NCAV
   const colSpan = baseCols + 1 /*token*/ + (showCheck ? 1 : 0) + (showRefill ? 1 : 0);
 
@@ -731,7 +746,7 @@ function GroupSection({
                 type="checkbox"
                 checked={allChecked}
                 ref={(el) => { if (el) el.indeterminate = !allChecked && someChecked; }}
-                onChange={() => onPickMany?.(selectableTickers, !allChecked)}
+                onChange={() => onPickMany?.(sectionKey, selectableTickers, !allChecked)}
                 className="h-3.5 w-3.5 rounded border-neutral-300 text-[#16a34a] focus:ring-[#16a34a]"
               />
               전체
@@ -800,7 +815,7 @@ function GroupSection({
                       title="이 그룹 전체 선택"
                       checked={allChecked}
                       ref={(el) => { if (el) el.indeterminate = !allChecked && someChecked; }}
-                      onChange={() => onPickMany?.(selectableTickers, !allChecked)}
+                      onChange={() => onPickMany?.(sectionKey, selectableTickers, !allChecked)}
                       className="h-4 w-4 rounded border-neutral-300 text-[#16a34a] focus:ring-[#16a34a]"
                     />
                   </th>
@@ -829,14 +844,14 @@ function GroupSection({
                 rows.map((row, idx) => (
                   <tr key={`${sectionKey}-${row.symbol}-${idx}`} className={cn(
                     "group transition-colors",
-                    picked.has(row.symbol) ? "bg-[#f0fdf4] dark:bg-[#14532d]/20" : "hover:bg-[#f0fdf4]/30 dark:hover:bg-[#14532d]/10"
+                    isPicked(row.symbol) ? "bg-[#f0fdf4] dark:bg-[#14532d]/20" : "hover:bg-[#f0fdf4]/30 dark:hover:bg-[#14532d]/10"
                   )}>
                     {showCheck && (
                       <td className="px-3 py-3">
                         <input
                           type="checkbox"
-                          checked={picked.has(row.symbol)}
-                          onChange={() => onTogglePick(row.symbol)}
+                          checked={isPicked(row.symbol)}
+                          onChange={() => onTogglePick(sectionKey, row.symbol)}
                           className="h-4 w-4 rounded border-neutral-300 text-[#16a34a] focus:ring-[#16a34a]"
                         />
                       </td>
@@ -920,15 +935,15 @@ function GroupSection({
             rows.map((row, idx) => (
               <div
                 key={`m-${sectionKey}-${row.symbol}-${idx}`}
-                className={cn("p-3", picked.has(row.symbol) && "bg-[#f0fdf4] dark:bg-[#14532d]/20")}
+                className={cn("p-3", isPicked(row.symbol) && "bg-[#f0fdf4] dark:bg-[#14532d]/20")}
               >
                 {/* 상단: 체크 + 종목 + 상태 */}
                 <div className="flex items-center gap-2">
                   {showCheck && (
                     <input
                       type="checkbox"
-                      checked={picked.has(row.symbol)}
-                      onChange={() => onTogglePick(row.symbol)}
+                      checked={isPicked(row.symbol)}
+                      onChange={() => onTogglePick(sectionKey, row.symbol)}
                       className="h-5 w-5 shrink-0 rounded border-neutral-300 text-[#16a34a] focus:ring-[#16a34a]"
                     />
                   )}


### PR DESCRIPTION
## 요청

1. balance-kr/us 에서 **좋아요 종목을 선택하면 그룹 내 종목까지 같이 선택**되던(부자연스러운) 문제 수정.
2. **좋아요 종목의 PER/PBR 등 지표가 잘 뜨도록** 보강 (특히 balance-kr).

## 변경

### 1. 선택 상태를 섹션별로 분리 (`components/balance/stockListTable.tsx`)
- 기존 `picked` 가 **종목 코드만**으로 관리돼, 같은 종목이 좋아요 섹션과 그룹 섹션에 동시에 나타나면 한쪽 선택이 양쪽 모두 선택된 것처럼 보였다.
- 선택 키를 **`section::symbol`** 로 바꿔(`pickKey`) 섹션별로 독립 선택되게 함.
  - 각 섹션 체크박스/전체선택은 자기 섹션 키 기준(`isPicked`)으로만 판단 → 좋아요 선택이 그룹으로 번지지 않음
  - 일괄 작업(복사/이동/새 그룹)은 선택 키에서 종목만 추출 + **섹션 간 중복 제거**(`pickedSymbols`) 후 처리

### 2. balance-kr 좋아요 지표 보강 (`app/(balance-kr)/balance-kr/page.tsx`)
- KR 좋아요 종목은 `stock_data_daily` JOIN 이 미스되면 per/pbr 가 비어온다. **KIS 국내 `inquire-price`** 로 보강(US 의 price-detail 보강과 동일 패턴).
  - 6자리 종목코드인 좋아요·운용 좋아요(`__likes__`) 중 per/pbr 가 비어있는 것만 **동시성 3** 으로 조회
  - per/pbr/eps/bps 를 숫자로 파싱해 `krLikeMetrics` 구성, 이미 받은 티커는 `ref` 로 중복 호출 방지
  - `StockListTable` 에 `metricsOverride={krLikeMetrics}` 전달 → 비어있는 지표만 채움

## 비고
- 백엔드 변경 없음. US 보강(#476)은 그대로 동작.

## Test Plan
- [ ] 좋아요 섹션에서 종목 선택 시 그룹/미지정 섹션 종목이 함께 선택되지 않음
- [ ] 같은 종목이 여러 섹션에 있어도 섹션별로 독립 선택
- [ ] 일괄 복사/이동 시 중복 없이 처리
- [ ] balance-kr 좋아요 종목 PER/PBR/EPS/BPS 표시 (JOIN 미스 종목 포함)
- [ ] `npx tsc --noEmit` · `npm run build` 통과 (확인 완료)

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_