### PR TITLE
feat(home): 스켈레톤 로딩 · 전략 쉬운 풀이 · 전략별 그룹 미리보기

### DIFF
--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -8,7 +8,7 @@ import {
   TrendingUp, ChevronRight, BarChart3, Zap, Layers,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { STRATEGY_PRESETS_CLIENT, STRATEGY_BADGE } from "@/lib/constants/strategies";
+import { STRATEGY_PRESETS_CLIENT, STRATEGY_BADGE, type StrategyPreset } from "@/lib/constants/strategies";
 
 interface PreviewStock {
   ticker: string;
@@ -21,8 +21,21 @@ interface PreviewStock {
 }
 
 const HOME_MKTCAP_MIN = 500;
-const PREVIEW_FETCH = 8;   // 미리보기 카드에 담는 종목 수
-const PREVIEW_PUBLIC = 5;  // 비로그인 시 블러 없이 공개하는 종목 수
+const PER_STRATEGY = 2;    // 전략 그룹당 노출 종목 수
+const GROUP_PUBLIC = 3;    // 비로그인 시 블러 없이 공개하는 전략 그룹 수
+
+// 전략별 정렬 키 (값이 작을수록 상위). NCAV 계열은 비율이 높을수록 좋으므로 음수.
+const STRATEGY_SORT: Record<string, (i: PreviewStock) => number> = {
+  ncav:           i => -(i.ncav_ratio ?? 0),
+  near_ncav:      i => -(i.ncav_ratio ?? 0),
+  low_pbr:        i => i.pbr > 0 ? i.pbr : Infinity,
+  s_rim:          i => i.pbr > 0 ? i.pbr : Infinity,
+  quality_value:  i => i.pbr > 0 ? i.pbr : Infinity,
+  balanced_value: i => i.pbr > 0 ? i.pbr : Infinity,
+  graham_number:  i => (i.per > 0 && i.pbr > 0) ? i.per * i.pbr : Infinity,
+  low_per:        i => i.per > 0 ? i.per : Infinity,
+  magic_formula:  i => i.per > 0 ? i.per : Infinity,
+};
 
 const STRATEGY_LABEL: Record<string, string> = {
   ncav: "NCAV", low_pbr: "저PBR", low_per: "저PER", s_rim: "S-RIM",
@@ -118,9 +131,9 @@ function useCountUp(target: number, duration = 1000) {
   return count;
 }
 
-function StockRow({ item, index }: { item: PreviewStock; index: number }) {
+function StockRow({ item, index, excludeStrategy }: { item: PreviewStock; index: number; excludeStrategy?: string }) {
   const ncav = item.ncav_ratio;
-  const strategies = item.strategies?.slice(0, 2) ?? [];
+  const strategies = (item.strategies ?? []).filter(s => s !== excludeStrategy).slice(0, 2);
 
   return (
     <div className="flex items-center gap-3 px-5 py-4 border-b border-neutral-100 dark:border-[#35332e] last:border-0 transition-colors">
@@ -175,6 +188,27 @@ function StockRow({ item, index }: { item: PreviewStock; index: number }) {
   );
 }
 
+function StrategyGroup({ preset, stocks }: { preset: StrategyPreset; stocks: PreviewStock[] }) {
+  return (
+    <div className="border-b border-neutral-100 dark:border-[#35332e] last:border-0">
+      <div className="px-4 py-2.5 bg-[#fcfaf7] dark:bg-[#1f1e1b] flex items-center gap-2">
+        <span className={cn(
+          "text-[11px] font-extrabold px-2 py-0.5 rounded shrink-0",
+          STRATEGY_BADGE[preset.id] ?? "bg-neutral-100 text-neutral-500"
+        )}>
+          {preset.label}
+        </span>
+        <span className="text-[11px] text-neutral-500 dark:text-neutral-400 truncate break-keep">
+          {preset.plain}
+        </span>
+      </div>
+      {stocks.map((item, i) => (
+        <StockRow key={`${preset.id}-${item.ticker}`} item={item} index={i} excludeStrategy={preset.id} />
+      ))}
+    </div>
+  );
+}
+
 export default function HomePage() {
   const { data: session, status } = useSession();
   const isLoggedIn = !!session;
@@ -196,7 +230,7 @@ export default function HomePage() {
           const all: PreviewStock[] = data.data;
           const filtered = all.filter(item => (item.market_cap ?? 0) >= HOME_MKTCAP_MIN);
           setPreview({
-            items: filtered.slice(0, PREVIEW_FETCH),
+            items: filtered,
             total: data.meta.total,
             filteredTotal: filtered.length,
             scanDate: data.meta.scanDate,
@@ -209,8 +243,19 @@ export default function HomePage() {
       .catch(() => setPreview(p => ({ ...p, loading: false })));
   }, []);
 
-  const publicItems = preview.items.slice(0, PREVIEW_PUBLIC);
-  const lockedItems = preview.items.slice(PREVIEW_PUBLIC);
+  // 전략별 상위 PER_STRATEGY개 그룹 (종목 없는 전략은 제외)
+  const groups = STRATEGY_PRESETS_CLIENT.map(preset => {
+    const sortFn = STRATEGY_SORT[preset.id] ?? (i => -(i.ncav_ratio ?? 0));
+    const stocks = preview.items
+      .filter(it => it.strategies?.includes(preset.id))
+      .sort((a, b) => sortFn(a) - sortFn(b))
+      .slice(0, PER_STRATEGY);
+    return { preset, stocks };
+  }).filter(g => g.stocks.length > 0);
+
+  const visibleGroups = isLoggedIn ? groups : groups.slice(0, GROUP_PUBLIC);
+  const lockedGroups = isLoggedIn ? [] : groups.slice(GROUP_PUBLIC);
+
   const formattedDate = preview.scanDate
     ? `${preview.scanDate.slice(0, 4)}.${preview.scanDate.slice(4, 6)}.${preview.scanDate.slice(6, 8)}`
     : null;
@@ -333,8 +378,8 @@ export default function HomePage() {
               </div>
               <p className="text-[11px] text-neutral-400 mt-0.5">
                 {isLoggedIn
-                  ? `NCAV 비율 순 · 전체 ${preview.filteredTotal}개`
-                  : `상위 ${PREVIEW_PUBLIC}개 미리 보기 · 전체 목록은 로그인 후`}
+                  ? `전략별 상위 ${PER_STRATEGY}개 · 전체 ${preview.filteredTotal}개`
+                  : `전략별 미리 보기 · 전체 목록은 로그인 후`}
               </p>
             </div>
             <Link
@@ -357,7 +402,7 @@ export default function HomePage() {
 
             {preview.loading ? (
               <div>
-                {Array.from({ length: PREVIEW_PUBLIC }).map((_, i) => (
+                {Array.from({ length: 5 }).map((_, i) => (
                   <div key={i} className="flex items-center gap-3 px-5 py-4 border-b border-neutral-100 dark:border-[#35332e] last:border-0">
                     <div className="w-4 h-3 rounded bg-neutral-100 dark:bg-[#2c2b27] animate-pulse shrink-0" />
                     <div className="flex-1 min-w-0 space-y-1.5">
@@ -368,41 +413,36 @@ export default function HomePage() {
                   </div>
                 ))}
               </div>
-            ) : preview.items.length === 0 ? (
+            ) : groups.length === 0 ? (
               <div className="py-10 text-center">
                 <BarChart3 size={24} className="text-neutral-300 dark:text-neutral-600 mx-auto mb-2" />
                 <p className="text-xs text-neutral-400">스캔 데이터가 없습니다.</p>
               </div>
             ) : (
               <>
-                {publicItems.map((item, i) => (
-                  <StockRow key={item.ticker} item={item} index={i} />
+                {visibleGroups.map(g => (
+                  <StrategyGroup key={g.preset.id} preset={g.preset} stocks={g.stocks} />
                 ))}
 
-                {/* Locked rows */}
-                {lockedItems.length > 0 && (
+                {/* Locked groups */}
+                {lockedGroups.length > 0 && (
                   <div className="relative">
-                    {lockedItems.map((item, i) => (
-                      <div
-                        key={item.ticker}
-                        className={cn(!isLoggedIn && "blur-sm select-none pointer-events-none")}
-                      >
-                        <StockRow item={item} index={publicItems.length + i} />
-                      </div>
-                    ))}
+                    <div className="blur-sm select-none pointer-events-none">
+                      {lockedGroups.map(g => (
+                        <StrategyGroup key={g.preset.id} preset={g.preset} stocks={g.stocks} />
+                      ))}
+                    </div>
 
-                    {!isLoggedIn && (
-                      <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-b from-white/40 to-white/90 dark:from-[#242320]/40 dark:to-[#242320]/95">
-                        <Link
-                          href="/login"
-                          className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-sm font-bold shadow-md shadow-[#16a34a]/20 transition-all"
-                        >
-                          <Lock size={13} />
-                          로그인하여 전체 확인
-                          <ArrowRight size={13} />
-                        </Link>
-                      </div>
-                    )}
+                    <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-b from-white/40 to-white/90 dark:from-[#242320]/40 dark:to-[#242320]/95">
+                      <Link
+                        href="/login"
+                        className="flex items-center gap-2 px-5 py-2.5 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-sm font-bold shadow-md shadow-[#16a34a]/20 transition-all"
+                      >
+                        <Lock size={13} />
+                        로그인하여 {groups.length}개 전략 전체 확인
+                        <ArrowRight size={13} />
+                      </Link>
+                    </div>
                   </div>
                 )}
 

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -5,7 +5,7 @@ import { useSession } from "next-auth/react";
 import Link from "next/link";
 import {
   Search, Calculator, Filter, Lock, ArrowRight,
-  TrendingUp, ChevronRight, Loader2, BarChart3, Zap, Layers,
+  TrendingUp, ChevronRight, BarChart3, Zap, Layers,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { STRATEGY_PRESETS_CLIENT, STRATEGY_BADGE } from "@/lib/constants/strategies";
@@ -299,9 +299,18 @@ export default function HomePage() {
           </div>
         )}
         {preview.loading && (
-          <div className="border-t border-neutral-100 dark:border-[#2c2b27] flex items-center justify-center gap-2 py-3 text-neutral-400">
-            <Loader2 size={11} className="animate-spin" />
-            <span className="text-xs">집계 중...</span>
+          <div className="border-t border-neutral-100 dark:border-[#2c2b27] relative">
+            <div className="max-w-3xl mx-auto px-5 py-5 grid grid-cols-3 gap-0">
+              {[0, 1, 2].map(i => (
+                <div key={i} className={cn(
+                  "flex flex-col items-center py-1 gap-1.5",
+                  i === 1 && "border-x border-neutral-100 dark:border-[#2c2b27]"
+                )}>
+                  <div className="h-5 w-14 rounded-md bg-neutral-200/80 dark:bg-[#35332e] animate-pulse" />
+                  <div className="h-2.5 w-12 rounded bg-neutral-100 dark:bg-[#2c2b27] animate-pulse" />
+                </div>
+              ))}
+            </div>
           </div>
         )}
       </section>
@@ -345,9 +354,17 @@ export default function HomePage() {
             </div>
 
             {preview.loading ? (
-              <div className="flex items-center justify-center py-12 gap-2 text-neutral-400">
-                <Loader2 size={16} className="animate-spin" />
-                <span className="text-sm">불러오는 중...</span>
+              <div>
+                {[0, 1, 2, 3, 4].map(i => (
+                  <div key={i} className="flex items-center gap-3 px-5 py-4 border-b border-neutral-100 dark:border-[#35332e] last:border-0">
+                    <div className="w-4 h-3 rounded bg-neutral-100 dark:bg-[#2c2b27] animate-pulse shrink-0" />
+                    <div className="flex-1 min-w-0 space-y-1.5">
+                      <div className="h-3.5 w-32 rounded bg-neutral-200/80 dark:bg-[#35332e] animate-pulse" />
+                      <div className="h-2.5 w-16 rounded bg-neutral-100 dark:bg-[#2c2b27] animate-pulse" />
+                    </div>
+                    <div className="h-7 w-12 rounded-md bg-neutral-200/80 dark:bg-[#35332e] animate-pulse shrink-0" />
+                  </div>
+                ))}
               </div>
             ) : preview.items.length === 0 ? (
               <div className="py-10 text-center">
@@ -437,7 +454,10 @@ export default function HomePage() {
                   </span>
                   <ChevronRight size={13} className="text-neutral-300 dark:text-neutral-600 group-hover:text-[#16a34a] group-hover:translate-x-0.5 transition-all" />
                 </div>
-                <p className="text-[11px] text-neutral-500 dark:text-neutral-400 leading-relaxed break-keep">
+                <p className="text-xs text-neutral-700 dark:text-neutral-200 font-medium leading-relaxed break-keep mb-1">
+                  {s.plain}
+                </p>
+                <p className="text-[10px] text-neutral-400 dark:text-neutral-500 font-mono leading-relaxed break-keep">
                   {s.hint}
                 </p>
               </Link>

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -21,6 +21,8 @@ interface PreviewStock {
 }
 
 const HOME_MKTCAP_MIN = 500;
+const PREVIEW_FETCH = 8;   // 미리보기 카드에 담는 종목 수
+const PREVIEW_PUBLIC = 5;  // 비로그인 시 블러 없이 공개하는 종목 수
 
 const STRATEGY_LABEL: Record<string, string> = {
   ncav: "NCAV", low_pbr: "저PBR", low_per: "저PER", s_rim: "S-RIM",
@@ -194,7 +196,7 @@ export default function HomePage() {
           const all: PreviewStock[] = data.data;
           const filtered = all.filter(item => (item.market_cap ?? 0) >= HOME_MKTCAP_MIN);
           setPreview({
-            items: filtered.slice(0, 5),
+            items: filtered.slice(0, PREVIEW_FETCH),
             total: data.meta.total,
             filteredTotal: filtered.length,
             scanDate: data.meta.scanDate,
@@ -207,8 +209,8 @@ export default function HomePage() {
       .catch(() => setPreview(p => ({ ...p, loading: false })));
   }, []);
 
-  const publicItems = preview.items.slice(0, 3);
-  const lockedItems = preview.items.slice(3);
+  const publicItems = preview.items.slice(0, PREVIEW_PUBLIC);
+  const lockedItems = preview.items.slice(PREVIEW_PUBLIC);
   const formattedDate = preview.scanDate
     ? `${preview.scanDate.slice(0, 4)}.${preview.scanDate.slice(4, 6)}.${preview.scanDate.slice(6, 8)}`
     : null;
@@ -332,7 +334,7 @@ export default function HomePage() {
               <p className="text-[11px] text-neutral-400 mt-0.5">
                 {isLoggedIn
                   ? `NCAV 비율 순 · 전체 ${preview.filteredTotal}개`
-                  : "상위 3개 미리 보기 · 전체 목록은 로그인 후"}
+                  : `상위 ${PREVIEW_PUBLIC}개 미리 보기 · 전체 목록은 로그인 후`}
               </p>
             </div>
             <Link
@@ -355,7 +357,7 @@ export default function HomePage() {
 
             {preview.loading ? (
               <div>
-                {[0, 1, 2, 3, 4].map(i => (
+                {Array.from({ length: PREVIEW_PUBLIC }).map((_, i) => (
                   <div key={i} className="flex items-center gap-3 px-5 py-4 border-b border-neutral-100 dark:border-[#35332e] last:border-0">
                     <div className="w-4 h-3 rounded bg-neutral-100 dark:bg-[#2c2b27] animate-pulse shrink-0" />
                     <div className="flex-1 min-w-0 space-y-1.5">

--- a/cf-idiotquant/lib/constants/strategies.ts
+++ b/cf-idiotquant/lib/constants/strategies.ts
@@ -29,18 +29,19 @@ export interface StrategyPreset {
     id: string;
     label: string;
     hint: string;
+    plain: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     clientFilter?: (item: Record<string, any>) => boolean;
 }
 
 export const STRATEGY_PRESETS_CLIENT: StrategyPreset[] = [
-    { id: 'ncav',           label: 'NCAV',     hint: '순유동자산 > 시가총액 — 그레이엄 청산가치 이하',          clientFilter: i => safeNum(i.ncav_ratio) >= 1.0 },
-    { id: 'low_pbr',        label: '저PBR',    hint: 'PBR < 0.5 — 순자산 절반 이하 가격',                       clientFilter: i => safeNum(i.pbr) > 0 && safeNum(i.pbr) < 0.5 },
-    { id: 'low_per',        label: '저PER',    hint: 'PER < 10 + 흑자(EPS > 0)',                                 clientFilter: i => safeNum(i.eps) > 0 && safeNum(i.per) > 0 && safeNum(i.per) < 10 },
-    { id: 's_rim',          label: 'S-RIM',    hint: 'ROE > 8% & PBR < 1.0 — 초과이익 기업 장부가 이하',        clientFilter: i => { const roe = safeNum(i.bps) > 0 ? safeNum(i.eps) / safeNum(i.bps) * 100 : 0; return roe > 8 && safeNum(i.pbr) > 0 && safeNum(i.pbr) < 1.0; } },
-    { id: 'graham_number',  label: '그레이엄', hint: 'PER × PBR < 22.5 — 그레이엄 복합 안전마진',               clientFilter: i => safeNum(i.eps) > 0 && safeNum(i.bps) > 0 && safeNum(i.per) > 0 && safeNum(i.pbr) > 0 && safeNum(i.per) * safeNum(i.pbr) < 22.5 },
-    { id: 'magic_formula',  label: '마법공식', hint: 'PER < 15 & ROE > 10% — Greenblatt 변형',                  clientFilter: i => safeNum(i.eps) > 0 && safeNum(i.per) > 0 && safeNum(i.per) < 15 && safeNum(i.bps) > 0 && safeNum(i.eps) / safeNum(i.bps) * 100 > 10 },
-    { id: 'quality_value',  label: '퀄리티',   hint: 'ROE > 15% & PBR < 2.0 — 버핏 스타일',                     clientFilter: i => safeNum(i.eps) > 0 && safeNum(i.bps) > 0 && safeNum(i.eps) / safeNum(i.bps) * 100 > 15 && safeNum(i.pbr) > 0 && safeNum(i.pbr) < 2.0 },
-    { id: 'near_ncav',      label: 'NCAV근접', hint: 'NCAV 0.7~1.0 — 청산가치 근접 관찰',                       clientFilter: i => safeNum(i.ncav_ratio) >= 0.7 && safeNum(i.ncav_ratio) < 1.0 },
-    { id: 'balanced_value', label: '균형가치', hint: 'PER 5~15 & PBR < 1.5 & EPS > 0',                          clientFilter: i => safeNum(i.eps) > 0 && safeNum(i.per) > 5 && safeNum(i.per) < 15 && safeNum(i.pbr) > 0 && safeNum(i.pbr) < 1.5 },
+    { id: 'ncav',           label: 'NCAV',     plain: '지금 회사를 팔아 빚을 다 갚아도 주가보다 더 남는 회사',  hint: '순유동자산 > 시가총액 — 그레이엄 청산가치 이하',          clientFilter: i => safeNum(i.ncav_ratio) >= 1.0 },
+    { id: 'low_pbr',        label: '저PBR',    plain: '가진 자산 가치의 절반도 안 되는 값에 거래되는 회사',     hint: 'PBR < 0.5 — 순자산 절반 이하 가격',                       clientFilter: i => safeNum(i.pbr) > 0 && safeNum(i.pbr) < 0.5 },
+    { id: 'low_per',        label: '저PER',    plain: '버는 이익에 비해 주가가 유난히 싼 흑자 회사',           hint: 'PER < 10 + 흑자(EPS > 0)',                                 clientFilter: i => safeNum(i.eps) > 0 && safeNum(i.per) > 0 && safeNum(i.per) < 10 },
+    { id: 's_rim',          label: 'S-RIM',    plain: '이익을 꾸준히 잘 내는데도 장부가치보다 싼 회사',         hint: 'ROE > 8% & PBR < 1.0 — 초과이익 기업 장부가 이하',        clientFilter: i => { const roe = safeNum(i.bps) > 0 ? safeNum(i.eps) / safeNum(i.bps) * 100 : 0; return roe > 8 && safeNum(i.pbr) > 0 && safeNum(i.pbr) < 1.0; } },
+    { id: 'graham_number',  label: '그레이엄', plain: '이익도 자산도 모두 싸서 안전마진이 두툼한 회사',         hint: 'PER × PBR < 22.5 — 그레이엄 복합 안전마진',               clientFilter: i => safeNum(i.eps) > 0 && safeNum(i.bps) > 0 && safeNum(i.per) > 0 && safeNum(i.pbr) > 0 && safeNum(i.per) * safeNum(i.pbr) < 22.5 },
+    { id: 'magic_formula',  label: '마법공식', plain: '싸면서 돈도 잘 버는, 가성비 좋은 회사',                 hint: 'PER < 15 & ROE > 10% — Greenblatt 변형',                  clientFilter: i => safeNum(i.eps) > 0 && safeNum(i.per) > 0 && safeNum(i.per) < 15 && safeNum(i.bps) > 0 && safeNum(i.eps) / safeNum(i.bps) * 100 > 10 },
+    { id: 'quality_value',  label: '퀄리티',   plain: '돈을 아주 잘 버는 우량 기업을 적당한 값에',             hint: 'ROE > 15% & PBR < 2.0 — 버핏 스타일',                     clientFilter: i => safeNum(i.eps) > 0 && safeNum(i.bps) > 0 && safeNum(i.eps) / safeNum(i.bps) * 100 > 15 && safeNum(i.pbr) > 0 && safeNum(i.pbr) < 2.0 },
+    { id: 'near_ncav',      label: 'NCAV근접', plain: '청산가치에 거의 닿은, 곧 NCAV가 될 관찰 후보',          hint: 'NCAV 0.7~1.0 — 청산가치 근접 관찰',                       clientFilter: i => safeNum(i.ncav_ratio) >= 0.7 && safeNum(i.ncav_ratio) < 1.0 },
+    { id: 'balanced_value', label: '균형가치', plain: '이익·자산·가격이 고루 균형 잡힌 무난한 회사',           hint: 'PER 5~15 & PBR < 1.5 & EPS > 0',                          clientFilter: i => safeNum(i.eps) > 0 && safeNum(i.per) > 5 && safeNum(i.per) < 15 && safeNum(i.pbr) > 0 && safeNum(i.pbr) < 1.5 },
 ];


### PR DESCRIPTION
## 개요

홈(`/`) MLP 개선 — 로딩 체감 개선, 전문용어 친절화, 발굴 종목 미리보기를 전략별 쇼케이스로 재구성.

## 변경 사항

### 1. 스켈레톤 로딩 (`app/(home)/page.tsx`)
- 히어로 통계 스트립의 "집계 중..." 스피너 → 3열 통계 레이아웃을 닮은 펄스 스켈레톤
- 발굴 종목 목록의 "불러오는 중..." 스피너 → 종목 행 모양 스켈레톤
- 정적으로 멈춰 보이던 스피너 대신 레이아웃이 먼저 잡혀 체감 로딩 개선. 고아 `Loader2` import 정리.

### 2. 전략 카드 쉬운 풀이 (`lib/constants/strategies.ts`)
- 9개 전략에 `plain`(쉬운 한줄 풀이) 필드 추가 — 예: NCAV → "지금 회사를 팔아 빚을 다 갚아도 주가보다 더 남는 회사"
- 홈 카드에서 쉬운 설명을 메인으로, 기존 수식 `hint`는 보조 텍스트로 노출
- `hint`는 백테스트/스크리너 툴팁에서 계속 사용 — 신규 필드만 추가해 기존 동작 영향 없음

### 3. 발굴 종목 미리보기 → 전략별 그룹
- NCAV 비율 단일 순위 → **9개 전략별 그룹(전략당 상위 2개)**으로 재구성
- 전략별 정렬 키 추가 (NCAV 계열=비율, 저PBR·S-RIM·퀄리티·균형=PBR, 저PER·마법공식=PER, 그레이엄=PER×PBR)
- 각 그룹에 전략 라벨 + 쉬운 풀이 헤더 노출 → 9전략을 골고루 쇼케이스
- 비로그인은 상위 3개 전략 그룹 공개 + 나머지 블러/로그인 유도, 로그인 시 전체 노출
- `StockRow`에 `excludeStrategy` 옵션 추가(그룹 헤더와 중복되는 배지 제거)

## 검증
- `npx tsc --noEmit` 통과
- `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018GZJFkXboRhmtrsPuUfGMp)_