### PR TITLE
docs: CLAUDE.md에 영어 사고 / 한글 설명 지침 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Behavioral Guidelines
 
+**Always think in English.** Regardless of the language used in the request, reason and think in English.
+
 **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
 ### 1. Think Before Coding

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Always think in English.** Regardless of the language used in the request, reason and think in English.
 
+**Explain results in Korean.** While thinking in English, write explanations and responses to the user in Korean.
+
 **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
 
 ### 1. Think Before Coding


### PR DESCRIPTION
## 변경 요약

`CLAUDE.md`의 `## Behavioral Guidelines` 섹션에 두 가지 지침을 추가했습니다.

- **Always think in English.** 요청 언어와 무관하게 사고/추론은 영어로 한다.
- **Explain results in Korean.** 사고는 영어로 하되, 사용자에게 전달하는 설명/응답은 한글로 작성한다.

## 변경 파일

- `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZmvL8hb5ZiuEZczunWvB9)_