### PR TITLE
feat(balance): 계좌 페이지 개선 (색상 복구·빈/에러 상태·모바일 상태바)

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -115,7 +115,7 @@ function OrderRow({ item, isNccs }: { item: any; isNccs: boolean }) {
           "px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-wide",
           isBuy
             ? "bg-red-50 text-red-500 dark:bg-red-950/40"
-            : "bg-[#f0fdf4] text-[#f0fdf4]0 dark:bg-[#052e16]/40"
+            : "bg-[#f0fdf4] text-[#16a34a] dark:bg-[#052e16]/40"
         )}>
           {item.ord_dvsn_name || (isNccs ? "대기" : "현금")}
         </span>
@@ -480,7 +480,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                   value={isLoading ? null : `${totalEvalAmt.toLocaleString()}원`}
                   sub={isLoading ? "" : `주식 ${sctsEvluAmt.toLocaleString()}원 · CMA ${cmaEvluAmt.toLocaleString()}원`}
                   icon={<Wallet size={15} />}
-                  iconBg="bg-[#f0fdf4] dark:bg-[#052e16]/40 text-[#f0fdf4]0"
+                  iconBg="bg-[#f0fdf4] dark:bg-[#052e16]/40 text-[#16a34a]"
                   accentColor="bg-[#16a34a] dark:bg-[#16a34a]"
                 />
                 <KpiCard
@@ -517,7 +517,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                     <MetricChip
                       label="당일 등락"
                       value={`${isDailyPositive ? "▲ +" : "▼ "}${asstIcdcAmt.toLocaleString()}원`}
-                      valueClass={isDailyPositive ? "text-rose-500" : "text-[#f0fdf4]0"}
+                      valueClass={isDailyPositive ? "text-rose-500" : "text-[#16a34a]"}
                     />
                     <MetricChip
                       label="금일 매수"
@@ -532,7 +532,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                     <MetricChip
                       label="금일 매수 - 매도"
                       value={`${(thdtBuyAmt - thdtSllAmt) >= 0 ? "+" : ""}${(thdtBuyAmt - thdtSllAmt).toLocaleString()}원`}
-                      valueClass={(thdtBuyAmt - thdtSllAmt) >= 0 ? "text-rose-500" : "text-[#f0fdf4]0"}
+                      valueClass={(thdtBuyAmt - thdtSllAmt) >= 0 ? "text-rose-500" : "text-[#16a34a]"}
                     />
                     {totLoanAmt > 0 && (
                       <MetricChip

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -82,7 +82,7 @@ function OverseasOrderRow({ item, isNccs }: { item: any; isNccs: boolean }) {
       <td className="py-3.5 px-4">
         <span className={cn(
           "px-2.5 py-1 rounded-full text-[10px] font-black uppercase tracking-wide",
-          isBuy ? "bg-red-50 text-red-500 dark:bg-red-950/40" : "bg-[#f0fdf4] text-[#f0fdf4]0 dark:bg-[#052e16]/40"
+          isBuy ? "bg-red-50 text-red-500 dark:bg-red-950/40" : "bg-[#f0fdf4] text-[#16a34a] dark:bg-[#052e16]/40"
         )}>
           {item.sll_buy_dvsn_cd_name || (isBuy ? "매수" : "매도")}
         </span>
@@ -468,7 +468,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
                   subLabel="원화 평가액"
                   subValue={isLoading ? null : fmtKrw(totalAssetKrw)}
                   icon={<BarChart3 size={15} />}
-                  iconBg="bg-[#f0fdf4] dark:bg-[#052e16]/40 text-[#f0fdf4]0"
+                  iconBg="bg-[#f0fdf4] dark:bg-[#052e16]/40 text-[#16a34a]"
                   accentColor="bg-[#16a34a] dark:bg-[#16a34a]"
                   loading={isLoading}
                 />

--- a/cf-idiotquant/components/balance/ccnlTable.tsx
+++ b/cf-idiotquant/components/balance/ccnlTable.tsx
@@ -40,10 +40,10 @@ export default function OverseasCcnlTable({ data, className = "" }: Props) {
     return (
         <div className={`w-full ${className}`}>
             {/* 상태 바 */}
-            <div className="flex items-center justify-between mb-2">
-                <div className="text-sm">[주문체결내역]</div>
-                <div className="text-sm">상태: <span className="font-medium">{data?.state}</span></div>
-                <div className="text-sm">응답코드: {data?.rt_cd} • {data?.msg1}</div>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mb-2 text-xs text-neutral-500 dark:text-neutral-400">
+                <span className="font-bold text-neutral-700 dark:text-neutral-200">주문체결내역</span>
+                <span>상태: <span className="font-medium">{data?.state}</span></span>
+                {data?.msg1 && <span className="text-neutral-400 truncate">{data?.rt_cd} · {data?.msg1}</span>}
             </div>
 
             <ScrollArea.Root className="rounded-md border border-slate-200">

--- a/cf-idiotquant/components/balance/nccsTable.tsx
+++ b/cf-idiotquant/components/balance/nccsTable.tsx
@@ -40,10 +40,10 @@ export default function OverseasNccsTable({ data, className = "" }: Props) {
     return (
         <div className={`w-full ${className}`}>
             {/* 상태 바 */}
-            <div className="flex items-center justify-between mb-2">
-                <div className="text-sm">[미체결내역]</div>
-                <div className="text-sm">상태: <span className="font-medium">{data?.state}</span></div>
-                <div className="text-sm">응답코드: {data?.rt_cd} • {data?.msg1}</div>
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mb-2 text-xs text-neutral-500 dark:text-neutral-400">
+                <span className="font-bold text-neutral-700 dark:text-neutral-200">미체결내역</span>
+                <span>상태: <span className="font-medium">{data?.state}</span></span>
+                {data?.msg1 && <span className="text-neutral-400 truncate">{data?.rt_cd} · {data?.msg1}</span>}
             </div>
 
             {/* Radix ScrollArea를 써서 가로 스크롤과 세로 스크롤을 모두 잡아줍니다. */}

--- a/cf-idiotquant/components/balance/shared.tsx
+++ b/cf-idiotquant/components/balance/shared.tsx
@@ -112,7 +112,7 @@ export function LoadingState({ message = "계좌 데이터를 불러오는 중..
   return (
     <div className="h-screen w-full flex flex-col items-center justify-center bg-[#fcfaf7] dark:bg-[#1a1915] gap-3">
       <div className="p-4 rounded-2xl bg-white dark:bg-[#242320] border border-neutral-200 dark:border-[#35332e] shadow-sm">
-        <Loader2 className="w-7 h-7 text-[#f0fdf4]0 animate-spin" />
+        <Loader2 className="w-7 h-7 text-[#16a34a] animate-spin" />
       </div>
       <p className="text-sm font-bold text-neutral-400">{message}</p>
     </div>
@@ -340,11 +340,11 @@ export function PnlIcon({ positive, size = 15 }: { positive: boolean; size?: num
 export function pnlIconBg(positive: boolean) {
   return positive
     ? "bg-red-50 dark:bg-red-950/40 text-red-500"
-    : "bg-[#f0fdf4] dark:bg-[#052e16]/40 text-[#f0fdf4]0";
+    : "bg-[#f0fdf4] dark:bg-[#052e16]/40 text-[#16a34a]";
 }
 
 export function pnlValueColor(positive: boolean) {
-  return positive ? "text-red-500" : "text-[#f0fdf4]0";
+  return positive ? "text-red-500" : "text-[#16a34a]";
 }
 
 export function pnlAccentColor(positive: boolean) {

--- a/cf-idiotquant/components/balance/shared.tsx
+++ b/cf-idiotquant/components/balance/shared.tsx
@@ -160,16 +160,23 @@ export function TabButton({ active, onClick, children }: { active: boolean; onCl
   );
 }
 
+// 표가 아닌 곳(모바일 카드 등)에서 쓰는 빈 상태
+export function EmptyState({ message, icon }: { message: string; icon?: React.ReactNode }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-14 gap-3">
+      <div className="p-3 rounded-2xl bg-[#faf9f7] dark:bg-[#35332e]">
+        {icon ?? <InboxIcon size={20} className="text-neutral-400" />}
+      </div>
+      <p className="text-sm text-neutral-400 font-medium">{message}</p>
+    </div>
+  );
+}
+
 export function EmptyRow({ colSpan, message }: { colSpan: number; message: string }) {
   return (
     <tr>
       <td colSpan={colSpan}>
-        <div className="flex flex-col items-center justify-center py-14 gap-3">
-          <div className="p-3 rounded-2xl bg-[#faf9f7] dark:bg-[#35332e]">
-            <InboxIcon size={20} className="text-neutral-400" />
-          </div>
-          <p className="text-sm text-neutral-400 font-medium">{message}</p>
-        </div>
+        <EmptyState message={message} />
       </td>
     </tr>
   );

--- a/cf-idiotquant/components/inquireBalanceResult.tsx
+++ b/cf-idiotquant/components/inquireBalanceResult.tsx
@@ -16,12 +16,13 @@ import {
     Loader2,
     Search,
     PlusCircle,
-    FolderOpen
+    FolderOpen,
+    AlertCircle
 } from "lucide-react";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { useToast, ToastContainer } from "@/components/balance/shared";
+import { useToast, ToastContainer, EmptyState, EmptyRow } from "@/components/balance/shared";
 import {
     reqGetInquirePrice,
     getKoreaInvestmentInquirePrice,
@@ -342,14 +343,26 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
                 </div>
             </div>
 
-            {props.kiBalance.msg1 && (
-                <div className="flex items-start gap-3 p-4 bg-[#faf9f7] dark:bg-[#242320] border border-neutral-200 dark:border-[#35332e] rounded-2xl">
-                    <Info size={18} className="text-neutral-400 mt-0.5 shrink-0" />
-                    <p className="text-sm text-neutral-600 dark:text-neutral-400 font-medium leading-relaxed">
-                        {props.kiBalance.msg1}
-                    </p>
-                </div>
-            )}
+            {props.kiBalance.msg1 && (() => {
+                // KIS rt_cd: "0" = 정상. 그 외 값이면 오류/경고로 보고 강조.
+                const isError = props.kiBalance.rt_cd != null && String(props.kiBalance.rt_cd) !== "0";
+                return (
+                    <div className={`flex items-start gap-3 p-4 rounded-2xl border ${
+                        isError
+                            ? "bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-900/50"
+                            : "bg-[#faf9f7] dark:bg-[#242320] border-neutral-200 dark:border-[#35332e]"
+                    }`}>
+                        {isError
+                            ? <AlertCircle size={18} className="text-red-500 mt-0.5 shrink-0" />
+                            : <Info size={18} className="text-neutral-400 mt-0.5 shrink-0" />}
+                        <p className={`text-sm font-medium leading-relaxed ${
+                            isError ? "text-red-700 dark:text-red-300" : "text-neutral-600 dark:text-neutral-400"
+                        }`}>
+                            {props.kiBalance.msg1}
+                        </p>
+                    </div>
+                );
+            })()}
 
             {/* 테이블 섹션 */}
             <div className="overflow-hidden bg-white dark:bg-[#242320] rounded-[2rem] border border-neutral-200 dark:border-[#35332e] shadow-sm">
@@ -440,7 +453,7 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker 
     const MobileCardList = () => (
         <div className="divide-y divide-neutral-100 dark:divide-[#35332e]">
             {sortedItems.length === 0 && (
-                <p className="py-10 text-center text-sm text-neutral-400">보유 종목이 없습니다.</p>
+                <EmptyState message="보유 종목이 없습니다" />
             )}
             {sortedItems.map((item, idx) => {
                 const profitRt = Number(getFieldValue(item, "profit_rt"));
@@ -535,9 +548,7 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker 
                     </thead>
                     <tbody className="divide-y divide-neutral-100 dark:divide-[#35332e]">
                         {sortedItems.length === 0 && (
-                            <tr>
-                                <td colSpan={8} className="py-10 text-center text-sm text-neutral-400">보유 종목이 없습니다.</td>
-                            </tr>
+                            <EmptyRow colSpan={8} message="보유 종목이 없습니다" />
                         )}
                         {sortedItems.map((item, idx) => {
                             const profitRt = Number(getFieldValue(item, "profit_rt"));

--- a/cf-idiotquant/components/inquireBalanceResult.tsx
+++ b/cf-idiotquant/components/inquireBalanceResult.tsx
@@ -326,7 +326,7 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
                         label="평가 손익률"
                         value={`${totalProfitRate >= 0 ? "▲ +" : "▼ "}${totalProfitRate.toFixed(2)}%`}
                         subValue={`손익 합계: ${formatValue(evlu_smtl - pchs_smtl, "MONEY")}`}
-                        colorClass={totalProfitRate >= 0 ? "text-rose-500" : "text-[#f0fdf4]0"}
+                        colorClass={totalProfitRate >= 0 ? "text-rose-500" : "text-[#16a34a]"}
                     />
                     <SummaryItem
                         label="총 평가금액"
@@ -459,7 +459,7 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker 
                                 <span className="text-[10px] font-mono text-neutral-500">{item.pdno || item.ovrs_pdno}</span>
                                 {renderGroupBadge(item)}
                             </div>
-                            <span className={`text-sm font-black font-mono shrink-0 ${isPositive ? "text-rose-500" : "text-[#f0fdf4]0"}`}>
+                            <span className={`text-sm font-black font-mono shrink-0 ${isPositive ? "text-rose-500" : "text-[#16a34a]"}`}>
                                 {isPositive ? "▲" : "▼"} {isPositive ? "+" : ""}{profitRt.toFixed(2)}%
                             </span>
                         </div>
@@ -569,7 +569,7 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker 
                                             {formatValue(avgPrice, "MONEY")}
                                         </div>
                                     </td>
-                                    <td className={`p-4 text-right font-mono text-sm font-black ${isPositive ? "text-rose-500" : "text-[#f0fdf4]0"}`}>
+                                    <td className={`p-4 text-right font-mono text-sm font-black ${isPositive ? "text-rose-500" : "text-[#16a34a]"}`}>
                                         {isPositive ? "▲ +" : "▼ "}{profitRt.toFixed(2)}%
                                     </td>
                                     <td className="p-4 text-right font-mono text-sm font-bold text-neutral-600 dark:text-neutral-400">


### PR DESCRIPTION
## 변경 요약

계좌(balance) 페이지를 **시각(1)·모바일(3)·빈/로딩/에러 상태(4)** 방향으로 개선합니다.

### 1. 시각/레이아웃
- **깨진 색상 클래스 복구**: find/replace 잔재인 `text-[#f0fdf4]0`(무효 Tailwind 클래스) 12곳을 브랜드 그린 `#16a34a`로 복구. 하락/마이너스 손익 값·매도 배지·로더 스피너가 의도한 색으로 표시됩니다.
- 공용 `EmptyState` 추가 후 `EmptyRow`가 이를 재사용(일관성).

### 3. 모바일
- US 주문내역(체결/미체결) 상태바가 `justify-between` 3개 항목으로 모바일에서 넘치던 것을 **flex-wrap + 뉴트럴 팔레트**로 변경 → 좁은 화면에서 줄바꿈, 톤 일치.
- 새 빈/에러 상태는 모바일 카드·데스크탑 양쪽 반응형.

### 4. 빈/로딩/에러 상태
- **잔고 보유 빈 상태**: 밋밋한 텍스트 → 아이콘+메시지 빈 상태(모바일 카드 + 데스크탑 표). KR·US 공용.
- **상태 배너 에러 인지화**: KIS `rt_cd`가 `"0"`이 아니면 빨강+경고 아이콘, 정상이면 뉴트럴 info로 구분.

## 검증
- `npx tsc --noEmit`: 에러 0.

## 변경 파일
- `cf-idiotquant/components/balance/shared.tsx`
- `cf-idiotquant/components/balance/balanceKrView.tsx`
- `cf-idiotquant/components/balance/balanceUsView.tsx`
- `cf-idiotquant/components/balance/ccnlTable.tsx`
- `cf-idiotquant/components/balance/nccsTable.tsx`
- `cf-idiotquant/components/inquireBalanceResult.tsx`

## 후속 후보 (별도 작업)
- US 주문내역 테이블(`ccnlTable`/`nccsTable`)을 KR처럼 모바일 카드 뷰로 전면 재구성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZmvL8hb5ZiuEZczunWvB9)_