### PR TITLE
feat: balance 그룹 종목에 종목명+symbol 함께 표시

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -32,10 +32,29 @@ import { UsCapitalStockItem, KrUsCapitalType, StockGroup, LIKES_GROUP_ID, QuantR
 import { LikedStockItem } from "@/lib/features/stockLikes/stockLikesSlice";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import validCorpCodeArray from "@/public/data/validCorpCodeArray.json";
+import validCorpNameArray from "@/public/data/validCorpNameArray.json";
 
 /** Tailwind 클래스 병합 유틸리티 */
 function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+// KR 종목코드(6자리) → 종목명 매핑. validCorpCodeArray / validCorpNameArray 는 같은 순서의 병렬 배열.
+const KR_CODE_TO_NAME: Record<string, string> = (() => {
+  const codes = validCorpCodeArray as string[];
+  const names = validCorpNameArray as string[];
+  const map: Record<string, string> = {};
+  for (let i = 0; i < codes.length; i++) map[codes[i]] = names[i];
+  return map;
+})();
+
+/** symbol/ticker 에 대응하는 표시용 종목명 결정. 백엔드 name 우선, 없으면 KR 코드맵으로 보강. */
+function resolveDisplayName(symbol: string, rawName?: string | null): string | undefined {
+  const n = (rawName ?? "").trim();
+  if (n && n !== symbol) return n;
+  const kr = KR_CODE_TO_NAME[symbol];
+  return kr && kr !== symbol ? kr : undefined;
 }
 
 /** 선택 상태 키: 섹션별로 독립 선택되도록 (section + symbol) 형태로 보관 */
@@ -89,6 +108,7 @@ function formatConditions(r?: QuantRule): string[] {
 /** 그룹 섹션·찜 섹션이 공통으로 쓰는 정규화된 행 */
 interface DisplayRow {
   symbol: string;
+  name?: string;           // 표시용 종목명 (있으면 symbol 과 함께 노출)
   per?: number | string | null;
   pbr?: number | string | null;
   bps?: number | null;
@@ -133,6 +153,7 @@ const tokenAmounts = [10000, 100000, 1000000];
 function normalizeCapital(row: UsCapitalStockItem, status?: EffStatus): DisplayRow {
   return {
     symbol: row.symbol,
+    name: resolveDisplayName(row.symbol, row.name),
     per: row.condition?.per,
     pbr: row.condition?.pbr,
     bps: row.condition?.bps,
@@ -149,6 +170,7 @@ function normalizeCapital(row: UsCapitalStockItem, status?: EffStatus): DisplayR
 function normalizeLiked(lk: LikedStockItem, status?: EffStatus): DisplayRow {
   return {
     symbol: lk.ticker,
+    name: resolveDisplayName(lk.ticker, lk.stock_name),
     per: lk.per,
     pbr: lk.pbr,
     bps: lk.bps,
@@ -857,12 +879,23 @@ function GroupSection({
                       </td>
                     )}
                     <td className="px-4 py-3">
-                      <button onClick={() => openDetail(row.raw)} className="flex items-center gap-2 group/btn">
-                        <div className="p-1.5 rounded-md bg-[#faf9f7] dark:bg-[#35332e] transition-all">
+                      <button onClick={() => openDetail(row.raw)} className="flex items-center gap-2 group/btn min-w-0">
+                        <div className="shrink-0 p-1.5 rounded-md bg-[#faf9f7] dark:bg-[#35332e] transition-all">
                           <TrendingUp className="w-3.5 h-3.5" />
                         </div>
-                        <span className="font-bold text-sm text-neutral-900 dark:text-neutral-100 group-hover/btn:text-[#16a34a] transition-colors tracking-tight">
-                          {row.symbol}
+                        <span className="flex min-w-0 flex-col items-start leading-tight">
+                          {row.name ? (
+                            <>
+                              <span className="font-bold text-sm text-neutral-900 dark:text-neutral-100 group-hover/btn:text-[#16a34a] transition-colors tracking-tight truncate max-w-[180px]">
+                                {row.name}
+                              </span>
+                              <span className="text-[10px] text-neutral-400 font-mono tracking-wider">{row.symbol}</span>
+                            </>
+                          ) : (
+                            <span className="font-bold text-sm text-neutral-900 dark:text-neutral-100 group-hover/btn:text-[#16a34a] transition-colors tracking-tight">
+                              {row.symbol}
+                            </span>
+                          )}
                         </span>
                       </button>
                     </td>
@@ -951,7 +984,14 @@ function GroupSection({
                     <div className="shrink-0 rounded-md bg-[#faf9f7] p-1.5 dark:bg-[#35332e]">
                       <TrendingUp className="w-3.5 h-3.5" />
                     </div>
-                    <span className="truncate text-sm font-bold text-neutral-900 dark:text-neutral-100">{row.symbol}</span>
+                    {row.name ? (
+                      <span className="flex min-w-0 flex-col items-start leading-tight">
+                        <span className="truncate max-w-[160px] text-sm font-bold text-neutral-900 dark:text-neutral-100">{row.name}</span>
+                        <span className="text-[10px] text-neutral-400 font-mono tracking-wider">{row.symbol}</span>
+                      </span>
+                    ) : (
+                      <span className="truncate text-sm font-bold text-neutral-900 dark:text-neutral-100">{row.symbol}</span>
+                    )}
                   </button>
                   <div className="ml-auto shrink-0">
                     <StatusBadge status={row.status} />


### PR DESCRIPTION
## 요청

balance-kr·balance-us 그룹 내 종목이 **symbol/ticker 만** 표시돼 가독성이 떨어진다. 종목명과 symbol 을 함께 표시.

## 변경 (`components/balance/stockListTable.tsx`)

- 종목 셀(데스크탑 테이블 · 모바일 카드)에서 **종목명을 굵게**, 그 아래 **symbol/ticker 를 보조 라인**으로 함께 노출 (스크리너 행과 동일한 형태). 종목명이 없으면 기존처럼 symbol 만 표시 → 회귀 없음.
- **종목명 출처 (2단계 보강)**:
  1. 백엔드 `name` 우선
  2. 없으면 **KR 6자리 종목코드 → 종목명** 매핑으로 보강 (`validCorpCodeArray`/`validCorpNameArray` 병렬 배열, 2,401종목)
- 핵심: KR 운용 종목은 백엔드 NCAV candidate 에 `name` 이 없어 `005930` 같은 코드만 보였는데, 이제 `삼성전자`(005930)처럼 표시. US 좋아요 종목은 `stock_name` 으로 채워짐.

## 비고
- 백엔드 변경 없음. `validCorp*Array.json` 은 이미 다른 컴포넌트(inquireBalanceResult)에서 쓰던 정적 데이터.

## Test Plan
- [ ] balance-kr 그룹/미지정/좋아요 종목에 종목명 + 코드가 함께 표시 (예: 삼성전자 / 005930)
- [ ] 종목명을 못 찾는 경우 symbol 만 표시(회귀 없음)
- [ ] balance-us 좋아요/운용 종목 표시 정상
- [ ] 데스크탑·모바일 레이아웃 정상(이름 truncate)
- [ ] `npx tsc --noEmit` · `npm run build` 통과 (확인 완료)

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_