### PR TITLE
feat(balance): 종목별 토큰 리셋 기능 추가 (전체/개별)

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -34,6 +34,8 @@ import {
   selectKrCapital, selectKrCapitalTokenMinusAll,
   selectKrCapitalTokenMinusOne, selectKrCapitalTokenPlusAll,
   selectKrCapitalTokenPlusOne,
+  reqPostKrCapitalTokenResetAll, reqPostKrCapitalTokenResetOne,
+  selectKrCapitalTokenResetAll, selectKrCapitalTokenResetOne,
   reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate,
   reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup, reqPostKrCapitalStocksGroup, reqPostKrCapitalLikesCopy,
   selectKrGroupOp,
@@ -181,6 +183,8 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
   const krCapitalPlusOne = useAppSelector(selectKrCapitalTokenPlusOne);
   const krCapitalMinusAll = useAppSelector(selectKrCapitalTokenMinusAll);
   const krCapitalMinusOne = useAppSelector(selectKrCapitalTokenMinusOne);
+  const krCapitalResetAll = useAppSelector(selectKrCapitalTokenResetAll);
+  const krCapitalResetOne = useAppSelector(selectKrCapitalTokenResetOne);
   const krGroupOp = useAppSelector(selectKrGroupOp);
   const krQuantRule = useAppSelector(selectKrQuantRule);
   const krBudget = useAppSelector(selectKrBudget);
@@ -323,12 +327,12 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
   }, [krCapital.state, balanceKey]);
 
   useEffect(() => {
-    const states = [krCapitalPlusAll?.state, krCapitalPlusOne?.state, krCapitalMinusAll?.state, krCapitalMinusOne?.state];
+    const states = [krCapitalPlusAll?.state, krCapitalPlusOne?.state, krCapitalMinusAll?.state, krCapitalMinusOne?.state, krCapitalResetAll?.state, krCapitalResetOne?.state];
     if (states.some(s => s === "fulfilled")) {
       dispatch(reqGetKrCapital(balanceKey));
       addToast("success", "토큰 잔액이 업데이트되었습니다.");
     }
-  }, [krCapitalPlusAll?.state, krCapitalPlusOne?.state, krCapitalMinusAll?.state, krCapitalMinusOne?.state]);
+  }, [krCapitalPlusAll?.state, krCapitalPlusOne?.state, krCapitalMinusAll?.state, krCapitalMinusOne?.state, krCapitalResetAll?.state, krCapitalResetOne?.state]);
 
   useEffect(() => {
     if (kiBalance.state === "fulfilled") setLastUpdated(new Date());
@@ -353,6 +357,8 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
   const doTokenPlusOne = (num: number, ticker: string) => ticker && dispatch(reqPostKrCapitalTokenPlusOne({ key: balanceKey, num, ticker }));
   const doTokenMinusAll = (num: number) => dispatch(reqPostKrCapitalTokenMinusAll({ key: balanceKey, num }));
   const doTokenMinusOne = (num: number, ticker: string) => ticker && dispatch(reqPostKrCapitalTokenMinusOne({ key: balanceKey, num, ticker }));
+  const doTokenResetAll = () => dispatch(reqPostKrCapitalTokenResetAll({ key: balanceKey }));
+  const doTokenResetOne = (ticker: string) => ticker && dispatch(reqPostKrCapitalTokenResetOne({ key: balanceKey, ticker }));
 
   // 그룹 관리 핸들러
   const doCreateGroup = (name: string, tickers?: string[]) => dispatch(reqPostKrCapitalGroupCreate({ key: balanceKey, name, tickers }));
@@ -617,6 +623,8 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                 doTokenPlusOne={doTokenPlusOne}
                 doTokenMinusAll={doTokenMinusAll}
                 doTokenMinusOne={doTokenMinusOne}
+                doTokenResetAll={doTokenResetAll}
+                doTokenResetOne={doTokenResetOne}
                 session={session}
                 onCreateGroup={doCreateGroup}
                 onRenameGroup={doRenameGroup}

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -41,6 +41,8 @@ import {
   selectUsCapital, selectUsCapitalTokenMinusAll,
   selectUsCapitalTokenPlusAll, selectUsCapitalTokenPlusOne,
   selectUsCapitalTokenMinusOne,
+  reqPostUsCapitalTokenResetAll, reqPostUsCapitalTokenResetOne,
+  selectUsCapitalTokenResetAll, selectUsCapitalTokenResetOne,
   reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate,
   reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup, reqPostUsCapitalStocksGroup, reqPostUsCapitalLikesCopy,
   selectUsGroupOp,
@@ -167,6 +169,8 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
   const usCapitalPlusOne = useAppSelector(selectUsCapitalTokenPlusOne);
   const usCapitalMinusAll = useAppSelector(selectUsCapitalTokenMinusAll);
   const usCapitalMinusOne = useAppSelector(selectUsCapitalTokenMinusOne);
+  const usCapitalResetAll = useAppSelector(selectUsCapitalTokenResetAll);
+  const usCapitalResetOne = useAppSelector(selectUsCapitalTokenResetOne);
   const usGroupOp = useAppSelector(selectUsGroupOp);
   const usQuantRule = useAppSelector(selectUsQuantRule);
   const likedListAll = useAppSelector(selectLikedList);
@@ -291,12 +295,12 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
   }, [balanceKey]);
 
   useEffect(() => {
-    const states = [usCapitalPlusAll?.state, usCapitalPlusOne?.state, usCapitalMinusAll?.state, usCapitalMinusOne?.state];
+    const states = [usCapitalPlusAll?.state, usCapitalPlusOne?.state, usCapitalMinusAll?.state, usCapitalMinusOne?.state, usCapitalResetAll?.state, usCapitalResetOne?.state];
     if (states.some(s => s === "fulfilled")) {
       dispatch(reqGetUsCapital(balanceKey));
       addToast("success", "토큰 잔액이 업데이트되었습니다.");
     }
-  }, [usCapitalPlusAll?.state, usCapitalPlusOne?.state, usCapitalMinusAll?.state, usCapitalMinusOne?.state]);
+  }, [usCapitalPlusAll?.state, usCapitalPlusOne?.state, usCapitalMinusAll?.state, usCapitalMinusOne?.state, usCapitalResetAll?.state, usCapitalResetOne?.state]);
 
   useEffect(() => {
     if (kiBalance.state === "fulfilled") setLastUpdated(new Date());
@@ -321,6 +325,8 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
   const doTokenPlusOne = (num: number, ticker: string) => ticker && dispatch(reqPostUsCapitalTokenPlusOne({ key: balanceKey, num, ticker }));
   const doTokenMinusAll = (num: number) => dispatch(reqPostUsCapitalTokenMinusAll({ key: balanceKey, num }));
   const doTokenMinusOne = (num: number, ticker: string) => ticker && dispatch(reqPostUsCapitalTokenMinusOne({ key: balanceKey, num, ticker }));
+  const doTokenResetAll = () => dispatch(reqPostUsCapitalTokenResetAll({ key: balanceKey }));
+  const doTokenResetOne = (ticker: string) => ticker && dispatch(reqPostUsCapitalTokenResetOne({ key: balanceKey, ticker }));
 
   // 그룹 관리 핸들러
   const doCreateGroup = (name: string, tickers?: string[]) => dispatch(reqPostUsCapitalGroupCreate({ key: balanceKey, name, tickers }));
@@ -651,6 +657,8 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
                 doTokenPlusOne={doTokenPlusOne}
                 doTokenMinusAll={doTokenMinusAll}
                 doTokenMinusOne={doTokenMinusOne}
+                doTokenResetAll={doTokenResetAll}
+                doTokenResetOne={doTokenResetOne}
                 session={session}
                 onCreateGroup={doCreateGroup}
                 onRenameGroup={doRenameGroup}

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -27,6 +27,7 @@ import {
   CircleCheck,
   CircleSlash,
   CircleDashed,
+  RotateCcw,
 } from "lucide-react";
 import { UsCapitalStockItem, KrUsCapitalType, StockGroup, LIKES_GROUP_ID, QuantRule } from "@/lib/features/capital/capitalSlice";
 import { LikedStockItem } from "@/lib/features/stockLikes/stockLikesSlice";
@@ -129,6 +130,8 @@ interface Props {
   doTokenPlusOne: (val: number, sym: string) => void;
   doTokenMinusAll: (val: number) => void;
   doTokenMinusOne: (val: number, sym: string) => void;
+  doTokenResetAll?: () => void;
+  doTokenResetOne?: (sym: string) => void;
   className?: string;
   session: any;
   // 그룹 관리
@@ -204,6 +207,8 @@ export default function StockListTable({
   doTokenPlusOne,
   doTokenMinusAll,
   doTokenMinusOne,
+  doTokenResetAll,
+  doTokenResetOne,
   className = "",
   session,
   onCreateGroup,
@@ -476,6 +481,15 @@ export default function StockListTable({
                   </button>
                 </div>
               ))}
+              {doTokenResetAll && (
+                <button
+                  onClick={() => { if (window.confirm("전체 활성 종목의 토큰을 0으로 리셋할까요?")) doTokenResetAll(); }}
+                  title="전체 종목 토큰 리셋"
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-red-300 dark:border-red-800 bg-white dark:bg-[#242320] px-3 py-1.5 text-xs font-bold text-red-600 hover:bg-red-50 dark:hover:bg-red-950 transition-colors"
+                >
+                  <RotateCcw className="w-3.5 h-3.5" /> 전체 리셋
+                </button>
+              )}
             </div>
             {/* 새 그룹 추가 */}
             <div className="ml-auto flex items-center gap-2">
@@ -572,6 +586,7 @@ export default function StockListTable({
         onPickMany={pickMany}
         doTokenPlusOne={doTokenPlusOne}
         doTokenMinusOne={doTokenMinusOne}
+        doTokenResetOne={doTokenResetOne}
         openDetail={openDetail}
         monthlyPerStock={monthlyPerStock}
       />
@@ -606,6 +621,7 @@ export default function StockListTable({
           onPickMany={pickMany}
           doTokenPlusOne={doTokenPlusOne}
           doTokenMinusOne={doTokenMinusOne}
+          doTokenResetOne={doTokenResetOne}
           openDetail={openDetail}
           monthlyPerStock={monthlyPerStock}
         />
@@ -630,6 +646,7 @@ export default function StockListTable({
         onPickMany={pickMany}
         doTokenPlusOne={doTokenPlusOne}
         doTokenMinusOne={doTokenMinusOne}
+        doTokenResetOne={doTokenResetOne}
         openDetail={openDetail}
         monthlyPerStock={monthlyPerStock}
       />
@@ -716,6 +733,7 @@ interface GroupSectionProps {
   onPickMany?: (section: string, tickers: string[], select: boolean) => void;
   doTokenPlusOne: (val: number, sym: string) => void;
   doTokenMinusOne: (val: number, sym: string) => void;
+  doTokenResetOne?: (sym: string) => void;
   openDetail: (raw: any) => void;
   monthlyPerStock?: number;
 }
@@ -724,7 +742,7 @@ function GroupSection({
   sectionKey, title, subtitle, icon, accent, count, rows, isMaster, tradingActive, onToggleTrading, hideTrading,
   conditionChips, editing, editingName, onEditNameChange, onStartRename, onCommitRename, onDelete,
   emptyText, collapsed, onToggleCollapse, picked, onTogglePick, onPickMany,
-  doTokenPlusOne, doTokenMinusOne, openDetail, monthlyPerStock = 0,
+  doTokenPlusOne, doTokenMinusOne, doTokenResetOne, openDetail, monthlyPerStock = 0,
 }: GroupSectionProps) {
   const showRefill = isMaster && rows.some(r => r.movable);
   const showCheck = isMaster && rows.length > 0; // 모든 행 선택 가능(좋아요는 복사용)
@@ -968,7 +986,7 @@ function GroupSection({
                     {showRefill && (
                       <td className="px-4 py-3">
                         {row.movable ? (
-                          <div className="flex justify-end gap-1.5">
+                          <div className="flex justify-end gap-1.5 flex-wrap">
                             {tokenAmounts.map(amt => (
                               <div key={`indiv-${amt}`} className="flex items-center rounded-md border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] overflow-hidden shadow-xs">
                                 <button onClick={() => doTokenPlusOne(amt, row.symbol)} className="px-2 py-1 hover:bg-[#f5f1eb] dark:hover:bg-[#35332e] text-[10px] font-bold border-r border-neutral-100 dark:border-[#35332e]">
@@ -979,6 +997,11 @@ function GroupSection({
                                 </button>
                               </div>
                             ))}
+                            {doTokenResetOne && Number(row.token) > 0 && (
+                              <button onClick={() => doTokenResetOne(row.symbol)} title="토큰 0으로 리셋" className="flex items-center rounded-md border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] px-1.5 py-1 text-neutral-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950 transition-colors">
+                                <RotateCcw className="w-3 h-3" />
+                              </button>
+                            )}
                           </div>
                         ) : (
                           <span className="block text-right text-neutral-300">-</span>
@@ -1064,6 +1087,11 @@ function GroupSection({
                             </button>
                           </div>
                         ))}
+                        {doTokenResetOne && Number(row.token) > 0 && (
+                          <button onClick={() => doTokenResetOne(row.symbol)} title="리셋" className="flex items-center rounded-md border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] px-2 py-1.5 text-neutral-400 active:text-red-500 active:bg-red-50 dark:active:bg-red-950">
+                            <RotateCcw className="w-3 h-3" />
+                          </button>
+                        )}
                       </div>
                     )}
                   </div>

--- a/cf-idiotquant/lib/features/capital/capitalAPI.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalAPI.tsx
@@ -128,3 +128,15 @@ export const getKrCapitalBudget: any = async (key: string) =>
     getKoreaInvestmentRequest(`/kr/capital/budget?kakao-id=${key}`, {});
 export const postKrCapitalBudget: any = async (key: string, monthly_budget_krw: number) =>
     postKoreaInvestmentRequest(`/kr/capital/budget?kakao-id=${key}`, {}, { monthly_budget_krw });
+
+// ============================================================================
+// 토큰 리셋 API (KR / US)
+// ============================================================================
+export const postKrCapitalTokenResetAll: any = async (key: string) =>
+    postKoreaInvestmentRequest(`/kr/capital/token/reset/all?kakao-id=${key}`, {});
+export const postKrCapitalTokenResetOne: any = async (key: string, ticker: string) =>
+    postKoreaInvestmentRequest(`/kr/capital/token/reset/ticker/${ticker}?kakao-id=${key}`, {});
+export const postUsCapitalTokenResetAll: any = async (key: string) =>
+    postKoreaInvestmentRequest(`/us/capital/token/reset/all?kakao-id=${key}`, {});
+export const postUsCapitalTokenResetOne: any = async (key: string, ticker: string) =>
+    postKoreaInvestmentRequest(`/us/capital/token/reset/ticker/${ticker}?kakao-id=${key}`, {});

--- a/cf-idiotquant/lib/features/capital/capitalSlice.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalSlice.tsx
@@ -1,6 +1,6 @@
 import { PayloadAction } from "@reduxjs/toolkit";
 import { createAppSlice } from "@/lib/createAppSlice";
-import { getKrCapital, getUsCapital, postKrCapitalTokenMinusAll, postKrCapitalTokenMinusOne, postKrCapitalTokenPlusAll, postKrCapitalTokenPlusOne, postUsCapitalTokenMinusAll, postUsCapitalTokenMinusOne, postUsCapitalTokenPlusAll, postUsCapitalTokenPlusOne, postKrCapitalGroupCreate, postKrCapitalGroupUpdate, postKrCapitalGroupDelete, postKrCapitalStockGroup, postKrCapitalStocksGroup, postKrCapitalLikesCopy, postUsCapitalGroupCreate, postUsCapitalGroupUpdate, postUsCapitalGroupDelete, postUsCapitalStockGroup, postUsCapitalStocksGroup, postUsCapitalLikesCopy, getKrQuantRule, postKrQuantRule, getUsQuantRule, postUsQuantRule, getKrCapitalBudget, postKrCapitalBudget } from "./capitalAPI";
+import { getKrCapital, getUsCapital, postKrCapitalTokenMinusAll, postKrCapitalTokenMinusOne, postKrCapitalTokenPlusAll, postKrCapitalTokenPlusOne, postUsCapitalTokenMinusAll, postUsCapitalTokenMinusOne, postUsCapitalTokenPlusAll, postUsCapitalTokenPlusOne, postKrCapitalGroupCreate, postKrCapitalGroupUpdate, postKrCapitalGroupDelete, postKrCapitalStockGroup, postKrCapitalStocksGroup, postKrCapitalLikesCopy, postUsCapitalGroupCreate, postUsCapitalGroupUpdate, postUsCapitalGroupDelete, postUsCapitalStockGroup, postUsCapitalStocksGroup, postUsCapitalLikesCopy, getKrQuantRule, postKrQuantRule, getUsQuantRule, postUsQuantRule, getKrCapitalBudget, postKrCapitalBudget, postKrCapitalTokenResetAll, postKrCapitalTokenResetOne, postUsCapitalTokenResetAll, postUsCapitalTokenResetOne } from "./capitalAPI";
 
 /** 예약(가상) 그룹 id — 좋아요(찜) 종목 그룹 */
 export const LIKES_GROUP_ID = "__likes__";
@@ -128,10 +128,14 @@ export interface CapitalType {
     krCapitalTokenPlusOne: CapitalTokenRefillType;
     krCapitalTokenMinusAll: CapitalTokenRefillType;
     krCapitalTokenMinusOne: CapitalTokenRefillType;
+    krCapitalTokenResetAll: CapitalTokenRefillType;
+    krCapitalTokenResetOne: CapitalTokenRefillType;
     usCapitalTokenPlusAll: CapitalTokenRefillType;
     usCapitalTokenPlusOne: CapitalTokenRefillType;
     usCapitalTokenMinusAll: CapitalTokenRefillType;
     usCapitalTokenMinusOne: CapitalTokenRefillType;
+    usCapitalTokenResetAll: CapitalTokenRefillType;
+    usCapitalTokenResetOne: CapitalTokenRefillType;
     krGroupOp: CapitalTokenRefillType;
     usGroupOp: CapitalTokenRefillType;
     krQuantRule: QuantRuleState;
@@ -174,6 +178,12 @@ const initialState: CapitalType = {
     krCapitalTokenMinusOne: {
         state: "init"
     },
+    krCapitalTokenResetAll: {
+        state: "init"
+    },
+    krCapitalTokenResetOne: {
+        state: "init"
+    },
     usCapital: {
         state: "init",
         time_stamp: {
@@ -205,6 +215,12 @@ const initialState: CapitalType = {
         state: "init"
     },
     usCapitalTokenMinusOne: {
+        state: "init"
+    },
+    usCapitalTokenResetAll: {
+        state: "init"
+    },
+    usCapitalTokenResetOne: {
         state: "init"
     },
     krGroupOp: {
@@ -323,6 +339,26 @@ export const capitalSlice = createAppSlice({
                 }
             }
         ),
+        reqPostKrCapitalTokenResetAll: create.asyncThunk(
+            async ({ key }: { key?: string }) => {
+                return await postKrCapitalTokenResetAll(key);
+            },
+            {
+                pending: (state) => { state.krCapitalTokenResetAll.state = "pending"; },
+                fulfilled: (state) => { state.krCapitalTokenResetAll.state = "fulfilled"; },
+                rejected: (state) => { state.krCapitalTokenResetAll.state = "rejected"; },
+            }
+        ),
+        reqPostKrCapitalTokenResetOne: create.asyncThunk(
+            async ({ key, ticker }: { key?: string, ticker: string }) => {
+                return await postKrCapitalTokenResetOne(key, ticker);
+            },
+            {
+                pending: (state) => { state.krCapitalTokenResetOne.state = "pending"; },
+                fulfilled: (state) => { state.krCapitalTokenResetOne.state = "fulfilled"; },
+                rejected: (state) => { state.krCapitalTokenResetOne.state = "rejected"; },
+            }
+        ),
 
         // US
         reqGetUsCapital: create.asyncThunk(
@@ -423,6 +459,26 @@ export const capitalSlice = createAppSlice({
                     console.log(`[reqPostUsCapitalTokenMinusOne] rejected`);
                     state.usCapitalTokenMinusOne.state = "rejected"
                 }
+            }
+        ),
+        reqPostUsCapitalTokenResetAll: create.asyncThunk(
+            async ({ key }: { key?: string }) => {
+                return await postUsCapitalTokenResetAll(key);
+            },
+            {
+                pending: (state) => { state.usCapitalTokenResetAll.state = "pending"; },
+                fulfilled: (state) => { state.usCapitalTokenResetAll.state = "fulfilled"; },
+                rejected: (state) => { state.usCapitalTokenResetAll.state = "rejected"; },
+            }
+        ),
+        reqPostUsCapitalTokenResetOne: create.asyncThunk(
+            async ({ key, ticker }: { key?: string, ticker: string }) => {
+                return await postUsCapitalTokenResetOne(key, ticker);
+            },
+            {
+                pending: (state) => { state.usCapitalTokenResetOne.state = "pending"; },
+                fulfilled: (state) => { state.usCapitalTokenResetOne.state = "fulfilled"; },
+                rejected: (state) => { state.usCapitalTokenResetOne.state = "rejected"; },
             }
         ),
 
@@ -645,11 +701,15 @@ export const capitalSlice = createAppSlice({
         selectKrCapitalTokenPlusOne: (state) => state.krCapitalTokenPlusOne,
         selectKrCapitalTokenMinusAll: (state) => state.krCapitalTokenMinusAll,
         selectKrCapitalTokenMinusOne: (state) => state.krCapitalTokenMinusOne,
+        selectKrCapitalTokenResetAll: (state) => state.krCapitalTokenResetAll,
+        selectKrCapitalTokenResetOne: (state) => state.krCapitalTokenResetOne,
         selectUsCapital: (state) => state.usCapital,
         selectUsCapitalTokenPlusAll: (state) => state.usCapitalTokenPlusAll,
         selectUsCapitalTokenPlusOne: (state) => state.usCapitalTokenPlusOne,
         selectUsCapitalTokenMinusAll: (state) => state.usCapitalTokenMinusAll,
         selectUsCapitalTokenMinusOne: (state) => state.usCapitalTokenMinusOne,
+        selectUsCapitalTokenResetAll: (state) => state.usCapitalTokenResetAll,
+        selectUsCapitalTokenResetOne: (state) => state.usCapitalTokenResetOne,
         selectKrGroupOp: (state) => state.krGroupOp,
         selectUsGroupOp: (state) => state.usGroupOp,
         selectKrQuantRule: (state) => state.krQuantRule,
@@ -658,8 +718,8 @@ export const capitalSlice = createAppSlice({
     }
 });
 
-export const { reqGetKrCapital, reqPostKrCapitalTokenPlusAll, reqPostKrCapitalTokenPlusOne, reqPostKrCapitalTokenMinusAll, reqPostKrCapitalTokenMinusOne } = capitalSlice.actions;
-export const { selectKrCapital, selectKrCapitalTokenPlusAll, selectKrCapitalTokenPlusOne, selectKrCapitalTokenMinusAll, selectKrCapitalTokenMinusOne } = capitalSlice.selectors;
+export const { reqGetKrCapital, reqPostKrCapitalTokenPlusAll, reqPostKrCapitalTokenPlusOne, reqPostKrCapitalTokenMinusAll, reqPostKrCapitalTokenMinusOne, reqPostKrCapitalTokenResetAll, reqPostKrCapitalTokenResetOne } = capitalSlice.actions;
+export const { selectKrCapital, selectKrCapitalTokenPlusAll, selectKrCapitalTokenPlusOne, selectKrCapitalTokenMinusAll, selectKrCapitalTokenMinusOne, selectKrCapitalTokenResetAll, selectKrCapitalTokenResetOne } = capitalSlice.selectors;
 export const { reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate, reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup, reqPostKrCapitalStocksGroup, reqPostKrCapitalLikesCopy } = capitalSlice.actions;
 export const { reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate, reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup, reqPostUsCapitalStocksGroup, reqPostUsCapitalLikesCopy } = capitalSlice.actions;
 export const { selectKrGroupOp, selectUsGroupOp } = capitalSlice.selectors;
@@ -667,5 +727,5 @@ export const { reqGetKrQuantRule, reqPostKrQuantRule, reqGetUsQuantRule, reqPost
 export const { selectKrQuantRule, selectUsQuantRule } = capitalSlice.selectors;
 export const { reqGetKrCapitalBudget, reqPostKrCapitalBudget } = capitalSlice.actions;
 export const { selectKrBudget } = capitalSlice.selectors;
-export const { reqGetUsCapital, reqPostUsCapitalTokenPlusAll, reqPostUsCapitalTokenPlusOne, reqPostUsCapitalTokenMinusAll, reqPostUsCapitalTokenMinusOne } = capitalSlice.actions;
-export const { selectUsCapital, selectUsCapitalTokenPlusAll, selectUsCapitalTokenPlusOne, selectUsCapitalTokenMinusAll, selectUsCapitalTokenMinusOne } = capitalSlice.selectors;
+export const { reqGetUsCapital, reqPostUsCapitalTokenPlusAll, reqPostUsCapitalTokenPlusOne, reqPostUsCapitalTokenMinusAll, reqPostUsCapitalTokenMinusOne, reqPostUsCapitalTokenResetAll, reqPostUsCapitalTokenResetOne } = capitalSlice.actions;
+export const { selectUsCapital, selectUsCapitalTokenPlusAll, selectUsCapitalTokenPlusOne, selectUsCapitalTokenMinusAll, selectUsCapitalTokenMinusOne, selectUsCapitalTokenResetAll, selectUsCapitalTokenResetOne } = capitalSlice.selectors;


### PR DESCRIPTION
## 변경 요약

balance 페이지의 종목 관리 섹션에 **토큰 리셋** 기능을 추가합니다.

### 신규 API 함수 (`capitalAPI.tsx`)
- `postKrCapitalTokenResetAll` / `postKrCapitalTokenResetOne`
- `postUsCapitalTokenResetAll` / `postUsCapitalTokenResetOne`
→ `/kr(us)/capital/token/reset/all` 및 `/token/reset/ticker/{ticker}` 호출

### Redux slice (`capitalSlice.tsx`)
- KR/US 각각 `reqPostCapitalTokenResetAll/One` thunk 4개 추가
- `selectKrCapitalTokenResetAll/One`, `selectUsCapitalTokenResetAll/One` selector 4개 추가
- `initialState`에 초기값(`{ state: "init" }`) 추가

### UI (`stockListTable.tsx`)
- **헤더 영역**: "전체 리셋" 버튼 (confirm 다이얼로그 → `doTokenResetAll` 호출)
- **데스크탑 테이블**: Refill 컬럼에 종목별 `RotateCcw` 버튼 (`token > 0`일 때만 표시)
- **모바일 카드**: Refill 행에 종목별 리셋 버튼 추가

### View wiring (`balanceKrView.tsx`, `balanceUsView.tsx`)
- reset selector `useAppSelector` 추가
- `doTokenResetAll` / `doTokenResetOne` 핸들러 추가
- 토큰 상태 effect에 reset 상태 포함 → fulfilled 시 capital 재조회
- `StockListTable`에 `doTokenResetAll`, `doTokenResetOne` props 전달

## 검증
- `npx tsc --noEmit`: 에러 0

## 변경 파일
- `cf-idiotquant/lib/features/capital/capitalAPI.tsx`
- `cf-idiotquant/lib/features/capital/capitalSlice.tsx`
- `cf-idiotquant/components/balance/stockListTable.tsx`
- `cf-idiotquant/components/balance/balanceKrView.tsx`
- `cf-idiotquant/components/balance/balanceUsView.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZmvL8hb5ZiuEZczunWvB9)_