### PR TITLE
자동매매 on/off 토글을 선택 계정(kakaoId) 기준으로

### DIFF
--- a/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
+++ b/cf-idiotquant/app/(balance-kr)/balance-kr/page.tsx
@@ -287,12 +287,12 @@ function BalanceKr() {
     if (tradingStatus.state === "pending" || tradingStatus.KR === null) return;
     const next = !tradingStatus.KR;
     try {
-      await dispatch(reqSetTradingActive({ country: "KR", isActive: next })).unwrap();
+      await dispatch(reqSetTradingActive({ country: "KR", isActive: next, key: balanceKey })).unwrap();
       addToast("success", `국내 자동매매가 ${next ? "활성화" : "비활성화"}되었습니다.`);
     } catch {
       addToast("error", "자동매매 상태 변경에 실패했습니다.");
     }
-  }, [tradingStatus, dispatch, addToast]);
+  }, [tradingStatus, dispatch, addToast, balanceKey]);
 
   useEffect(() => {
     const urlKey = searchParams.get("key");
@@ -305,6 +305,7 @@ function BalanceKr() {
     dispatch(reqGetInquireBalance(balanceKey));
     fetchOrderHistory(balanceKey);
     dispatch(reqGetKrCapital(balanceKey));
+    dispatch(reqFetchTradingStatus({ country: "KR", key: balanceKey }));
   }, [balanceKey]);
 
   useEffect(() => {
@@ -319,7 +320,6 @@ function BalanceKr() {
     }
     dispatch(reqGetCapitalToken());
     dispatch(reqGetKakaoMemberList());
-    dispatch(reqFetchTradingStatus("KR"));
     dispatch(reqGetMyLikes());
   }, [session, status, dispatch, router]);
 

--- a/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
+++ b/cf-idiotquant/app/(balance-us)/balance-us/page.tsx
@@ -252,12 +252,12 @@ function BalanceUs() {
     if (tradingStatus.state === "pending" || tradingStatus.US === null) return;
     const next = !tradingStatus.US;
     try {
-      await dispatch(reqSetTradingActive({ country: "US", isActive: next })).unwrap();
+      await dispatch(reqSetTradingActive({ country: "US", isActive: next, key: balanceKey })).unwrap();
       addToast("success", `미국 자동매매가 ${next ? "활성화" : "비활성화"}되었습니다.`);
     } catch {
       addToast("error", "자동매매 상태 변경에 실패했습니다.");
     }
-  }, [tradingStatus, dispatch, addToast]);
+  }, [tradingStatus, dispatch, addToast, balanceKey]);
 
   const handleOrderResult = useCallback((status: "success" | "error", message: string) => {
     addToast(status, message);
@@ -286,13 +286,15 @@ function BalanceUs() {
       return;
     }
     dispatch(reqGetKakaoMemberList());
-    dispatch(reqFetchTradingStatus("US"));
     dispatch(reqGetMyLikes());
   }, [session, status, dispatch, router]);
 
   // 트레이딩 조건(quant_rule) 로드
   useEffect(() => {
-    if (balanceKey && balanceKey !== "undefined") dispatch(reqGetUsQuantRule(balanceKey));
+    if (balanceKey && balanceKey !== "undefined") {
+      dispatch(reqGetUsQuantRule(balanceKey));
+      dispatch(reqFetchTradingStatus({ country: "US", key: balanceKey }));
+    }
   }, [balanceKey, dispatch]);
 
   // 조건 저장 결과 토스트

--- a/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeSlice.tsx
+++ b/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeSlice.tsx
@@ -459,8 +459,8 @@ export const algorithmTradeSlice = createAppSlice({
             }
         ),
         reqFetchTradingStatus: create.asyncThunk(
-            async (country: "KR" | "US") => {
-                const value = await fetchTradingStatus(country);
+            async ({ country, key }: { country: "KR" | "US"; key?: string }) => {
+                const value = await fetchTradingStatus(country, key);
                 if (value === null) throw new Error("fetch_failed");
                 return { country, value };
             },
@@ -474,8 +474,8 @@ export const algorithmTradeSlice = createAppSlice({
             }
         ),
         reqSetTradingActive: create.asyncThunk(
-            async ({ country, isActive }: { country: "KR" | "US"; isActive: boolean }) => {
-                const ok = await setTradingActive(country, isActive);
+            async ({ country, isActive, key }: { country: "KR" | "US"; isActive: boolean; key?: string }) => {
+                const ok = await setTradingActive(country, isActive, key);
                 if (!ok) throw new Error("set_failed");
                 return { country, isActive };
             },

--- a/cf-idiotquant/lib/features/algorithmTrade/tradingStatusAPI.ts
+++ b/cf-idiotquant/lib/features/algorithmTrade/tradingStatusAPI.ts
@@ -1,6 +1,8 @@
-export async function fetchTradingStatus(country: "KR" | "US"): Promise<boolean | null> {
+// key(=선택 계정 kakaoId, admin 전용)가 있으면 그 계정 대상으로 조회/토글
+export async function fetchTradingStatus(country: "KR" | "US", key?: string): Promise<boolean | null> {
   try {
-    const res = await fetch(`/api/proxy/trading/account-status?country=${country}`);
+    const q = key ? `&kakao-id=${key}` : "";
+    const res = await fetch(`/api/proxy/trading/account-status?country=${country}${q}`);
     if (res.status === 404) return false; // 계정 미등록 → OFF 상태로 버튼 표시
     const json = await res.json();
     if (!json.success) return null;
@@ -10,8 +12,9 @@ export async function fetchTradingStatus(country: "KR" | "US"): Promise<boolean 
   }
 }
 
-export async function setTradingActive(country: "KR" | "US", isActive: boolean): Promise<boolean> {
-  const res = await fetch(`/api/proxy/trading/account-status?country=${country}`, {
+export async function setTradingActive(country: "KR" | "US", isActive: boolean, key?: string): Promise<boolean> {
+  const q = key ? `&kakao-id=${key}` : "";
+  const res = await fetch(`/api/proxy/trading/account-status?country=${country}${q}`, {
     method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ is_active: isActive }),


### PR DESCRIPTION
## 개요

admin이 `balance-kr`/`balance-us`에서 **계정을 선택한 뒤 그 계정의 자동매매를 on/off**할 수 있도록, account-status 조회/토글에 선택 계정(kakaoId)을 전달합니다.

## 변경 사항

- **`tradingStatusAPI.ts`** — `fetchTradingStatus`/`setTradingActive`에 optional `key` 추가 → `?kakao-id` 쿼리로 전달
- **`algorithmTradeSlice.tsx`** — `reqFetchTradingStatus`/`reqSetTradingActive` thunk가 `key`를 받도록 시그니처 확장
- **`balance-kr`/`balance-us` page** — on/off 토글에 `balanceKey` 전달 + trading-status 조회를 `[balanceKey]` 이펙트로 이동(계정 전환 시 자동 갱신)

## 연동
- 백엔드(`accountStatus.js`에서 admin `?kakao-id` 처리)는 `idiotquant-worker` 별도 PR과 함께 동작.

## 검증
- `npx tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018GZJFkXboRhmtrsPuUfGMp)_