### PR TITLE
feat: 기본 폰트를 serif 계열로 변경 (Lora + Noto Serif KR)

### DIFF
--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent() {
+function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,7 +1028,8 @@ function BacktestContent() {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
+    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
+    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1674,7 +1675,7 @@ function BacktestContent() {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
+                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2198,21 +2199,13 @@ export default function BacktestPage() {
         );
     }
 
-    if (!isAdmin) {
-        return (
-            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
-                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
-            </div>
-        );
-    }
-
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent />
+            <BacktestContent isAdmin={isAdmin} />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/(backtest)/backtest/page.tsx
+++ b/cf-idiotquant/app/(backtest)/backtest/page.tsx
@@ -1018,7 +1018,7 @@ function PortfolioSnapshotChart({ result, loading, strategy, currentPriceMap, se
 
 // ─── Main content ─────────────────────────────────────────────────────────────
 
-function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
+function BacktestContent() {
     const dispatch    = useAppDispatch();
     const router      = useRouter();
     const datesState  = useAppSelector(selectNcavDailyDates);
@@ -1028,8 +1028,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
     const [currentPriceMap,     setCurrentPriceMap]     = useState<Map<string, number>>(new Map());
     const [currentLstnMap,      setCurrentLstnMap]      = useState<Map<string, number>>(new Map());
     const [splitAdjusted,       setSplitAdjusted]       = useState(false);
-    // 히스토리 탭은 개발 중이라 admin 에게만 노출. 비-admin 기본 탭은 포트폴리오.
-    const [viewTab,             setViewTab]             = useState<ViewTabId>(isAdmin ? 'history' : 'portfolio');
+    const [viewTab,             setViewTab]             = useState<ViewTabId>('history');
     const [selectedStock,       setSelectedStock]       = useState<string | null>(null);
     const [stockHistory,        setStockHistory]        = useState<DailyItem[]>([]);
     const [sortKey,             setSortKey]             = useState<SortKey>('ncav_ratio');
@@ -1675,7 +1674,7 @@ function BacktestContent({ isAdmin }: { isAdmin: boolean }) {
 
                         {/* ── View Tabs ── */}
                         <div className="flex items-end gap-0 border-b border-neutral-200 dark:border-[#35332e] -mb-2">
-                            {((isAdmin ? ['history', 'portfolio', 'stocks'] : ['portfolio', 'stocks']) as ViewTabId[]).map(tab => {
+                            {(['history', 'portfolio', 'stocks'] as const).map(tab => {
                                 const labels = { history: '히스토리', portfolio: '포트폴리오', stocks: '종목 목록' };
                                 return (
                                     <button
@@ -2199,13 +2198,21 @@ export default function BacktestPage() {
         );
     }
 
+    if (!isAdmin) {
+        return (
+            <div className="flex flex-col items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] gap-3">
+                <p className="text-sm font-bold text-neutral-500 dark:text-neutral-400">준비 중인 기능입니다.</p>
+            </div>
+        );
+    }
+
     return (
         <Suspense fallback={
             <div className="flex items-center justify-center min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
                 <Loader2 className="animate-spin text-[#16a34a]" size={24} />
             </div>
         }>
-            <BacktestContent isAdmin={isAdmin} />
+            <BacktestContent />
         </Suspense>
     );
 }

--- a/cf-idiotquant/app/global.css
+++ b/cf-idiotquant/app/global.css
@@ -1,5 +1,3 @@
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/cf-idiotquant/app/layout.tsx
+++ b/cf-idiotquant/app/layout.tsx
@@ -1,17 +1,17 @@
 import "@/app/global.css";
 import type { Metadata, Viewport } from "next";
-import { Inter, Noto_Sans_KR, JetBrains_Mono } from "next/font/google";
+import { Lora, Noto_Serif_KR, JetBrains_Mono } from "next/font/google";
 
-const inter = Inter({
+const lora = Lora({
   subsets: ["latin"],
-  variable: "--font-inter",
+  variable: "--font-serif-latin",
   display: "swap",
 });
 
-const notoSansKr = Noto_Sans_KR({
+const notoSerifKr = Noto_Serif_KR({
   weight: ["400", "500", "700", "900"],
   subsets: ["latin"],
-  variable: "--font-noto-kr",
+  variable: "--font-serif-kr",
   display: "swap",
 });
 
@@ -170,10 +170,10 @@ export default function RootLayout({
         <meta name="google-adsense-account" content="ca-pub-6995198721227228" />
       </head>
       <body className={cn(
-        inter.variable,
-        notoSansKr.variable,
+        lora.variable,
+        notoSerifKr.variable,
         jetbrainsMono.variable,
-        "min-h-screen font-sans antialiased",
+        "min-h-screen font-serif antialiased",
         "bg-[#faf9f7] dark:bg-[#1a1915] text-neutral-900 dark:text-neutral-50"
       )}>
         <StoreProvider>

--- a/cf-idiotquant/tailwind.config.ts
+++ b/cf-idiotquant/tailwind.config.ts
@@ -37,9 +37,9 @@ const config = {
         },
       },
       fontFamily: {
-        sans: ["Pretendard Variable", "var(--font-inter)", "var(--font-noto-kr)", "ui-sans-serif", "system-ui", "-apple-system", "sans-serif"],
+        sans: ["Pretendard Variable", "ui-sans-serif", "system-ui", "-apple-system", "sans-serif"],
         mono: ["var(--font-mono)", "ui-monospace", "Menlo", "monospace"],
-        serif: ["Times New Roman", "Georgia", "serif"],
+        serif: ["var(--font-serif-latin)", "Lora", "var(--font-serif-kr)", "Noto Serif KR", "Georgia", "serif"],
       },
       colors: {
         background: "var(--background)",


### PR DESCRIPTION
## 변경

기본 폰트를 sans-serif(Pretendard/Inter/Noto Sans KR)에서 serif 계열로 교체해 가독성을 높였다.

| | 변경 전 | 변경 후 |
|---|---|---|
| 영문 | Inter (sans-serif) | **Lora** (serif) |
| 한국어 | Noto Sans KR | **Noto Serif KR** |
| 모노스페이스 | JetBrains Mono | JetBrains Mono (유지) |
| body class | `font-sans` | `font-serif` |

## 파일

### `app/layout.tsx`
- `Inter` / `Noto_Sans_KR` → `Lora` / `Noto_Serif_KR` (CSS 변수 `--font-serif-latin`, `--font-serif-kr`)
- body className `font-sans` → `font-serif`

### `tailwind.config.ts`
- `serif` 폰트 스택: `var(--font-serif-latin)` → `Lora` → `var(--font-serif-kr)` → `Noto Serif KR` → `Georgia` → `serif`

### `app/global.css`
- 더 이상 사용하지 않는 Pretendard CDN import 제거

## 비고
- 숫자·코드는 `font-mono` (JetBrains Mono) 그대로 유지 — 금융 데이터 가독성 영향 없음
- `font-sans`를 명시한 컴포넌트는 Pretendard → system sans로 fallback

## Test Plan
- [ ] 전 페이지에서 본문 텍스트가 Lora(영문) / Noto Serif KR(한국어)로 렌더되는지 확인
- [ ] `font-mono` 숫자·코드 영역은 JetBrains Mono 유지 확인
- [ ] 다크 모드 가독성 확인
- [ ] `npx tsc --noEmit` 통과 (확인 완료)

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_