### PR TITLE
feat(balance): 자동매매 개선 (흐름 요약·예산/토큰 시각화·조건 편집·그룹 예산)

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -629,6 +629,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                 countryTradingActive={tradingStatus.KR === true}
                 quantRule={krQuantRule.rule}
                 metricsOverride={krLikeMetrics}
+                monthlyPerStock={krBudget?.monthly_per_stock}
               />
             </SectionPanel>
           ) : null,

--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -47,6 +47,7 @@ import InquireBalanceResult from "@/components/inquireBalanceResult";
 import StockListTable from "@/components/balance/stockListTable";
 import QuantRuleEditor from "@/components/balance/quantRuleEditor";
 import RefillSettings from "@/components/balance/refillSettings";
+import TradingFlowSummary from "@/components/balance/tradingFlowSummary";
 import { PortfolioChartSection } from "@/components/balance/portfolioChart";
 import { type NavSection } from "@/components/balance/sectionNav";
 import { BalanceShell } from "@/components/balance/balanceShell";
@@ -597,6 +598,17 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                     ? <span className="text-[10px] font-mono text-neutral-500 dark:text-neutral-400 bg-[#faf9f7] dark:bg-[#242320] px-2 py-0.5 rounded-full">{krCapital.stock_list.length}종목</span>
                     : null
                 }
+              />
+              <TradingFlowSummary
+                country="KR"
+                tradingActive={tradingStatus.KR}
+                groups={krCapital.groups ?? []}
+                stockList={krCapital.stock_list ?? []}
+                quantRule={krQuantRule?.rule}
+                budget={krBudget}
+                onToggleTrading={handleToggleTrading}
+                togglePending={tradingStatus.state === "pending"}
+                className="mb-5"
               />
               <StockListTable
                 data={krCapital}

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -51,6 +51,7 @@ import { getQuotationsPriceDetail } from "@/lib/features/koreaInvestmentUsMarket
 
 import InquireBalanceResult from "@/components/inquireBalanceResult";
 import QuantRuleEditor from "@/components/balance/quantRuleEditor";
+import TradingFlowSummary from "@/components/balance/tradingFlowSummary";
 import StockListTable from "@/components/balance/stockListTable";
 import { PortfolioChartSection } from "@/components/balance/portfolioChart";
 import { type NavSection } from "@/components/balance/sectionNav";
@@ -632,6 +633,16 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
                     ? <span className="text-[10px] font-mono text-neutral-500 dark:text-neutral-400 bg-[#faf9f7] dark:bg-[#242320] px-2 py-0.5 rounded-full">{usCapital.stock_list.length}종목</span>
                     : null
                 }
+              />
+              <TradingFlowSummary
+                country="US"
+                tradingActive={tradingStatus.US}
+                groups={usCapital.groups ?? []}
+                stockList={usCapital.stock_list ?? []}
+                quantRule={usQuantRule?.rule}
+                onToggleTrading={handleToggleTrading}
+                togglePending={tradingStatus.state === "pending"}
+                className="mb-5"
               />
               <StockListTable
                 data={usCapital}

--- a/cf-idiotquant/components/balance/quantRuleEditor.tsx
+++ b/cf-idiotquant/components/balance/quantRuleEditor.tsx
@@ -63,6 +63,22 @@ export default function QuantRuleEditor({ data, isMaster, onSave, className = ""
 
   const metaFor = (k: string) => desc[k] ?? inferMeta(k);
 
+  // 저장값/기본값 대비 변경 여부 — 변경된 필드를 강조하고 기본값을 힌트로 보여준다.
+  const savedDraft = useMemo(() => ruleToDraft(rule), [JSON.stringify(rule)]);
+  const defaultDraft = useMemo(() => ruleToDraft(data?.default ?? {}), [JSON.stringify(data?.default)]);
+  const isChanged = (k: string) => {
+    if (metaFor(k).type === "boolean") return !!draft[k] !== !!savedDraft[k];
+    return String(draft[k] ?? "") !== String(savedDraft[k] ?? "");
+  };
+  const changedCount = fieldKeys.filter(isChanged).length;
+  const fmtDefault = (k: string) => {
+    const meta = metaFor(k);
+    const dv = defaultDraft[k];
+    if (dv == null || dv === "") return null;
+    if (meta.type === "boolean") return dv ? "사용함" : "사용 안 함";
+    return String(dv);
+  };
+
   const setField = (k: string, v: string | boolean) => {
     setDraft(prev => ({ ...prev, [k]: v }));
     setDirty(true);
@@ -128,10 +144,20 @@ export default function QuantRuleEditor({ data, isMaster, onSave, className = ""
         {fieldKeys.map((k) => {
           const meta = metaFor(k);
           const val = draft[k];
+          const changed = isChanged(k);
+          const defaultVal = fmtDefault(k);
           return (
-            <div key={k} className="rounded-xl border border-neutral-200 bg-white p-3 dark:border-[#35332e] dark:bg-[#1a1915]">
+            <div key={k} className={cn(
+              "rounded-xl border bg-white p-3 dark:bg-[#1a1915] transition-colors",
+              changed
+                ? "border-[#16a34a] ring-1 ring-[#16a34a]/30 dark:border-[#16a34a]"
+                : "border-neutral-200 dark:border-[#35332e]"
+            )}>
               <div className="mb-1.5 flex items-center justify-between gap-2">
-                <span className="text-xs font-bold text-neutral-800 dark:text-neutral-200">{meta.label}</span>
+                <span className="flex items-center gap-1.5 text-xs font-bold text-neutral-800 dark:text-neutral-200">
+                  {meta.label}
+                  {changed && <span className="rounded bg-[#16a34a]/10 px-1.5 py-0.5 text-[9px] font-extrabold text-[#16a34a]">변경됨</span>}
+                </span>
                 <code className="text-[9px] text-neutral-300 dark:text-neutral-600">{k}</code>
               </div>
               <p className="mb-2 flex items-start gap-1 text-[10px] leading-tight text-neutral-400">
@@ -172,6 +198,14 @@ export default function QuantRuleEditor({ data, isMaster, onSave, className = ""
                   className="w-full rounded-lg border border-neutral-200 bg-[#fcfaf7] px-3 py-1.5 font-mono text-sm font-bold text-neutral-800 outline-none focus:border-[#16a34a] disabled:opacity-60 dark:border-[#35332e] dark:bg-[#242320] dark:text-neutral-200"
                 />
               )}
+              {defaultVal != null && (
+                <div className="mt-1.5 flex items-center justify-between gap-2 text-[10px] text-neutral-400">
+                  <span>기본값 <span className="font-mono">{defaultVal}</span></span>
+                  {changed && isMaster && (
+                    <button type="button" onClick={() => setField(k, defaultDraft[k])} className="font-bold text-neutral-400 hover:text-[#16a34a]">되돌리기</button>
+                  )}
+                </div>
+              )}
             </div>
           );
         })}
@@ -180,6 +214,9 @@ export default function QuantRuleEditor({ data, isMaster, onSave, className = ""
       {/* 액션 */}
       {isMaster && (
         <div className="flex flex-wrap items-center justify-end gap-2">
+          {changedCount > 0 && (
+            <span className="mr-auto text-xs font-bold text-[#16a34a]">{changedCount}개 변경됨</span>
+          )}
           {data?.saveState === "fulfilled" && !dirty && (
             <span className="inline-flex items-center gap-1 text-xs font-bold text-[#16a34a]">
               <CheckCircle2 className="h-3.5 w-3.5" /> 저장됨

--- a/cf-idiotquant/components/balance/refillSettings.tsx
+++ b/cf-idiotquant/components/balance/refillSettings.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Coins } from "lucide-react";
+import { Coins, ChevronRight } from "lucide-react";
 
 export interface RefillData {
     has_account: boolean;
@@ -17,12 +17,28 @@ export interface RefillData {
 
 const won = (n: number) => `₩${Math.round(Number(n) || 0).toLocaleString("ko-KR")}`;
 
-function Stat({ label, value, sub }: { label: string; value: string; sub?: string }) {
+// 예산 흐름 노드 (월 예산 → 종목당 월 → 종목당 5분)
+function FlowNode({ label, value, sub, accent }: { label: string; value: string; sub?: string; accent?: boolean }) {
     return (
-        <div className="bg-[#faf9f7] dark:bg-[#1f1e1b] border border-neutral-200/70 dark:border-[#3a3834] rounded-xl px-3 py-2.5 flex flex-col gap-0.5 min-w-0">
+        <div className={
+            "flex-1 min-w-0 rounded-xl border px-3 py-2.5 flex flex-col gap-0.5 " +
+            (accent
+                ? "border-[#bbf7d0] dark:border-[#166534]/60 bg-[#f0fdf4] dark:bg-[#052e16]/20"
+                : "border-neutral-200/70 dark:border-[#3a3834] bg-[#faf9f7] dark:bg-[#1f1e1b]")
+        }>
             <span className="text-[10px] text-neutral-400 dark:text-neutral-500 truncate">{label}</span>
-            <span className="text-sm font-black text-neutral-800 dark:text-neutral-100 tabular-nums truncate">{value}</span>
+            <span className={"text-sm font-black tabular-nums truncate " + (accent ? "text-[#15803d] dark:text-[#16a34a]" : "text-neutral-800 dark:text-neutral-100")}>{value}</span>
             {sub && <span className="text-[10px] text-neutral-400 dark:text-neutral-500 truncate">{sub}</span>}
+        </div>
+    );
+}
+
+// 노드 사이 연산 설명 (모바일: 아래 화살표 / 데스크탑: 오른쪽 화살표)
+function FlowOp({ text }: { text: string }) {
+    return (
+        <div className="flex sm:flex-col items-center justify-center gap-1 shrink-0 text-neutral-400 dark:text-neutral-500">
+            <ChevronRight size={14} className="rotate-90 sm:rotate-0 shrink-0" />
+            <span className="text-[9px] font-bold whitespace-nowrap">{text}</span>
         </div>
     );
 }
@@ -47,12 +63,13 @@ export default function RefillSettings({
 
     return (
         <div className="space-y-3">
-            {/* 요약: 모바일 2열, sm 이상 4열 */}
-            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2.5">
-                <Stat label="총 리필량 (월)" value={won(data.monthly_budget_krw)} />
-                <Stat label="리필 주기" value={`${data.period_minutes}분마다`} sub={data.market_hours || "장중"} />
-                <Stat label="종목당 (5분)" value={won(data.per_tick_per_stock)} sub={`활성 ${data.active_count}종목`} />
-                <Stat label="종목당 (월)" value={won(data.monthly_per_stock)} />
+            {/* 예산 흐름: 월 예산 → (활성 N종목 분배) → 종목당 월 → (5분마다 적립) → 종목당 5분 */}
+            <div className="flex flex-col sm:flex-row sm:items-stretch gap-2">
+                <FlowNode label="월 예산 (총 리필량)" value={won(data.monthly_budget_krw)} sub={`${data.period_minutes}분마다 · ${data.market_hours || "장중"}`} accent />
+                <FlowOp text={`÷ 활성 ${data.active_count}종목`} />
+                <FlowNode label="종목당 (월)" value={won(data.monthly_per_stock)} />
+                <FlowOp text={`${data.period_minutes}분마다 적립`} />
+                <FlowNode label="종목당 (5분)" value={won(data.per_tick_per_stock)} sub={`전체 ${won(data.per_tick_total)}`} />
             </div>
 
             {/* 월 예산 조절 */}

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -738,6 +738,8 @@ function GroupSection({
     per: r.per,
     roe: Number(r.bps) > 0 ? (Number(r.eps) / Number(r.bps)) * 100 : null,
   })), [rows]);
+  // 그룹 예산(토큰) 합계 — 그룹 단위 운용 현황을 헤더에 표시
+  const tokenTotal = useMemo(() => rows.reduce((s, r) => s + (r.movable ? (Number(r.token) || 0) : 0), 0), [rows]);
   // 선택 여부는 이 섹션 키 기준으로만 판단(다른 섹션의 동일 종목과 분리)
   const isPicked = (sym: string) => picked.has(pickKey(sectionKey, sym));
   const allChecked = selectableTickers.length > 0 && selectableTickers.every(isPicked);
@@ -778,6 +780,11 @@ function GroupSection({
           <span className="px-2 py-0.5 text-[10px] font-mono font-bold bg-neutral-100 text-neutral-500 dark:bg-[#35332e] dark:text-neutral-400 rounded-full">
             {count}종목
           </span>
+          {tokenTotal > 0 && (
+            <span className="px-2 py-0.5 text-[10px] font-mono font-bold bg-[#f0fdf4] text-[#16a34a] dark:bg-[#14532d]/30 rounded-full" title="이 그룹 예산(토큰) 합계">
+              예산 ₩{Math.round(tokenTotal).toLocaleString("ko-KR")}
+            </span>
+          )}
           {/* 그룹 전체선택 (데스크탑·모바일 공통) */}
           {showCheck && !collapsed && (
             <label className="inline-flex cursor-pointer items-center gap-1 text-[10px] font-bold text-neutral-500 dark:text-neutral-400">

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -147,6 +147,8 @@ interface Props {
   quantRule?: QuantRule;
   // 지표 보강 (예: US 좋아요 종목은 stock_data_daily 에 없어 KIS price-detail 로 보강)
   metricsOverride?: Record<string, { per?: number | null; pbr?: number | null; bps?: number | null; eps?: number | null; marketCap?: number | null }>;
+  // 종목당 월 예산 (토큰 충전 진행 막대 기준값)
+  monthlyPerStock?: number;
 }
 
 const tokenAmounts = [10000, 100000, 1000000];
@@ -216,6 +218,7 @@ export default function StockListTable({
   countryTradingActive = false,
   quantRule,
   metricsOverride,
+  monthlyPerStock = 0,
 }: Props) {
   const stockList = data?.stock_list ?? [];
   const groups: StockGroup[] = data?.groups ?? [];
@@ -570,6 +573,7 @@ export default function StockListTable({
         doTokenPlusOne={doTokenPlusOne}
         doTokenMinusOne={doTokenMinusOne}
         openDetail={openDetail}
+        monthlyPerStock={monthlyPerStock}
       />
 
       {/* ===== 3. 사용자 그룹 섹션들 ===== */}
@@ -603,6 +607,7 @@ export default function StockListTable({
           doTokenPlusOne={doTokenPlusOne}
           doTokenMinusOne={doTokenMinusOne}
           openDetail={openDetail}
+          monthlyPerStock={monthlyPerStock}
         />
       ))}
 
@@ -626,6 +631,7 @@ export default function StockListTable({
         doTokenPlusOne={doTokenPlusOne}
         doTokenMinusOne={doTokenMinusOne}
         openDetail={openDetail}
+        monthlyPerStock={monthlyPerStock}
       />
 
       {/* 상세 분석 모달 */}
@@ -711,13 +717,14 @@ interface GroupSectionProps {
   doTokenPlusOne: (val: number, sym: string) => void;
   doTokenMinusOne: (val: number, sym: string) => void;
   openDetail: (raw: any) => void;
+  monthlyPerStock?: number;
 }
 
 function GroupSection({
   sectionKey, title, subtitle, icon, accent, count, rows, isMaster, tradingActive, onToggleTrading, hideTrading,
   conditionChips, editing, editingName, onEditNameChange, onStartRename, onCommitRename, onDelete,
   emptyText, collapsed, onToggleCollapse, picked, onTogglePick, onPickMany,
-  doTokenPlusOne, doTokenMinusOne, openDetail,
+  doTokenPlusOne, doTokenMinusOne, openDetail, monthlyPerStock = 0,
 }: GroupSectionProps) {
   const showRefill = isMaster && rows.some(r => r.movable);
   const showCheck = isMaster && rows.length > 0; // 모든 행 선택 가능(좋아요는 복사용)
@@ -940,7 +947,16 @@ function GroupSection({
                       </span>
                     </td>
                     <td className="px-4 py-3 text-right font-mono font-black text-[#16a34a] dark:text-[#16a34a]">
-                      {row.movable ? (row.token?.toLocaleString() ?? 0) : "-"}
+                      {row.movable ? (
+                        <div className="flex flex-col items-end gap-1">
+                          <span>{row.token?.toLocaleString() ?? 0}</span>
+                          {monthlyPerStock > 0 && (
+                            <div className="w-16 h-1 rounded-full bg-neutral-100 dark:bg-[#35332e] overflow-hidden" title={`종목당 월 예산 대비 ${Math.round(Math.min(1, (Number(row.token) || 0) / monthlyPerStock) * 100)}%`}>
+                              <div className="h-full bg-[#16a34a] rounded-full" style={{ width: `${Math.min(100, ((Number(row.token) || 0) / monthlyPerStock) * 100)}%` }} />
+                            </div>
+                          )}
+                        </div>
+                      ) : "-"}
                     </td>
                     {showRefill && (
                       <td className="px-4 py-3">
@@ -1021,8 +1037,13 @@ function GroupSection({
                 {/* 예산 + Refill (운용 종목만) */}
                 {row.movable && (
                   <div className="mt-2.5 flex items-center justify-between gap-2">
-                    <span className="text-[11px] text-neutral-500 dark:text-neutral-400">
-                      예산 <b className="font-mono font-black text-[#16a34a]">{row.token?.toLocaleString() ?? 0}</b>
+                    <span className="text-[11px] text-neutral-500 dark:text-neutral-400 flex items-center gap-2">
+                      <span>예산 <b className="font-mono font-black text-[#16a34a]">{row.token?.toLocaleString() ?? 0}</b></span>
+                      {monthlyPerStock > 0 && (
+                        <span className="w-14 h-1 rounded-full bg-neutral-100 dark:bg-[#35332e] overflow-hidden inline-block" title={`종목당 월 예산 대비 ${Math.round(Math.min(1, (Number(row.token) || 0) / monthlyPerStock) * 100)}%`}>
+                          <span className="block h-full bg-[#16a34a] rounded-full" style={{ width: `${Math.min(100, ((Number(row.token) || 0) / monthlyPerStock) * 100)}%` }} />
+                        </span>
+                      )}
                     </span>
                     {showRefill && (
                       <div className="flex flex-wrap justify-end gap-1">

--- a/cf-idiotquant/components/balance/tradingFlowSummary.tsx
+++ b/cf-idiotquant/components/balance/tradingFlowSummary.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { Power, Check, ChevronRight, AlertTriangle, Zap } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { StockGroup, QuantRule, BudgetState, LIKES_GROUP_ID } from "@/lib/features/capital/capitalSlice";
+
+const won = (n: number) => `₩${Math.round(Number(n) || 0).toLocaleString("ko-KR")}`;
+
+interface FlowStep {
+  key: string;
+  label: string;
+  ok: boolean;
+  detail: string;
+}
+
+interface Props {
+  country: "KR" | "US";
+  tradingActive: boolean | null;
+  groups: StockGroup[];
+  stockList: { group_id?: string | null }[];
+  quantRule?: QuantRule;
+  budget?: BudgetState;          // KR 전용 (US 는 예산 단계 없음)
+  onToggleTrading?: () => void;
+  togglePending?: boolean;
+  className?: string;
+}
+
+// 자동매매가 실제로 일어나는 조건(자동매매 ON → 활성 대상 → 운용 종목 → 예산)을
+// 파이프라인으로 시각화하고, 막혀 있으면 무엇이 필요한지 알려준다.
+export default function TradingFlowSummary({
+  country, tradingActive, groups, stockList, quantRule, budget,
+  onToggleTrading, togglePending, className,
+}: Props) {
+  const realGroups = groups.filter(g => g.id !== LIKES_GROUP_ID);
+  const activeGroups = realGroups.filter(g => g.is_trading_active !== false);
+  // 좋아요(__likes__) 풀은 관심목록이라 매매 대상이 아니므로 제외
+  const operating = stockList.filter(s => s.group_id !== LIKES_GROUP_ID);
+  const unassigned = operating.filter(s => !s.group_id || !realGroups.some(g => g.id === s.group_id));
+
+  const isOn = tradingActive === true;
+  const hasActiveTarget = activeGroups.length > 0 || unassigned.length > 0;
+  const hasStocks = operating.length > 0;
+  const budgetOk = !budget || budget.monthly_budget_krw > 0;
+
+  const steps: FlowStep[] = [
+    { key: "trading", label: "자동매매", ok: isOn, detail: tradingActive === null ? "—" : isOn ? "ON" : "OFF" },
+    { key: "target", label: "활성 대상", ok: hasActiveTarget, detail: `그룹 ${activeGroups.length}/${realGroups.length}${unassigned.length ? ` · 미지정 ${unassigned.length}` : ""}` },
+    { key: "stocks", label: "운용 종목", ok: hasStocks, detail: `${operating.length}종목` },
+    ...(budget ? [{ key: "budget", label: "월 예산", ok: budget.monthly_budget_krw > 0, detail: budget.monthly_budget_krw > 0 ? won(budget.monthly_budget_krw) : "미설정" }] : []),
+  ];
+
+  const ready = isOn && hasActiveTarget && hasStocks && budgetOk;
+
+  const missing: string[] = [];
+  if (!isOn) missing.push("자동매매 ON");
+  if (!hasStocks) missing.push("운용 종목 추가");
+  if (!hasActiveTarget) missing.push("그룹 ON 또는 미지정 종목");
+  if (budget && budget.monthly_budget_krw <= 0) missing.push("월 예산 설정");
+
+  // 조건 요약 (상위 N종목 · NCAV ≥ x · 종목당 틱 배분)
+  const activeCount = quantRule?.active_count;
+  const ncav = quantRule?.ncav_ratio;
+  const perStock = budget && budget.per_tick_per_stock > 0 ? budget.per_tick_per_stock : 0;
+  const condBits: string[] = [];
+  if (activeCount != null && activeCount > 0) condBits.push(`상위 ${activeCount}종목`);
+  if (ncav != null && ncav > 0) condBits.push(`NCAV ≥ ${ncav}`);
+  if (perStock > 0) condBits.push(`5분당 종목당 ${won(perStock)}`);
+
+  return (
+    <div className={cn(
+      "rounded-2xl border p-4 sm:p-5",
+      ready
+        ? "border-[#bbf7d0] dark:border-[#166534]/60 bg-[#f0fdf4] dark:bg-[#052e16]/20"
+        : "border-amber-200 dark:border-amber-900/50 bg-amber-50/60 dark:bg-amber-950/20",
+      className
+    )}>
+      {/* 헤더: 상태 + 토글 */}
+      <div className="flex items-center justify-between gap-3 mb-4">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className={cn("p-1.5 rounded-lg shrink-0", ready ? "bg-[#16a34a] text-white" : "bg-amber-400 text-white")}>
+            {ready ? <Zap size={14} /> : <AlertTriangle size={14} />}
+          </span>
+          <div className="min-w-0">
+            <p className={cn("text-sm font-black leading-tight", ready ? "text-[#15803d] dark:text-[#16a34a]" : "text-amber-700 dark:text-amber-400")}>
+              {ready ? "자동매매 가동 중" : "자동매매 대기"}
+            </p>
+            <p className="text-[11px] text-neutral-500 dark:text-neutral-400 truncate">
+              {ready
+                ? (condBits.length ? `${condBits.join(" · ")} 조건으로 5분마다 매매` : "조건 충족 종목을 5분마다 매매합니다")
+                : `매매 실행에 필요: ${missing.join(", ")}`}
+            </p>
+          </div>
+        </div>
+        {onToggleTrading && tradingActive !== null && (
+          <button
+            onClick={onToggleTrading}
+            disabled={togglePending}
+            className={cn(
+              "flex items-center gap-1.5 px-3 py-2 rounded-xl text-xs font-bold border transition-all shrink-0 disabled:opacity-60",
+              isOn
+                ? "bg-[#16a34a] text-white border-[#16a34a] hover:bg-[#15803d]"
+                : "bg-white dark:bg-[#242320] text-neutral-500 border-neutral-200 dark:border-[#35332e] hover:border-neutral-400"
+            )}
+          >
+            <Power size={13} />
+            {isOn ? "ON" : "OFF"}
+          </button>
+        )}
+      </div>
+
+      {/* 파이프라인 단계 */}
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {steps.map((s, i) => (
+          <div key={s.key} className="flex items-center gap-1.5">
+            <div className={cn(
+              "flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border bg-white dark:bg-[#242320]",
+              s.ok ? "border-[#bbf7d0] dark:border-[#166534]/60" : "border-neutral-200 dark:border-[#35332e]"
+            )}>
+              <span className={cn(
+                "w-4 h-4 rounded-full flex items-center justify-center shrink-0",
+                s.ok ? "bg-[#16a34a] text-white" : "bg-neutral-200 dark:bg-[#4a4641] text-neutral-400"
+              )}>
+                {s.ok ? <Check size={10} strokeWidth={3} /> : <span className="text-[9px] font-black">{i + 1}</span>}
+              </span>
+              <span className="text-[11px] font-bold text-neutral-700 dark:text-neutral-200 whitespace-nowrap">{s.label}</span>
+              <span className={cn("text-[11px] font-mono font-bold whitespace-nowrap", s.ok ? "text-[#16a34a]" : "text-neutral-400")}>{s.detail}</span>
+            </div>
+            {i < steps.length - 1 && <ChevronRight size={13} className="text-neutral-300 dark:text-neutral-600 shrink-0" />}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 요약

계좌 페이지의 **자동매매**를 네 영역에서 개선합니다.

### 1. 매매 흐름 가시성 — `TradingFlowSummary` (신규)
운용 종목 관리 섹션 상단(KR·US)에 파이프라인 패널 추가:
**자동매매 ON/OFF → 활성 대상(그룹/미지정) → 운용 종목 → 월 예산(KR)**
- 단계별 충족 체크 + 인라인 ON/OFF 토글
- 조건 요약(`상위 N종목 · NCAV ≥ x · 종목당 틱 배분`)
- 대기 상태면 "매매 실행에 필요: …" 진단 표시 (US는 예산 단계 없음)

### 2. 예산·토큰 시각화
- `RefillSettings`: 독립 stat 카드 → **예산 흐름**(월 예산 →÷활성N종목→ 종목당(월) →N분마다 적립→ 종목당(5분)), 모바일에선 화살표 세로 전환
- `StockListTable`: 운용 종목마다 **토큰 충전 막대**(현재 토큰 / 종목당 월 예산), 데스크탑·모바일

### 3. 트레이딩 조건 편집 UX — `QuantRuleEditor`
- 저장값과 다른 필드 **변경 강조**(초록 테두리 + `변경됨` 배지)
- 필드별 **기본값 힌트** + `되돌리기`
- 저장 버튼 옆 **변경 개수** 표시

### 4. 그룹 운용 관리 — `StockListTable`
- 각 그룹 헤더에 **`예산 ₩X`(그룹 토큰 합계)** 칩 → 그룹별 운용 현황 즉시 파악

## 검증
- `npx tsc --noEmit`: 에러 0.

## 변경 파일
- `cf-idiotquant/components/balance/tradingFlowSummary.tsx` (신규)
- `cf-idiotquant/components/balance/refillSettings.tsx`
- `cf-idiotquant/components/balance/quantRuleEditor.tsx`
- `cf-idiotquant/components/balance/stockListTable.tsx`
- `cf-idiotquant/components/balance/balanceKrView.tsx`
- `cf-idiotquant/components/balance/balanceUsView.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZmvL8hb5ZiuEZczunWvB9)_