### PR TITLE
fix(scan): getScanDailyList limit 2000 → 2500

### DIFF
--- a/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeAPI.tsx
+++ b/cf-idiotquant/lib/features/algorithmTrade/algorithmTradeAPI.tsx
@@ -46,7 +46,7 @@ export const getQuantRuleDesc: any = async () => {
 export const getScanDailyList: any = async (date?: string, strategy?: string) => {
     const dateParam = date ?? "latest";
     const strategyParam = strategy ?? "all";
-    const subUrl = `/scan/daily?date=${encodeURIComponent(dateParam)}&strategy=${strategyParam}&limit=2000&sort=ncav_ratio&order=desc`;
+    const subUrl = `/scan/daily?date=${encodeURIComponent(dateParam)}&strategy=${strategyParam}&limit=2500&sort=ncav_ratio&order=desc`;
     return getAlgorithmTradeRequest(subUrl);
 }
 
@@ -64,7 +64,7 @@ export const getScanDailyByTicker = async (ticker: string, limit = 30) =>
     getAlgorithmTradeRequest(`/scan/daily/ticker/${encodeURIComponent(ticker)}?limit=${limit}`);
 
 export const getScanDailyAll = async (date: string) =>
-    getAlgorithmTradeRequest(`/scan/daily?date=${encodeURIComponent(date)}&strategy=all&limit=2000`);
+    getAlgorithmTradeRequest(`/scan/daily?date=${encodeURIComponent(date)}&strategy=all&limit=2500`);
 
 export const getPortfolioSimulation = async (startDate: string, strategy: string) =>
     getAlgorithmTradeRequest(`/scan/portfolio?start_date=${encodeURIComponent(startDate)}&strategy=${encodeURIComponent(strategy)}`);


### PR DESCRIPTION
## 개요

스캔 결과(`/scan/daily`)가 항상 2,000개로 잘리던 문제를 수정합니다. 전체 스캔 종목수가 2,400개라 기존 `limit=2000`으로는 결과가 잘렸습니다.

## 변경 사항

- **`lib/features/algorithmTrade/algorithmTradeAPI.tsx`** — `getScanDailyList`, `getScanDailyAll`의 `limit=2000 → 2500` (백엔드 clamp 상한과 동일하게 상향)

> 백엔드(`scan.js`의 limit clamp 상한 `2000 → 2500`)는 `idiotquant-worker` 별도 PR과 함께 동작합니다.

## 검증

- `npx tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018GZJFkXboRhmtrsPuUfGMp)_