### PR TITLE
feat: 매매 체결 후 보유수량 즉시 반영 + analyze 국내 종목 시장/업종 표시

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -593,6 +593,7 @@ function AnalyzeContent() {
                       pbr: stockData?.pbr ?? 0,
                       eps: currency + (stockData?.eps ?? 0).toFixed(0),
                       sector: data?.kiPrice?.output?.bstp_kor_isnm ?? "DEFAULT",
+                      market: data?.kiPrice?.output?.rprs_mrkt_kor_name ?? "",
                     }}
                     chartConfig={chartConfig}
                     rawData={data}

--- a/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
+++ b/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
@@ -266,14 +266,14 @@ function BalanceKr() {
   const handleOrderResult = useCallback((status: "success" | "error", message: string) => {
     addToast(status, message);
     if (status === "success") {
-      dispatch(reqGetInquireBalance(balanceKey));
-      fetchOrderHistory(balanceKey);
       setLastUpdated(new Date());
-      // KIS API 체결 반영 지연 대비 2초 후 재조회
-      setTimeout(() => {
-        dispatch(reqGetInquireBalance(balanceKey));
-        fetchOrderHistory(balanceKey);
-      }, 2000);
+      // KIS 잔고조회는 체결 반영까지 지연이 있어, 여러 번 staged 재조회로 보유수량을 즉시 반영
+      [0, 1500, 3500, 6000].forEach((delay) => {
+        setTimeout(() => {
+          dispatch(reqGetInquireBalance(balanceKey));
+          fetchOrderHistory(balanceKey);
+        }, delay);
+      });
     }
   }, [balanceKey, dispatch, fetchOrderHistory, addToast]);
 

--- a/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
+++ b/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
@@ -262,14 +262,15 @@ function BalanceUs() {
   const handleOrderResult = useCallback((status: "success" | "error", message: string) => {
     addToast(status, message);
     if (status === "success") {
-      dispatch(reqGetOverseasStockTradingInquirePresentBalance(balanceKey));
-      dispatch(reqGetOverseasStockTradingInquireCcnl(balanceKey));
-      dispatch(reqGetOverseasStockTradingInquireNccs(balanceKey));
       setLastUpdated(new Date());
-      // KIS API 체결 반영 지연 대비 2초 후 재조회
-      setTimeout(() => {
-        dispatch(reqGetOverseasStockTradingInquirePresentBalance(balanceKey));
-      }, 2000);
+      // KIS 잔고조회는 체결 반영까지 지연이 있어, 여러 번 staged 재조회로 보유수량을 즉시 반영
+      [0, 1500, 3500, 6000].forEach((delay) => {
+        setTimeout(() => {
+          dispatch(reqGetOverseasStockTradingInquirePresentBalance(balanceKey));
+          dispatch(reqGetOverseasStockTradingInquireCcnl(balanceKey));
+          dispatch(reqGetOverseasStockTradingInquireNccs(balanceKey));
+        }, delay);
+      });
     }
   }, [balanceKey, dispatch, addToast]);
 

--- a/cf-idiotquant/app/(search)/search/components/StockCard.tsx
+++ b/cf-idiotquant/app/(search)/search/components/StockCard.tsx
@@ -118,7 +118,8 @@ export const StockCard = ({ stock, chartConfig }: StockCardProps) => {
   const ncavUpside  = Number(stock?.ncavScore ?? 0);
   const isUp        = ncavUpside >= 0;
   const currency    = stock?.isUs ? "$" : "₩";
-  const market      = stock?.isUs ? "NYSE/NASDAQ" : "KRX";
+  const market      = stock?.isUs ? "NYSE/NASDAQ" : (stock?.market || "KRX");
+  const sector      = !stock?.isUs && stock?.sector && stock.sector !== "DEFAULT" ? stock.sector : null;
 
   const logoUrl = stock?.isUs
     ? `https://img.logo.dev/ticker/${stock.ticker}?token=${process.env.NEXT_PUBLIC_CLEARBIT_API_KEY}&size=200`
@@ -181,9 +182,16 @@ export const StockCard = ({ stock, chartConfig }: StockCardProps) => {
                 <h2 className="font-black text-neutral-900 dark:text-white text-[15px] leading-snug line-clamp-2">
                   {stock?.name}
                 </h2>
-                <p className="text-[10px] font-mono text-neutral-400 dark:text-neutral-500 mt-0.5 truncate">
-                  {stock?.ticker} · {market}
-                </p>
+                <div className="flex items-center gap-1.5 flex-wrap mt-0.5">
+                  <p className="text-[10px] font-mono text-neutral-400 dark:text-neutral-500 truncate">
+                    {stock?.ticker} · {market}
+                  </p>
+                  {sector && (
+                    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-[9px] font-bold bg-neutral-100 text-neutral-600 dark:bg-[#35332e] dark:text-neutral-300">
+                      {sector}
+                    </span>
+                  )}
+                </div>
               </div>
               {/* 등급 배지 */}
               <span className={cn(


### PR DESCRIPTION
## 변경

두 가지 독립 개선.

### 1. balance-kr/us 매매 체결 후 보유수량 즉시 반영 (`63034bc`)

**문제**: balance-kr·balance-us 에서 매매 주문 후 보유수량이 바로 갱신되지 않았다.

**원인**: KIS 주문 API 는 *접수* 시점에 성공을 반환하고, 잔고조회(`hldg_qty`/`cblc_qty`)는 *체결* 반영까지 수 초 지연이 있다. 기존엔 0초·2초 한 번씩만 재조회해, 그 사이 체결된 보유수량을 놓칠 수 있었다.

**변경** (`app/(balance-kr)/balance-kr/page.tsx`, `app/(balance-us)/balance-us/page.tsx`):
- 단일 2초 재조회 → **0 / 1.5 / 3.5 / 6초 staged 재조회** 로 변경
- 체결이 KIS 에 반영되는 즉시 보유수량 테이블이 갱신됨
- 지정가 주문이라 미체결 가능성이 있어, 낙관적(즉시 +수량) 업데이트 대신 실제 체결 반영을 잡아내는 staged 폴링 사용

### 2. analyze 국내 종목에 시장 구분(코스피/코스닥) + 업종 표시 (`1411e7b`)

**요청**: analyze 에서 국내 종목인 경우 코스피/코스닥 등 시장 구분과 업종을 표시.

**변경**:
- `app/(analyze)/analyze/page.tsx`: KR stock 객체에 `market`(`kiPrice.output.rprs_mrkt_kor_name`) 추가. 업종(`bstp_kor_isnm`)은 기존 `sector` 로 이미 전달 중.
- `app/(search)/search/components/StockCard.tsx`: KR 시장 표시를 하드코딩된 "KRX" → 실제 시장명(코스피/코스닥)으로, 종목코드·시장 라인 옆에 **업종 배지** 추가

**안전성**: 두 필드 모두 fallback 처리(`market` 없으면 "KRX", `sector` 없으면 미표시)되어, StockCard 를 공유하는 검색 페이지 등 다른 화면과 US 종목은 기존 동작 그대로 유지.

## Test Plan
- [ ] balance-kr/us 에서 매수/매도 체결 후 수동 새로고침 없이 보유수량이 수 초 내 반영
- [ ] analyze 국내 종목에 코스피/코스닥 + 업종 표시, US 종목·검색 페이지 회귀 없음
- [ ] `npx tsc --noEmit` 통과 (확인 완료)

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_