### PR TITLE
feat: 스크리너 필터링 결과 링크 공유

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -19,7 +19,7 @@ import { STRATEGY_LABEL, STRATEGY_BADGE, STRATEGY_PRESETS_CLIENT as STRATEGY_PRE
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const safeNum = (v: any): number => { const n = Number(v); return isNaN(n) ? 0 : n; };
-import { RefreshCw, ChevronRight, Loader2, Search, SlidersHorizontal, TrendingUp, Info, X, Heart, Clock } from "lucide-react";
+import { RefreshCw, ChevronRight, Loader2, Search, SlidersHorizontal, TrendingUp, Info, X, Heart, Clock, Share2, Check } from "lucide-react";
 import * as Tooltip from "@radix-ui/react-tooltip";
 
 // =========================================================================
@@ -294,8 +294,9 @@ function ScreenerContent() {
     const [sortOrder, setSortOrder] = useState<SortOrder>(() =>
         searchParams.get('order') === 'asc' ? 'asc' : 'desc'
     );
-    const [searchQuery, setSearchQuery] = useState("");
+    const [searchQuery, setSearchQuery] = useState(() => searchParams.get('q') ?? "");
     const [displayCount, setDisplayCount] = useState(DAILY_PAGE_SIZE);
+    const [shareCopied, setShareCopied] = useState(false);
     const [excludeHoldings, setExcludeHoldings] = useState(() =>
         searchParams.get('exclude')?.split(',').includes('holdings') ?? false
     );
@@ -332,8 +333,8 @@ function ScreenerContent() {
         }
     }, [ncavDailyList.state, ncavDailyList.scanDate, ncavDailyDates.dates.length, dispatch]);
 
-    // 필터 상태 → URL 동기화 + localStorage 저장 (페이지 이동 후 재진입 시에도 필터 유지)
-    useEffect(() => {
+    // 현재 필터 상태를 그대로 재현하는 쿼리 스트링 (URL 동기화 + 공유 링크 공용)
+    const queryString = useMemo(() => {
         const params = new URLSearchParams();
         if (activeStrategyIds.size > 0)
             params.set('strategies', Array.from(activeStrategyIds).join(','));
@@ -350,8 +351,13 @@ function ScreenerContent() {
         if (excludeList) params.set('exclude', excludeList);
         if (minMarketCap > 0) params.set('mincap', String(minMarketCap));
         if (showLikedOnly) params.set('filter', 'liked');
-        const qs = params.toString();
-        router.replace(qs ? `/screener?${qs}` : '/screener', { scroll: false });
+        if (searchQuery.trim()) params.set('q', searchQuery.trim());
+        return params.toString();
+    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, minMarketCap, showLikedOnly, searchQuery]);
+
+    // 필터 상태 → URL 동기화 + localStorage 저장 (페이지 이동 후 재진입 시에도 필터 유지)
+    useEffect(() => {
+        router.replace(queryString ? `/screener?${queryString}` : '/screener', { scroll: false });
 
         // localStorage에도 전략 상태 저장 — 다른 페이지 이동 후 복귀 시 복원
         if (activeStrategyIds.size > 0) {
@@ -364,7 +370,24 @@ function ScreenerContent() {
         } else {
             localStorage.removeItem('screener:filterMode');
         }
-    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, minMarketCap, showLikedOnly, router]);
+    }, [queryString, activeStrategyIds, filterMode, router]);
+
+    // 현재 필터링 결과 링크 공유 (모바일: 네이티브 공유 시트 / 데스크탑: 클립보드 복사)
+    const handleShare = useCallback(async () => {
+        const url = `${window.location.origin}/screener${queryString ? `?${queryString}` : ''}`;
+        const nav = typeof navigator !== 'undefined' ? navigator : undefined;
+        if (nav?.share) {
+            try {
+                await nav.share({ title: "아이디어퀀트 발굴 종목", text: "필터링한 발굴 종목 보기", url });
+            } catch { /* 사용자가 공유 취소 — 무시 */ }
+            return;
+        }
+        try {
+            await nav?.clipboard?.writeText(url);
+            setShareCopied(true);
+            setTimeout(() => setShareCopied(false), 2000);
+        } catch { /* 클립보드 권한 없음 — 무시 */ }
+    }, [queryString]);
 
     const handleRefresh = useCallback(() => {
         dispatch(reqGetNcavDailyList("latest"));
@@ -663,6 +686,21 @@ function ScreenerContent() {
                         )}
 
                         <div className="flex-1" />
+
+                        {/* 결과 링크 공유 */}
+                        <button
+                            onClick={handleShare}
+                            className={cn(
+                                "shrink-0 flex items-center gap-1 px-2.5 py-1.5 rounded-lg border text-xs font-bold transition-all",
+                                shareCopied
+                                    ? "bg-[#f0fdf4] dark:bg-[#052e16]/30 border-[#86efac] dark:border-[#15803d] text-[#15803d] dark:text-[#16a34a]"
+                                    : "border-neutral-200 dark:border-[#3a3834] text-neutral-500 dark:text-neutral-400 hover:border-neutral-300 bg-white dark:bg-[#242320]"
+                            )}
+                            title="현재 필터링 결과 링크 공유"
+                        >
+                            {shareCopied ? <Check size={12} /> : <Share2 size={12} />}
+                            <span className="hidden sm:inline">{shareCopied ? "복사됨" : "공유"}</span>
+                        </button>
 
                         {/* 전략 가이드 토글 */}
                         <button


### PR DESCRIPTION
## 요청

screener 페이지에서 **발굴 종목 필터링 결과를 링크로 공유**하는 기능 추가.

## 배경

스크리너는 이미 모든 필터 상태(전략·정렬·시총·제외·관심)를 URL 에 동기화하고 있어 URL 자체가 공유 가능한 링크다. 여기에 공유 버튼 + 누락돼 있던 검색어 동기화를 더했다.

## 변경 (`app/(screener)/screener/page.tsx`)

- **공유 버튼** — 둘째 줄 툴바(전략 안내 옆)에 추가.
  - 모바일: 네이티브 공유 시트(`navigator.share`)
  - 데스크탑: 클립보드 복사 후 **"복사됨"**(체크 아이콘) 2초 피드백
- **검색어(`q`) URL 동기화** — 기존엔 `searchQuery` 가 URL 에 안 들어가 공유 링크에서 검색 조건이 빠졌다. `q` 파라미터로 포함/복원해 **검색어까지 정확히 재현**.
- 필터→URL 동기화 로직을 `queryString` `useMemo` 로 추출해 URL 동기화와 공유 링크가 같은 소스를 사용.

## 비고
- "관심" 필터(`filter=liked`)는 사용자별 개인 데이터라 공유 링크를 받은 사람에겐 본인의 관심 종목이 보임(전략 필터 공유는 의도대로 동작).
- 백엔드 변경 없음.

## Test Plan
- [ ] 전략·정렬·시총·제외·검색어를 건 뒤 "공유" → 데스크탑 클립보드 복사 + "복사됨" 표시
- [ ] 모바일에서 네이티브 공유 시트 노출
- [ ] 공유 링크를 새 탭에서 열면 동일한 필터·검색 결과 재현
- [ ] `npx tsc --noEmit` · `npm run build` 통과 (확인 완료)

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_