### PR TITLE
fix(balance-us): 포트폴리오 자산 구성 통화 기호 $→₩

### DIFF
--- a/cf-idiotquant/components/balance/portfolioChart.tsx
+++ b/cf-idiotquant/components/balance/portfolioChart.tsx
@@ -6,7 +6,7 @@ import {
   PieChart, Pie, BarChart, Bar, XAxis, YAxis, Tooltip, Cell, ResponsiveContainer,
 } from "recharts";
 import { InboxIcon } from "lucide-react";
-import { TabButton, ChartSectionSkeleton, fmtKrw, fmtUsd } from "@/components/balance/shared";
+import { TabButton, ChartSectionSkeleton, fmtKrw } from "@/components/balance/shared";
 
 // =========================================================================
 // 팔레트
@@ -26,11 +26,11 @@ const PIE_COLORS_DARK = [
 // =========================================================================
 // 커스텀 툴팁
 // =========================================================================
-function PieTooltip({ active, payload, isUs }: { active?: boolean; payload?: any[]; isUs: boolean }) {
+function PieTooltip({ active, payload }: { active?: boolean; payload?: any[] }) {
   if (!active || !payload || payload.length === 0) return null;
 
   const { name, value, percent } = payload[0];
-  const formatter = isUs ? fmtUsd : fmtKrw;
+  const formatter = fmtKrw;
   const pctStr = typeof percent === "number" && !isNaN(percent)
     ? `${(percent * 100).toFixed(1)}%`
     : "";
@@ -118,7 +118,7 @@ function PortfolioPieChart({ output1, isUs }: PortfolioPieChartProps) {
                 <Cell key={`cell-${index}`} fill={colors[index % colors.length]} />
               ))}
             </Pie>
-            <Tooltip content={<PieTooltip isUs={isUs} />} />
+            <Tooltip content={<PieTooltip />} />
           </PieChart>
         </ResponsiveContainer>
       </div>
@@ -127,7 +127,7 @@ function PortfolioPieChart({ output1, isUs }: PortfolioPieChartProps) {
       <div className="w-full sm:flex-1 sm:min-w-0 space-y-2.5 sm:max-h-[260px] sm:overflow-y-auto">
         {pieData.map((item, index) => {
           const percent = (item.value / totalValue) * 100;
-          const formatter = isUs ? fmtUsd : fmtKrw;
+          const formatter = fmtKrw;
 
           return (
             <div key={index} className="flex items-center gap-3 pb-2.5 border-b border-neutral-100 dark:border-[#35332e] last:border-0">


### PR DESCRIPTION
## 개요

미국 시장 잔고 화면의 **포트폴리오 자산 구성 차트** 툴팁에서 통화 기호가 `$`로 표시되던 것을 `₩`로 수정합니다. 자산 구성 금액은 원화 환산값이므로 원화 포맷이 맞습니다.

## 변경 사항 (`components/balance/portfolioChart.tsx`)

- `PieTooltip`의 `isUs` 분기 제거 → 항상 `fmtKrw` 사용
- 미사용이 된 `fmtUsd` import 정리, `PieTooltip`·`Tooltip`에서 `isUs` prop 제거

## 검증

- `npx tsc --noEmit` 통과
- 변경 범위: 단일 파일(`portfolioChart.tsx`), 5줄 수정

## 참고

이 브랜치의 이전 home 미리보기 작업(스켈레톤·전략별 그룹 등)은 PR #504로 이미 merge되어, 본 PR에는 통화 기호 수정 커밋만 포함됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018GZJFkXboRhmtrsPuUfGMp)_