### PR TITLE
fix(home): 온보딩 종목 수 표기 2,000 → 2,400

### DIFF
--- a/cf-idiotquant/app/(home)/layout.tsx
+++ b/cf-idiotquant/app/(home)/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'IdiotQuant - 무료 NCAV·저PBR·저PER 주식 스크리너',
-  description: '퀀트 알고리즘이 매일 코스피·코스닥 2,000개 종목을 스캔해 NCAV, 저PBR, 저PER, S-RIM 기준 저평가 주식을 자동 발굴합니다. 데이터 기반 스마트 가치투자의 시작.',
+  description: '퀀트 알고리즘이 매일 코스피·코스닥 2,400개 종목을 스캔해 NCAV, 저PBR, 저PER, S-RIM 기준 저평가 주식을 자동 발굴합니다. 데이터 기반 스마트 가치투자의 시작.',
   keywords: [
     'NCAV 주식', '저PBR 주식', '저PER 주식', '퀀트 투자', '주식 스크리너',
     '저평가 주식', '주식 발굴', '퀀트 전략', '가치투자', '코스피 저평가 주식',
@@ -40,7 +40,7 @@ const jsonLdFaq = {
       name: 'IdiotQuant 스크리너는 어떻게 작동하나요?',
       acceptedAnswer: {
         '@type': 'Answer',
-        text: '매일 코스피·코스닥 2,000개 종목의 재무제표(유동자산, 총부채, 순이익 등)와 실시간 시세를 자동으로 스캔합니다. NCAV, 저PBR, 저PER, S-RIM 등 퀀트 전략 기준을 충족하는 종목을 필터링해 매일 업데이트된 발굴 종목 목록을 제공합니다.',
+        text: '매일 코스피·코스닥 2,400개 종목의 재무제표(유동자산, 총부채, 순이익 등)와 실시간 시세를 자동으로 스캔합니다. NCAV, 저PBR, 저PER, S-RIM 등 퀀트 전략 기준을 충족하는 종목을 필터링해 매일 업데이트된 발굴 종목 목록을 제공합니다.',
       },
     },
     {

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -223,7 +223,7 @@ export default function HomePage() {
   }>({ items: [], total: 0, filteredTotal: 0, scanDate: null, loading: true });
 
   useEffect(() => {
-    fetch("/api/proxy/scan/daily?strategy=all&limit=2000&sort=ncav_ratio&order=desc")
+    fetch("/api/proxy/scan/daily?strategy=all&limit=2500&sort=ncav_ratio&order=desc")
       .then(r => r.json())
       .then((data: any) => {
         if (data.success) {
@@ -290,7 +290,7 @@ export default function HomePage() {
           </h1>
 
           <p className="text-sm sm:text-[15px] text-neutral-500 dark:text-neutral-400 font-medium leading-relaxed mb-7">
-            9가지 가치투자 전략으로 매일 2,000여 종목을<br className="hidden sm:block" />
+            9가지 가치투자 전략으로 매일 2,400여 종목을<br className="hidden sm:block" />
             알고리즘이 대신 분석합니다.
           </p>
 

--- a/cf-idiotquant/app/layout.tsx
+++ b/cf-idiotquant/app/layout.tsx
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
     default: 'IdiotQuant - 무료 NCAV·저PBR·저PER 주식 스크리너',
     template: '%s | IdiotQuant',
   },
-  description: '퀀트 알고리즘이 매일 코스피·코스닥 2,000개 종목을 스캔해 NCAV, 저PBR, 저PER, S-RIM 기준 저평가 주식을 자동 발굴합니다. 재무분석·목표주가·자동매매 기능 제공.',
+  description: '퀀트 알고리즘이 매일 코스피·코스닥 2,400개 종목을 스캔해 NCAV, 저PBR, 저PER, S-RIM 기준 저평가 주식을 자동 발굴합니다. 재무분석·목표주가·자동매매 기능 제공.',
   keywords: [
     '퀀트 투자', 'NCAV 주식', '저평가 주식', '주식 스크리너',
     '저PBR 주식', '저PER 주식', 'S-RIM', '주식 재무분석',


### PR DESCRIPTION
## 개요

홈(온보딩/랜딩) 페이지에 "2,000개/2,000여 종목"으로 표기되던 스캔 종목 수를 실제 스캔 대상(2,400종목)에 맞게 수정합니다.

## 변경 사항

### `app/(home)/page.tsx`
- 헤드라인 표시 문구 **"매일 2,000여 종목" → "매일 2,400여 종목"**
- 발굴 미리보기 fetch `limit=2000 → 2500` (목록 잘림 방지, scan limit 상향과 일관)

### SEO·구조화 데이터 (동일 문구 일관성)
- **`app/(home)/layout.tsx`** — description + FAQ 구조화 데이터 텍스트 `2,000개 → 2,400개`
- **`app/layout.tsx`** — 사이트 기본 description `2,000개 → 2,400개`

## 검증

- `npx tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018GZJFkXboRhmtrsPuUfGMp)_