### PR TITLE
feat: 종목 목록 복사 버튼 (종목명만 / 상세)

### DIFF
--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -15,6 +15,7 @@ import {
     reqGetMyLikes, reqToggleLike,
 } from "@/lib/features/stockLikes/stockLikesSlice";
 import { cn } from "@/lib/utils";
+import { CopyStockButtons, type CopyStock } from "@/components/copyStockButtons";
 import { STRATEGY_LABEL, STRATEGY_BADGE, STRATEGY_PRESETS_CLIENT as STRATEGY_PRESETS, MKTCAP_PRESETS } from "@/lib/constants/strategies";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -645,6 +646,16 @@ function ScreenerContent() {
     // 단일 전략만 선택했을 때, 그 전략 기준 컬럼을 강조 (0개·복수 선택이면 강조 안 함)
     const highlightMap: HighlightMap | null =
         activeStrategyIds.size === 1 ? (STRATEGY_HIGHLIGHT[Array.from(activeStrategyIds)[0]] ?? null) : null;
+
+    // 관심(좋아요) 목록 복사용 행
+    const likedCopyRows = useMemo<CopyStock[]>(() => filteredList.map(item => ({
+        name: item.name,
+        ticker: item.ticker,
+        ncav: item.ncav_ratio,
+        pbr: item.pbr,
+        per: item.per,
+        roe: safeNum(item.bps) > 0 ? (safeNum(item.eps) / safeNum(item.bps)) * 100 : null,
+    })), [filteredList]);
     const isLoading = !showLikedOnly && (ncavDailyList.state === "pending" || ncavDailyList.state === "init");
 
     const handleStockClick = useCallback((ticker: string, name: string) => {
@@ -1178,6 +1189,13 @@ function ScreenerContent() {
 
                 {!isLoading && filteredList.length > 0 && (
                     <>
+                        {/* 관심 목록 복사 (종목명만 / 상세) */}
+                        {showLikedOnly && (
+                            <div className="flex items-center justify-end gap-2 mb-3">
+                                <span className="text-[11px] text-neutral-400 font-medium">목록 복사</span>
+                                <CopyStockButtons rows={likedCopyRows} />
+                            </div>
+                        )}
                         {/* 데스크탑 테이블 */}
                         <div className="hidden md:block">
                             <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] overflow-hidden shadow-sm">

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -34,6 +34,7 @@ import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 import validCorpCodeArray from "@/public/data/validCorpCodeArray.json";
 import validCorpNameArray from "@/public/data/validCorpNameArray.json";
+import { CopyStockButtons, type CopyStock } from "@/components/copyStockButtons";
 
 /** Tailwind 클래스 병합 유틸리티 */
 function cn(...inputs: ClassValue[]) {
@@ -721,6 +722,15 @@ function GroupSection({
   const showRefill = isMaster && rows.some(r => r.movable);
   const showCheck = isMaster && rows.length > 0; // 모든 행 선택 가능(좋아요는 복사용)
   const selectableTickers = useMemo(() => rows.map(r => r.symbol), [rows]);
+  // 복사용 행: 종목명/티커 + 지표(ROE는 EPS/BPS로 계산)
+  const copyRows = useMemo<CopyStock[]>(() => rows.map(r => ({
+    name: r.name || r.symbol,
+    ticker: r.symbol,
+    ncav: r.ncavRatio,
+    pbr: r.pbr,
+    per: r.per,
+    roe: Number(r.bps) > 0 ? (Number(r.eps) / Number(r.bps)) * 100 : null,
+  })), [rows]);
   // 선택 여부는 이 섹션 키 기준으로만 판단(다른 섹션의 동일 종목과 분리)
   const isPicked = (sym: string) => picked.has(pickKey(sectionKey, sym));
   const allChecked = selectableTickers.length > 0 && selectableTickers.every(isPicked);
@@ -778,6 +788,8 @@ function GroupSection({
         </div>
 
         <div className="ml-auto flex items-center gap-2">
+          {/* 종목 목록 복사 (종목명만 / 상세) */}
+          <CopyStockButtons rows={copyRows} />
           {/* 적용 조건 칩 (그룹 ON 일 때) */}
           {conditionChips && conditionChips.length > 0 && (
             <div className="hidden md:flex items-center gap-1">

--- a/cf-idiotquant/components/copyStockButtons.tsx
+++ b/cf-idiotquant/components/copyStockButtons.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// 복사 대상 종목 한 줄. 지표는 있으면 상세 복사에 포함, 없으면 생략.
+export interface CopyStock {
+  name: string;
+  ticker: string;
+  ncav?: number | string | null;
+  pbr?: number | string | null;
+  per?: number | string | null;
+  roe?: number | string | null; // 퍼센트 값
+}
+
+const pos = (v: unknown): number | null => {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : null;
+};
+
+// 종목명만 줄바꿈으로 이어 붙임
+function namesText(rows: CopyStock[]): string {
+  return rows.map(r => r.name || r.ticker).join("\n");
+}
+
+// 사람이 읽는 텍스트: "삼성전자(005930) · NCAV 1.2x · PBR 0.9 · PER 8.1 · ROE 12.0%"
+function detailsText(rows: CopyStock[]): string {
+  return rows.map(r => {
+    const parts: string[] = [];
+    const ncav = pos(r.ncav); if (ncav != null) parts.push(`NCAV ${ncav.toFixed(2)}x`);
+    const pbr = pos(r.pbr);   if (pbr != null) parts.push(`PBR ${pbr.toFixed(2)}`);
+    const per = pos(r.per);   if (per != null) parts.push(`PER ${per.toFixed(1)}`);
+    const roe = pos(r.roe);   if (roe != null) parts.push(`ROE ${roe.toFixed(1)}%`);
+    const head = `${r.name || r.ticker}(${r.ticker})`;
+    return parts.length ? `${head} · ${parts.join(" · ")}` : head;
+  }).join("\n");
+}
+
+async function writeClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const BTN_CLS =
+  "inline-flex shrink-0 items-center gap-1 rounded-md border border-neutral-200 bg-white px-2 py-1 text-[11px] font-bold text-neutral-500 hover:bg-neutral-50 disabled:opacity-50 dark:border-[#35332e] dark:bg-[#242320] dark:hover:bg-[#2c2b27]";
+
+export function CopyStockButtons({ rows, className }: { rows: CopyStock[]; className?: string }) {
+  const [copied, setCopied] = useState<null | "names" | "details">(null);
+
+  if (rows.length === 0) return null;
+
+  const handle = async (kind: "names" | "details") => {
+    const ok = await writeClipboard(kind === "names" ? namesText(rows) : detailsText(rows));
+    if (ok) {
+      setCopied(kind);
+      setTimeout(() => setCopied(null), 1500);
+    }
+  };
+
+  return (
+    <div className={cn("flex items-center gap-1.5", className)}>
+      <button type="button" onClick={() => handle("names")} className={BTN_CLS} title="종목명만 복사">
+        {copied === "names" ? <Check className="w-3 h-3 text-[#16a34a]" /> : <Copy className="w-3 h-3" />}
+        {copied === "names" ? "복사됨" : "종목명"}
+      </button>
+      <button type="button" onClick={() => handle("details")} className={BTN_CLS} title="종목명 + 지표 함께 복사">
+        {copied === "details" ? <Check className="w-3 h-3 text-[#16a34a]" /> : <Copy className="w-3 h-3" />}
+        {copied === "details" ? "복사됨" : "상세"}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 요약

좋아요 목록과 계좌 종목 목록을 클립보드로 복사하는 버튼을 추가합니다. 버튼은 두 종류:

- **종목명**: 종목명만 줄바꿈으로 복사
- **상세**: 사람이 읽는 한 줄 형식으로 복사 — 예) `삼성전자(005930) · NCAV 1.2x · PBR 0.9 · PER 8.1 · ROE 12.0%` (데이터 없는 지표는 생략)

복사 성공 시 1.5초간 "복사됨" + 체크 표시.

## 배치 위치
1. **스크리너 '관심(좋아요)' 뷰** — 목록 상단 우측.
2. **계좌 페이지 `GroupSection` 헤더** — 단일 컴포넌트라 아래 세 섹션을 한 번에 커버 (KR·US 계좌 뷰 모두):
   - 좋아요(찜) 섹션
   - 사용자 그룹 섹션들
   - 미지정 섹션

## 구현 메모
- 공용 컴포넌트 `components/copyStockButtons.tsx` 신규 (`<CopyStockButtons rows={...} />`).
- ROE는 `EPS/BPS`로 계산해 기존 지표 로직과 일치.
- `navigator.clipboard.writeText` 사용, 실패 시 조용히 무시.

## 검증
- `npx tsc --noEmit`: 에러 0.

## 변경 파일
- `cf-idiotquant/components/copyStockButtons.tsx` (신규)
- `cf-idiotquant/components/balance/stockListTable.tsx`
- `cf-idiotquant/app/(screener)/screener/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZmvL8hb5ZiuEZczunWvB9)_