### PR TITLE
fix(seo): Organization 로고 경로 404 수정 + OG 이미지 추가

### DIFF
--- a/cf-idiotquant/app/layout.tsx
+++ b/cf-idiotquant/app/layout.tsx
@@ -87,12 +87,16 @@ export const metadata: Metadata = {
     siteName: 'IdiotQuant',
     locale: 'ko_KR',
     type: 'website',
+    images: [
+      { url: 'https://idiotquant.com/icon-512.png', width: 512, height: 512, alt: 'IdiotQuant' },
+    ],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'IdiotQuant - 무료 NCAV·저PBR 주식 스크리너',
     description: '퀀트 알고리즘이 매일 코스피·코스닥 저평가 주식을 발굴합니다.',
     creator: '@idiotquant',
+    images: ['https://idiotquant.com/icon-512.png'],
   },
 };
 
@@ -117,7 +121,7 @@ const jsonLdOrg = {
   '@type': 'Organization',
   'name': 'IdiotQuant',
   'url': 'https://idiotquant.com',
-  'logo': 'https://idiotquant.com/images/logo.png',
+  'logo': 'https://idiotquant.com/icon-512.png',
   'description': '퀀트 알고리즘 기반 무료 주식 스크리너 및 재무분석 서비스',
   'contactPoint': {
     '@type': 'ContactPoint',


### PR DESCRIPTION
## 개요

구글 검색 등에 로고가 반영되지 않던 원인 중 **코드로 고칠 수 있는 부분**을 수정합니다.

## 원인

`app/layout.tsx`의 Organization 구조화 데이터 `logo`가 존재하지 않는 `https://idiotquant.com/images/logo.png`(404)를 가리켜, 구글이 조직 로고를 가져오지 못했습니다. (`public/images/logo.png` 파일 없음)

## 변경 사항 (`app/layout.tsx`)

- **`jsonLdOrg.logo`** — `/images/logo.png`(404) → 실제 존재하는 `/icon-512.png`(512×512 새 브랜드 아이콘)
- **`openGraph.images` / `twitter.images`** — `/icon-512.png` 추가 (SNS 공유 미리보기 노출)

## 검증

- `npx tsc --noEmit` 통과

## 참고 (코드 밖)

- 파비콘(검색 결과 옆 아이콘) 파일은 이미 갱신·반영돼 있으며, 구글 재크롤 주기에 따라 갱신됩니다(수 주 소요 가능).
- 배포 후 Google Search Console에서 메인 URL 색인 생성 요청을 하면 반영이 빨라집니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018GZJFkXboRhmtrsPuUfGMp)_