### PR TITLE
feat: 복사 버튼 확장 (프로필·잔고·스크리너·analyze) + 상세 형식 가독성 개선

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -22,6 +22,7 @@ import {
   DollarSign, Coins, Heart, X, TrendingUp, ChevronLeft, Lock, ArrowRight, BarChart2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { CopyStockButtons } from '@/components/copyStockButtons';
 
 // =========================================================================
 // Dynamic imports
@@ -583,6 +584,19 @@ function AnalyzeContent() {
             {waitResponse && !isPriceLoaded && <ResultSkeleton />}
 
             <div className={cn(!isPriceLoaded ? 'hidden' : 'animate-in fade-in duration-400')}>
+
+              {/* 종목 정보 복사 (종목명만 / 상세) */}
+              {stockData && (
+                <div className="flex items-center justify-end gap-2 mb-3">
+                  <span className="text-[11px] text-neutral-400 font-medium">복사</span>
+                  <CopyStockButtons rows={[{
+                    name: displayName,
+                    ticker: krOrUs === 'US' ? name : (stockData.stockTicker ?? tickerFromUrl),
+                    pbr: stockData.pbr,
+                    per: stockData.per,
+                  }]} />
+                </div>
+              )}
 
               {/* 종목 카드 + 핵심 지표 — 최상단 */}
               <div className="grid grid-cols-1 lg:grid-cols-12 gap-5 mb-6">

--- a/cf-idiotquant/app/(profile)/profile/page.tsx
+++ b/cf-idiotquant/app/(profile)/profile/page.tsx
@@ -222,7 +222,7 @@ export default function ProfilePage() {
                     {likedList.length > 0 && (
                         <div className="px-5 pb-2 flex items-center justify-end gap-2">
                             <span className="text-[10px] text-neutral-400 font-medium">목록 복사</span>
-                            <CopyStockButtons rows={likedCopyRows} />
+                            <CopyStockButtons rows={likedCopyRows} label="관심 종목" />
                         </div>
                     )}
 

--- a/cf-idiotquant/app/(profile)/profile/page.tsx
+++ b/cf-idiotquant/app/(profile)/profile/page.tsx
@@ -11,6 +11,7 @@ import {
     reqGetMyLikes, reqToggleLike,
 } from "@/lib/features/stockLikes/stockLikesSlice";
 import { cn } from "@/lib/utils";
+import { CopyStockButtons, type CopyStock } from "@/components/copyStockButtons";
 
 const STRATEGY_BADGE: Record<string, string> = {
     ncav:           "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-400",
@@ -35,6 +36,16 @@ export default function ProfilePage() {
     const dispatch = useAppDispatch();
     const likedList = useAppSelector(selectLikedList);
     const likesState = useAppSelector(selectLikesState);
+
+    // 관심 종목 복사용 행 (ROE는 EPS/BPS로 계산)
+    const likedCopyRows: CopyStock[] = likedList.map(item => ({
+        name: item.stock_name ?? item.ticker,
+        ticker: item.ticker,
+        ncav: item.ncav_ratio,
+        pbr: item.pbr,
+        per: item.per,
+        roe: Number(item.bps) > 0 ? (Number(item.eps) / Number(item.bps)) * 100 : null,
+    }));
 
     const isMasterUser = session?.user?.name === process.env.NEXT_PUBLIC_MASTER;
     const isAdmin = (session?.user as any)?.role === "admin";
@@ -207,6 +218,13 @@ export default function ProfilePage() {
                             발굴 페이지에서 보기
                         </Link>
                     </div>
+
+                    {likedList.length > 0 && (
+                        <div className="px-5 pb-2 flex items-center justify-end gap-2">
+                            <span className="text-[10px] text-neutral-400 font-medium">목록 복사</span>
+                            <CopyStockButtons rows={likedCopyRows} />
+                        </div>
+                    )}
 
                     {likesState === "pending" || likesState === "init" ? (
                         <div className="px-5 py-5 flex justify-center">

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -647,8 +647,8 @@ function ScreenerContent() {
     const highlightMap: HighlightMap | null =
         activeStrategyIds.size === 1 ? (STRATEGY_HIGHLIGHT[Array.from(activeStrategyIds)[0]] ?? null) : null;
 
-    // 관심(좋아요) 목록 복사용 행
-    const likedCopyRows = useMemo<CopyStock[]>(() => filteredList.map(item => ({
+    // 목록 복사용 행 (관심 뷰·일반 발굴 목록 공용)
+    const copyRows = useMemo<CopyStock[]>(() => filteredList.map(item => ({
         name: item.name,
         ticker: item.ticker,
         ncav: item.ncav_ratio,
@@ -1189,13 +1189,11 @@ function ScreenerContent() {
 
                 {!isLoading && filteredList.length > 0 && (
                     <>
-                        {/* 관심 목록 복사 (종목명만 / 상세) */}
-                        {showLikedOnly && (
-                            <div className="flex items-center justify-end gap-2 mb-3">
-                                <span className="text-[11px] text-neutral-400 font-medium">목록 복사</span>
-                                <CopyStockButtons rows={likedCopyRows} />
-                            </div>
-                        )}
+                        {/* 목록 복사 (종목명만 / 상세) */}
+                        <div className="flex items-center justify-end gap-2 mb-3">
+                            <span className="text-[11px] text-neutral-400 font-medium">목록 복사</span>
+                            <CopyStockButtons rows={copyRows} label={showLikedOnly ? "관심 종목" : "발굴 종목"} />
+                        </div>
                         {/* 데스크탑 테이블 */}
                         <div className="hidden md:block">
                             <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] overflow-hidden shadow-sm">

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -789,7 +789,7 @@ function GroupSection({
 
         <div className="ml-auto flex items-center gap-2">
           {/* 종목 목록 복사 (종목명만 / 상세) */}
-          <CopyStockButtons rows={copyRows} />
+          <CopyStockButtons rows={copyRows} label={title} />
           {/* 적용 조건 칩 (그룹 ON 일 때) */}
           {conditionChips && conditionChips.length > 0 && (
             <div className="hidden md:flex items-center gap-1">

--- a/cf-idiotquant/components/copyStockButtons.tsx
+++ b/cf-idiotquant/components/copyStockButtons.tsx
@@ -8,33 +8,59 @@ import { cn } from "@/lib/utils";
 export interface CopyStock {
   name: string;
   ticker: string;
+  // 밸류에이션 지표 (스크리너·관심·운용 종목)
   ncav?: number | string | null;
   pbr?: number | string | null;
   per?: number | string | null;
   roe?: number | string | null; // 퍼센트 값
+  // 잔고(보유) 전용 — 있으면 상세에 포함
+  qty?: number | string | null;
+  evluAmt?: number | string | null;
+  profitRate?: number | string | null; // 퍼센트 값 (음수 가능)
 }
 
-const pos = (v: unknown): number | null => {
+const fin = (v: unknown): number | null => {
   const n = Number(v);
-  return Number.isFinite(n) && n > 0 ? n : null;
+  return Number.isFinite(n) ? n : null;
 };
+const pos = (v: unknown): number | null => {
+  const n = fin(v);
+  return n != null && n > 0 ? n : null;
+};
+
+// 한 종목의 지표 묶음 ("NCAV 1.20x · PBR 0.90 · 보유 10주 · 수익률 +5.2%")
+function metricsOf(r: CopyStock): string {
+  const parts: string[] = [];
+  const ncav = pos(r.ncav); if (ncav != null) parts.push(`NCAV ${ncav.toFixed(2)}x`);
+  const pbr = pos(r.pbr);   if (pbr != null) parts.push(`PBR ${pbr.toFixed(2)}`);
+  const per = pos(r.per);   if (per != null) parts.push(`PER ${per.toFixed(1)}`);
+  const roe = pos(r.roe);   if (roe != null) parts.push(`ROE ${roe.toFixed(1)}%`);
+  const qty = pos(r.qty);   if (qty != null) parts.push(`보유 ${qty.toLocaleString()}주`);
+  const evlu = pos(r.evluAmt); if (evlu != null) parts.push(`평가 ${Math.round(evlu).toLocaleString()}`);
+  const pr = fin(r.profitRate); if (pr != null) parts.push(`수익률 ${pr > 0 ? "+" : ""}${pr.toFixed(1)}%`);
+  return parts.join(" · ");
+}
 
 // 종목명만 줄바꿈으로 이어 붙임
 function namesText(rows: CopyStock[]): string {
   return rows.map(r => r.name || r.ticker).join("\n");
 }
 
-// 사람이 읽는 텍스트: "삼성전자(005930) · NCAV 1.2x · PBR 0.9 · PER 8.1 · ROE 12.0%"
-function detailsText(rows: CopyStock[]): string {
-  return rows.map(r => {
-    const parts: string[] = [];
-    const ncav = pos(r.ncav); if (ncav != null) parts.push(`NCAV ${ncav.toFixed(2)}x`);
-    const pbr = pos(r.pbr);   if (pbr != null) parts.push(`PBR ${pbr.toFixed(2)}`);
-    const per = pos(r.per);   if (per != null) parts.push(`PER ${per.toFixed(1)}`);
-    const roe = pos(r.roe);   if (roe != null) parts.push(`ROE ${roe.toFixed(1)}%`);
-    const head = `${r.name || r.ticker}(${r.ticker})`;
-    return parts.length ? `${head} · ${parts.join(" · ")}` : head;
-  }).join("\n");
+// 사람이 읽기 좋은 상세: 번호 + 2줄 블록
+//   관심 종목 3개
+//
+//   1. 삼성전자 (005930)
+//      NCAV 1.20x · PBR 0.90 · PER 8.1 · ROE 12.0%
+// (1개일 때는 번호·헤더 생략)
+function detailsText(rows: CopyStock[], label?: string): string {
+  const single = rows.length === 1;
+  const header = !single && label ? `${label} ${rows.length}개\n\n` : "";
+  const body = rows.map((r, i) => {
+    const head = `${single ? "" : `${i + 1}. `}${r.name || r.ticker} (${r.ticker})`;
+    const metrics = metricsOf(r);
+    return metrics ? `${head}\n${single ? "" : "   "}${metrics}` : head;
+  }).join("\n\n");
+  return header + body;
 }
 
 async function writeClipboard(text: string): Promise<boolean> {
@@ -49,13 +75,13 @@ async function writeClipboard(text: string): Promise<boolean> {
 const BTN_CLS =
   "inline-flex shrink-0 items-center gap-1 rounded-md border border-neutral-200 bg-white px-2 py-1 text-[11px] font-bold text-neutral-500 hover:bg-neutral-50 disabled:opacity-50 dark:border-[#35332e] dark:bg-[#242320] dark:hover:bg-[#2c2b27]";
 
-export function CopyStockButtons({ rows, className }: { rows: CopyStock[]; className?: string }) {
+export function CopyStockButtons({ rows, label, className }: { rows: CopyStock[]; label?: string; className?: string }) {
   const [copied, setCopied] = useState<null | "names" | "details">(null);
 
   if (rows.length === 0) return null;
 
   const handle = async (kind: "names" | "details") => {
-    const ok = await writeClipboard(kind === "names" ? namesText(rows) : detailsText(rows));
+    const ok = await writeClipboard(kind === "names" ? namesText(rows) : detailsText(rows, label));
     if (ok) {
       setCopied(kind);
       setTimeout(() => setCopied(null), 1500);

--- a/cf-idiotquant/components/inquireBalanceResult.tsx
+++ b/cf-idiotquant/components/inquireBalanceResult.tsx
@@ -36,6 +36,7 @@ import nyse_tickers from '@/public/data/usStockSymbols/nyse_tickers.json';
 import amex_tickers from '@/public/data/usStockSymbols/amex_tickers.json';
 import validCorpCodeArray from '@/public/data/validCorpCodeArray.json';
 import validCorpNameArray from '@/public/data/validCorpNameArray.json';
+import { CopyStockButtons, type CopyStock } from '@/components/copyStockButtons';
 
 // const MARKET_STOCK_MASTER = [
 //     ...KR_TICKER_MASTER,
@@ -426,6 +427,15 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker 
         setSortConfig({ key, direction: sortConfig.key === key && sortConfig.direction === "desc" ? "asc" : "desc" });
     };
 
+    // 잔고 복사용 행 (보유수량·평가금액·수익률)
+    const copyRows = useMemo<CopyStock[]>(() => inventoryData.map(item => ({
+        name: getFieldValue(item, "name") || String(item.pdno || item.ovrs_pdno || ""),
+        ticker: String(item.pdno || item.ovrs_pdno || ""),
+        qty: getFieldValue(item, "qty"),
+        evluAmt: getFieldValue(item, "evlu_amt"),
+        profitRate: getFieldValue(item, "profit_rt"),
+    })), [inventoryData]);
+
     // 모바일 카드 뷰
     const MobileCardList = () => (
         <div className="divide-y divide-neutral-100 dark:divide-[#35332e]">
@@ -495,6 +505,14 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker 
 
     return (
         <>
+            {/* 잔고 목록 복사 (종목명만 / 상세) */}
+            {copyRows.length > 0 && (
+                <div className="flex items-center justify-end gap-2 px-4 py-2 border-b border-neutral-100 dark:border-[#35332e]">
+                    <span className="text-[11px] text-neutral-400 font-medium">잔고 복사</span>
+                    <CopyStockButtons rows={copyRows} label="잔고" />
+                </div>
+            )}
+
             {/* 모바일: 카드 뷰 */}
             <div className="md:hidden">
                 <MobileCardList />


### PR DESCRIPTION
## 변경 요약

종목 목록 복사 버튼을 추가 페이지로 확장하고, "상세" 복사 텍스트의 가독성을 개선합니다.

### 복사 버튼 추가 위치
- **프로필 페이지** — "관심 종목" 섹션.
- **잔고(보유)** — `inquireBalanceResult`의 보유 목록 상단. 상세 항목은 잔고에 맞게 **보유수량·평가금액·수익률**.
- **스크리너** — 기존 '관심' 뷰뿐 아니라 **일반 발굴 목록**에도 표시 (라벨: 관심 종목 / 발굴 종목).
- **analyze** — 분석 중인 단일 종목 (종목명 / PBR·PER). analyze의 NCAV는 "업사이드 %"라 목록의 비율(x)과 의미가 달라 제외.

### "상세" 복사 가독성 개선
번호 + 2줄 블록 + 헤더 형식으로 변경:
```
관심 종목 2개

1. 삼성전자 (005930)
   NCAV 1.20x · PBR 0.90 · PER 8.1 · ROE 12.0%

2. 현대차 (005380)
   NCAV 0.85x · PBR 0.55 · PER 4.2 · ROE 9.5%
```
- 잔고: `보유 10주 · 평가 1,234,000 · 수익률 +5.2%`
- 단일 종목(analyze)은 번호·헤더 생략.
- 헤더 라벨은 위치별 자동(관심 종목 / 발굴 종목 / 잔고 / 그룹명 등).
- "종목명" 버튼은 종전대로 이름만 줄바꿈 복사.

### 구현 메모
- 공용 컴포넌트 `copyStockButtons.tsx`에 `label` prop, 잔고용 필드(qty·evluAmt·profitRate) 추가.
- ROE는 `EPS/BPS`로 계산해 기존 로직과 일치.

## 검증
- `npx tsc --noEmit`: 에러 0.
- 복사 텍스트 출력 시뮬레이션으로 형식 확인.

## 변경 파일
- `cf-idiotquant/components/copyStockButtons.tsx`
- `cf-idiotquant/components/inquireBalanceResult.tsx`
- `cf-idiotquant/components/balance/stockListTable.tsx`
- `cf-idiotquant/app/(profile)/profile/page.tsx`
- `cf-idiotquant/app/(screener)/screener/page.tsx`
- `cf-idiotquant/app/(analyze)/analyze/page.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZmvL8hb5ZiuEZczunWvB9)_