### PR TITLE
fix: analyze 페이지 검색 후 최근 검색 히스토리 항상 표시

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -516,9 +516,9 @@ function AnalyzeContent() {
         </div>
 
         {/* 인기 종목 + 최근 검색 */}
-        {!isPriceLoaded && (
+        {(popularStocks.length > 0 || krMarketHistory.length > 0) && (
           <div className="border-t border-neutral-100 dark:border-[#35332e]/50 bg-[#faf9f7]/50 dark:bg-[#242320]/30">
-            {popularStocks.length > 0 && (
+            {!isPriceLoaded && popularStocks.length > 0 && (
               <div className="max-w-4xl mx-auto px-4 py-2 flex items-center gap-3">
                 <div className="flex items-center gap-1.5 shrink-0">
                   <Flame size={11} className="text-amber-500" />
@@ -537,7 +537,7 @@ function AnalyzeContent() {
               </div>
             )}
             {krMarketHistory.length > 0 && (
-              <div className="max-w-4xl mx-auto px-4 py-2 flex items-center gap-3 border-t border-neutral-100 dark:border-[#35332e]/40">
+              <div className={cn("max-w-4xl mx-auto px-4 py-2 flex items-center gap-3", !isPriceLoaded && popularStocks.length > 0 && "border-t border-neutral-100 dark:border-[#35332e]/40")}>
                 <span className="text-[9px] font-bold text-neutral-400 uppercase tracking-wider shrink-0">최근 검색</span>
                 <div className="flex items-center gap-1.5 overflow-x-auto no-scrollbar">
                   {krMarketHistory.slice().reverse().slice(0, 8).map((s, i) => (

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }


### PR DESCRIPTION
## 문제

analyze 페이지에서 종목을 검색하면 헤더 하단의 "최근 검색" 바가 사라져 다른 종목으로 빠르게 이동할 수 없었다.

## 원인 (`app/(analyze)/analyze/page.tsx`)

최근 검색 + 인기 종목 섹션이 `{!isPriceLoaded && (...)}` 조건으로 감싸져 있어, 데이터가 로드되면 전체 섹션이 숨겨졌다.

## 변경

- **최근 검색(`krMarketHistory`)**: `isPriceLoaded` 여부와 무관하게 항상 표시 → 검색 후에도 헤더 하단에서 다른 종목으로 즉시 이동 가능
- **인기 종목(`popularStocks`)**: 기존대로 검색 전(`!isPriceLoaded`)에만 표시 (검색 후엔 화면이 복잡해지지 않도록)

## Test Plan
- [ ] 종목 검색 전: 인기 종목 + 최근 검색 모두 표시
- [ ] 종목 검색 후: 최근 검색만 헤더 하단에 표시, 클릭 시 다른 종목으로 이동
- [ ] 최근 검색 이력 없으면 해당 바 미표시

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_