### PR TITLE
feat: analyze 미국 종목에도 실제 거래소(NASDAQ/NYSE) 표시

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -581,6 +581,7 @@ function AnalyzeContent() {
                       pbr: stockData?.pbr ?? 0,
                       eps: currency + (stockData?.eps ?? 0),
                       sector: data?.usDetail?.output?.e_icod ?? "DEFAULT",
+                      market: data?.usSearchInfo?.output?.tr_mket_name || data?.usSearchInfo?.output?.ovrs_excg_name || "",
                     } : {
                       code: tickerFromUrl, isUs: false, name: displayName,
                       ticker: stockData?.stockTicker ?? '',

--- a/cf-idiotquant/app/(search)/search/components/StockCard.tsx
+++ b/cf-idiotquant/app/(search)/search/components/StockCard.tsx
@@ -118,7 +118,7 @@ export const StockCard = ({ stock, chartConfig }: StockCardProps) => {
   const ncavUpside  = Number(stock?.ncavScore ?? 0);
   const isUp        = ncavUpside >= 0;
   const currency    = stock?.isUs ? "$" : "₩";
-  const market      = stock?.isUs ? "NYSE/NASDAQ" : (stock?.market || "KRX");
+  const market      = stock?.market || (stock?.isUs ? "NYSE/NASDAQ" : "KRX");
   const sector      = !stock?.isUs && stock?.sector && stock.sector !== "DEFAULT" ? stock.sector : null;
 
   const logoUrl = stock?.isUs


### PR DESCRIPTION
## 변경

analyze 페이지에서 **미국 종목도 실제 상장 거래소**(NASDAQ/NYSE/AMEX)를 표시.

직전 PR(#487)에서 국내 종목의 시장 구분(코스피/코스닥)을 추가했는데, 미국 종목은 여전히 "NYSE/NASDAQ"로 하드코딩되어 있었다. 예) AAPL은 NASDAQ 상장사인데 정확한 거래소가 표시되지 않았다.

### 파일

- `app/(analyze)/analyze/page.tsx`: US stock 객체에 `market` 추가 — `usSearchInfo.output.tr_mket_name`(거래시장명), 없으면 `ovrs_excg_name`(거래소명)으로 fallback
- `app/(search)/search/components/StockCard.tsx`: market 표시를 `stock.market` 우선 사용으로 통일 — 값이 없으면 기존처럼 US "NYSE/NASDAQ", KR "KRX"로 fallback

### 안전성

`stock.market`이 비어 있으면 기존 동작 그대로(US "NYSE/NASDAQ", KR "KRX") 유지되어, StockCard를 공유하는 검색 페이지 등 다른 화면에 회귀 없음.

## Test Plan
- [ ] analyze 에서 AAPL → NASDAQ, NYSE 상장사 → 뉴욕 등 실제 거래소 표시
- [ ] KR 종목(코스피/코스닥) 회귀 없음
- [ ] 검색 페이지 등 market 미전달 화면 fallback 정상
- [ ] `npx tsc --noEmit` 통과 (확인 완료)

https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN

---
_Generated by [Claude Code](https://claude.ai/code/session_01XxyHNA3KQcBYBhfp8xTqCN)_