### PR TITLE
feat(balance): 미지정 종목 제거 버튼 + 자동매매 상태 수정 + 전량 매도 버튼

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -38,6 +38,7 @@ import {
   selectKrCapitalTokenResetAll, selectKrCapitalTokenResetOne,
   reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate,
   reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup, reqPostKrCapitalStocksGroup, reqPostKrCapitalLikesCopy,
+  reqPostKrCapitalStockRemove,
   selectKrGroupOp,
   reqGetKrQuantRule, reqPostKrQuantRule, selectKrQuantRule,
   reqGetKrCapitalBudget, reqPostKrCapitalBudget, selectKrBudget,
@@ -368,6 +369,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
   const doMoveStock = (ticker: string, groupId: string | null) => dispatch(reqPostKrCapitalStockGroup({ key: balanceKey, ticker, groupId }));
   const doBulkMove = (tickers: string[], groupId: string | null) => dispatch(reqPostKrCapitalStocksGroup({ key: balanceKey, tickers, groupId }));
   const doCopyLikes = (tickers: string[], groupId: string | null) => dispatch(reqPostKrCapitalLikesCopy({ key: balanceKey, tickers, groupId }));
+  const doDeleteStock = (ticker: string) => dispatch(reqPostKrCapitalStockRemove({ key: balanceKey, ticker }));
   const doSaveQuantRule = (rule: any) => dispatch(reqPostKrQuantRule({ key: balanceKey, rule }));
   const doSaveBudget = (monthly_budget_krw: number) => dispatch(reqPostKrCapitalBudget({ key: balanceKey, monthly_budget_krw }));
 
@@ -633,6 +635,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                 onMoveStock={doMoveStock}
                 onBulkMove={doBulkMove}
                 onCopyLikes={doCopyLikes}
+                onDeleteStock={doDeleteStock}
                 likedList={krLikedList}
                 countryTradingActive={tradingStatus.KR === true}
                 quantRule={krQuantRule.rule}

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -45,6 +45,7 @@ import {
   selectUsCapitalTokenResetAll, selectUsCapitalTokenResetOne,
   reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate,
   reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup, reqPostUsCapitalStocksGroup, reqPostUsCapitalLikesCopy,
+  reqPostUsCapitalStockRemove,
   selectUsGroupOp,
   reqGetUsQuantRule, reqPostUsQuantRule, selectUsQuantRule,
 } from "@/lib/features/capital/capitalSlice";
@@ -336,6 +337,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
   const doMoveStock = (ticker: string, groupId: string | null) => dispatch(reqPostUsCapitalStockGroup({ key: balanceKey, ticker, groupId }));
   const doBulkMove = (tickers: string[], groupId: string | null) => dispatch(reqPostUsCapitalStocksGroup({ key: balanceKey, tickers, groupId }));
   const doCopyLikes = (tickers: string[], groupId: string | null) => dispatch(reqPostUsCapitalLikesCopy({ key: balanceKey, tickers, groupId }));
+  const doDeleteStock = (ticker: string) => dispatch(reqPostUsCapitalStockRemove({ key: balanceKey, ticker }));
   const doSaveQuantRule = (rule: any) => dispatch(reqPostUsQuantRule({ key: balanceKey, rule }));
 
   const out2 = kiBalance?.output2?.[0];
@@ -667,6 +669,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
                 onMoveStock={doMoveStock}
                 onBulkMove={doBulkMove}
                 onCopyLikes={doCopyLikes}
+                onDeleteStock={doDeleteStock}
                 likedList={usLikedList}
                 countryTradingActive={tradingStatus.US === true}
                 quantRule={usQuantRule.rule}

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -142,6 +142,7 @@ interface Props {
   onMoveStock?: (ticker: string, groupId: string | null) => void;
   onBulkMove?: (tickers: string[], groupId: string | null) => void;
   onCopyLikes?: (tickers: string[], groupId: string | null) => void;
+  onDeleteStock?: (ticker: string) => void;
   // 좋아요(찜) 그룹
   likedList?: LikedStockItem[];
   onToggleLikesTrading?: (isActive: boolean) => void;
@@ -218,6 +219,7 @@ export default function StockListTable({
   onMoveStock,
   onBulkMove,
   onCopyLikes,
+  onDeleteStock,
   likedList = [],
   onToggleLikesTrading,
   countryTradingActive = false,
@@ -264,7 +266,7 @@ export default function StockListTable({
         continue;
       }
       const g = s.group_id ? gmap.get(s.group_id) : null;
-      const groupActive = g ? g.is_trading_active !== false : true;
+      const groupActive = g ? g.is_trading_active !== false : false;
       const status = capitalStatus(s.action, groupActive, countryTradingActive);
       const row = normalizeCapital(s, status);
       if (s.group_id && gmap.has(s.group_id)) byGroup.get(s.group_id)!.push(row);
@@ -303,7 +305,7 @@ export default function StockListTable({
       if (s.group_id === LIKES_GROUP_ID) continue;
       total++;
       const g = s.group_id ? gmap.get(s.group_id) : null;
-      const groupActive = g ? g.is_trading_active !== false : true;
+      const groupActive = g ? g.is_trading_active !== false : false;
       const st = capitalStatus(s.action, groupActive, countryTradingActive);
       if (st.tone === "active") active++;
       else if (st.tone === "excluded") excluded++;
@@ -631,13 +633,13 @@ export default function StockListTable({
       <GroupSection
         sectionKey="__unassigned__"
         title="미지정"
-        subtitle="그룹에 속하지 않은 종목 (자동매매 기본 포함)"
+        subtitle="그룹 미지정 종목 — 자동매매 OFF. 그룹에 추가하면 ON/OFF 설정 가능"
         icon={<FolderOpen className="w-4 h-4 text-neutral-400" />}
         accent="neutral"
         count={unassigned.length}
         rows={unassigned}
         isMaster={isMaster}
-        tradingActive={true}
+        tradingActive={false}
         emptyText="미지정 종목이 없습니다."
         collapsed={collapsed.has("__unassigned__")}
         onToggleCollapse={() => toggleCollapse("__unassigned__")}
@@ -649,6 +651,7 @@ export default function StockListTable({
         doTokenResetOne={doTokenResetOne}
         openDetail={openDetail}
         monthlyPerStock={monthlyPerStock}
+        onDeleteStock={isMaster && onDeleteStock ? onDeleteStock : undefined}
       />
 
       {/* 상세 분석 모달 */}
@@ -736,13 +739,14 @@ interface GroupSectionProps {
   doTokenResetOne?: (sym: string) => void;
   openDetail: (raw: any) => void;
   monthlyPerStock?: number;
+  onDeleteStock?: (ticker: string) => void;
 }
 
 function GroupSection({
   sectionKey, title, subtitle, icon, accent, count, rows, isMaster, tradingActive, onToggleTrading, hideTrading,
   conditionChips, editing, editingName, onEditNameChange, onStartRename, onCommitRename, onDelete,
   emptyText, collapsed, onToggleCollapse, picked, onTogglePick, onPickMany,
-  doTokenPlusOne, doTokenMinusOne, doTokenResetOne, openDetail, monthlyPerStock = 0,
+  doTokenPlusOne, doTokenMinusOne, doTokenResetOne, openDetail, monthlyPerStock = 0, onDeleteStock,
 }: GroupSectionProps) {
   const showRefill = isMaster && rows.some(r => r.movable);
   const showCheck = isMaster && rows.length > 0; // 모든 행 선택 가능(좋아요는 복사용)
@@ -763,7 +767,7 @@ function GroupSection({
   const allChecked = selectableTickers.length > 0 && selectableTickers.every(isPicked);
   const someChecked = selectableTickers.some(isPicked);
   const baseCols = 6; // 종목/상태/PER·PBR/BPS·EPS/시총/NCAV
-  const colSpan = baseCols + 1 /*token*/ + (showCheck ? 1 : 0) + (showRefill ? 1 : 0);
+  const colSpan = baseCols + 1 /*token*/ + (showCheck ? 1 : 0) + (showRefill ? 1 : 0) + (onDeleteStock ? 1 : 0);
 
   const accentBorder = accent === "rose" ? "border-rose-200 dark:border-rose-900/30"
     : accent === "green" ? "border-[#16a34a]/20 dark:border-[#16a34a]/20"
@@ -894,6 +898,7 @@ function GroupSection({
                 <th className="px-4 py-2.5 font-semibold uppercase tracking-wider text-center">NCAV 비율</th>
                 <th className="px-4 py-2.5 font-semibold uppercase tracking-wider text-right">Token</th>
                 {showRefill && <th className="px-4 py-2.5 font-semibold uppercase tracking-wider text-right">Refill</th>}
+                {onDeleteStock && <th className="px-4 py-2.5 w-10"></th>}
               </tr>
             </thead>
             <tbody className="divide-y divide-neutral-100 dark:divide-[#35332e]">
@@ -1008,6 +1013,17 @@ function GroupSection({
                         )}
                       </td>
                     )}
+                    {onDeleteStock && (
+                      <td className="px-2 py-3 text-right">
+                        <button
+                          onClick={() => { if (window.confirm(`'${row.name || row.symbol}' 종목을 제거할까요?`)) onDeleteStock(row.symbol); }}
+                          title="종목 제거"
+                          className="rounded-md p-1 text-neutral-300 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-950 transition-colors"
+                        >
+                          <X className="w-3.5 h-3.5" />
+                        </button>
+                      </td>
+                    )}
                   </tr>
                 ))
               )}
@@ -1051,8 +1067,17 @@ function GroupSection({
                       <span className="truncate text-sm font-bold text-neutral-900 dark:text-neutral-100">{row.symbol}</span>
                     )}
                   </button>
-                  <div className="ml-auto shrink-0">
+                  <div className="ml-auto shrink-0 flex items-center gap-1">
                     <StatusBadge status={row.status} />
+                    {onDeleteStock && (
+                      <button
+                        onClick={() => { if (window.confirm(`'${row.name || row.symbol}' 종목을 제거할까요?`)) onDeleteStock(row.symbol); }}
+                        title="종목 제거"
+                        className="rounded-md p-1 text-neutral-300 active:text-red-500 active:bg-red-50 dark:active:bg-red-950 transition-colors"
+                      >
+                        <X className="w-3.5 h-3.5" />
+                      </button>
+                    )}
                   </div>
                 </div>
 

--- a/cf-idiotquant/components/inquireBalanceResult.tsx
+++ b/cf-idiotquant/components/inquireBalanceResult.tsx
@@ -17,7 +17,8 @@ import {
     Search,
     PlusCircle,
     FolderOpen,
-    AlertCircle
+    AlertCircle,
+    ArrowDownRight,
 } from "lucide-react";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -127,6 +128,8 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
 
     const [isOrderModalOpen, setIsOrderModalOpen] = useState(false);
     const [selectedStock, setSelectedStock] = useState<any>(null);
+    const [orderInitialMode, setOrderInitialMode] = useState<"buy" | "sell">("buy");
+    const [orderInitialQty, setOrderInitialQty] = useState<string>("1");
 
     // 검색 제어 상태 관리
     const [searchQuery, setSearchQuery] = useState("");
@@ -181,8 +184,10 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
         }
     }, [props.kiOrderCash?.state]);
 
-    const handleOpenOrderModal = (stock: any) => {
+    const handleOpenOrderModal = (stock: any, mode: "buy" | "sell" = "buy", qty?: string) => {
         setSelectedStock(stock);
+        setOrderInitialMode(mode);
+        setOrderInitialQty(qty ?? "1");
         setIsOrderModalOpen(true);
         setIsDropdownOpen(false);
     };
@@ -383,6 +388,8 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
                     kiOrderCash={props.kiOrderCash}
                     reqPostOrderCash={props.reqPostOrderCash}
                     exRate={exRate}
+                    initialMode={orderInitialMode}
+                    initialQty={orderInitialQty}
                     onClose={() => setIsOrderModalOpen(false)}
                 />
             )}
@@ -400,7 +407,7 @@ function SummaryItem({ label, value, subValue, colorClass = "dark:text-white" }:
     );
 }
 
-function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker }: { inventoryData: any[], isUs: boolean, onOpenOrder: (stock: any) => void, groupByTicker?: Map<string, { name: string; active: boolean; assigned: boolean }> }) {
+function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker }: { inventoryData: any[], isUs: boolean, onOpenOrder: (stock: any, mode?: "buy" | "sell", qty?: string) => void, groupByTicker?: Map<string, { name: string; active: boolean; assigned: boolean }> }) {
     const [sortConfig, setSortConfig] = useState<any>({ key: "evlu_amt", direction: "desc" });
     const router = useRouter();
 
@@ -496,7 +503,7 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker 
                             </div>
                         </div>
                         {/* 액션 */}
-                        <div className="flex gap-2 pt-1">
+                        <div className="flex gap-2 pt-1 flex-wrap">
                             <button
                                 onClick={() => goAnalyze(item)}
                                 className="flex items-center gap-1.5 px-3 py-1.5 bg-neutral-100 dark:bg-[#35332e] text-neutral-600 dark:text-neutral-300 rounded-lg text-xs font-black transition-colors hover:bg-neutral-200 dark:hover:bg-[#4a4641]"
@@ -509,6 +516,14 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker 
                             >
                                 <Send size={12} /> 주문
                             </button>
+                            {Number(qty) > 0 && (
+                                <button
+                                    onClick={() => onOpenOrder(item, "sell", String(qty))}
+                                    className="flex items-center gap-1.5 px-3 py-1.5 bg-red-50 dark:bg-red-950/20 text-red-500 rounded-lg text-xs font-black transition-colors hover:bg-red-100 dark:hover:bg-red-950/40"
+                                >
+                                    <ArrowDownRight size={12} /> 전량 매도
+                                </button>
+                            )}
                         </div>
                     </div>
                 );
@@ -601,9 +616,19 @@ function SortableBalanceTable({ inventoryData, isUs, onOpenOrder, groupByTicker 
                                             <button
                                                 onClick={() => onOpenOrder(item)}
                                                 className="p-1.5 hover:bg-[#dcfce7] dark:hover:bg-[#14532d]/30 rounded-lg text-[#16a34a] transition-colors"
+                                                title="주문"
                                             >
                                                 <Send size={16} />
                                             </button>
+                                            {Number(qty) > 0 && (
+                                                <button
+                                                    onClick={() => onOpenOrder(item, "sell", String(qty))}
+                                                    className="flex items-center gap-1 px-2 py-1.5 hover:bg-red-50 dark:hover:bg-red-950/30 rounded-lg text-red-500 transition-colors text-[11px] font-black"
+                                                    title="전량 매도"
+                                                >
+                                                    <ArrowDownRight size={13} /> 전량
+                                                </button>
+                                            )}
                                         </div>
                                     </td>
                                 </tr>
@@ -647,10 +672,12 @@ interface OrderModalProps {
     kiOrderCash: any;
     reqPostOrderCash: any;
     exRate: number;
+    initialMode?: "buy" | "sell";
+    initialQty?: string;
     onClose: () => void;
 }
 
-function OrderModal({ isUs, stock, balanceKey, kiOrderCash, reqPostOrderCash, exRate, onClose }: OrderModalProps) {
+function OrderModal({ isUs, stock, balanceKey, kiOrderCash, reqPostOrderCash, exRate, initialMode = "buy", initialQty = "1", onClose }: OrderModalProps) {
     const dispatch = useAppDispatch();
 
     const krPriceState = useAppSelector(getKoreaInvestmentInquirePrice);
@@ -666,9 +693,10 @@ function OrderModal({ isUs, stock, balanceKey, kiOrderCash, reqPostOrderCash, ex
         ? parseFloat((rawPrice / exRate).toFixed(2))
         : rawPrice;
 
-    const [buyOrSell, setBuyOrSell] = useState<"buy" | "sell">("buy");
+    const [buyOrSell, setBuyOrSell] = useState<"buy" | "sell">(initialMode);
     const [price, setPrice] = useState(initialPrice > 0 ? String(initialPrice) : "");
-    const [qty, setQty] = useState("1");
+    const [qty, setQty] = useState(initialQty);
+    const heldQty = Number(getFieldValue(stock, "qty") || 0);
     const [priceError, setPriceError] = useState("");
     const [qtyError, setQtyError] = useState("");
     const [isFetchingPrice, setIsFetchingPrice] = useState(false);
@@ -793,7 +821,18 @@ function OrderModal({ isUs, stock, balanceKey, kiOrderCash, reqPostOrderCash, ex
                     </div>
 
                     <div className="space-y-1.5">
-                        <label className="text-xs font-black text-neutral-400 uppercase tracking-wider">주문 수량 (QTY)</label>
+                        <div className="flex items-center justify-between">
+                            <label className="text-xs font-black text-neutral-400 uppercase tracking-wider">주문 수량 (QTY)</label>
+                            {buyOrSell === "sell" && heldQty > 0 && (
+                                <button
+                                    type="button"
+                                    onClick={() => { setQty(formatValue(heldQty, "QTY").replace(/,/g, "")); if (qtyError) setQtyError(""); }}
+                                    className="text-[11px] font-black text-[#16a34a] hover:underline"
+                                >
+                                    전량 ({formatValue(heldQty, "QTY")})
+                                </button>
+                            )}
+                        </div>
                         <div className={`flex items-center border rounded-xl overflow-hidden ${qtyError ? "border-rose-500 dark:border-rose-500" : "border-neutral-200 dark:border-[#35332e]"}`}>
                             <button
                                 type="button"

--- a/cf-idiotquant/lib/features/capital/capitalAPI.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalAPI.tsx
@@ -140,3 +140,11 @@ export const postUsCapitalTokenResetAll: any = async (key: string) =>
     postKoreaInvestmentRequest(`/us/capital/token/reset/all?kakao-id=${key}`, {});
 export const postUsCapitalTokenResetOne: any = async (key: string, ticker: string) =>
     postKoreaInvestmentRequest(`/us/capital/token/reset/ticker/${ticker}?kakao-id=${key}`, {});
+
+// ============================================================================
+// 종목 제거 API (미지정 종목 stock_list에서 삭제)
+// ============================================================================
+export const postKrCapitalStockRemove: any = async (key: string, ticker: string) =>
+    postKoreaInvestmentRequest(`/kr/capital/stock/${ticker}/remove?kakao-id=${key}`, {});
+export const postUsCapitalStockRemove: any = async (key: string, ticker: string) =>
+    postKoreaInvestmentRequest(`/us/capital/stock/${ticker}/remove?kakao-id=${key}`, {});

--- a/cf-idiotquant/lib/features/capital/capitalSlice.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalSlice.tsx
@@ -1,6 +1,6 @@
 import { PayloadAction } from "@reduxjs/toolkit";
 import { createAppSlice } from "@/lib/createAppSlice";
-import { getKrCapital, getUsCapital, postKrCapitalTokenMinusAll, postKrCapitalTokenMinusOne, postKrCapitalTokenPlusAll, postKrCapitalTokenPlusOne, postUsCapitalTokenMinusAll, postUsCapitalTokenMinusOne, postUsCapitalTokenPlusAll, postUsCapitalTokenPlusOne, postKrCapitalGroupCreate, postKrCapitalGroupUpdate, postKrCapitalGroupDelete, postKrCapitalStockGroup, postKrCapitalStocksGroup, postKrCapitalLikesCopy, postUsCapitalGroupCreate, postUsCapitalGroupUpdate, postUsCapitalGroupDelete, postUsCapitalStockGroup, postUsCapitalStocksGroup, postUsCapitalLikesCopy, getKrQuantRule, postKrQuantRule, getUsQuantRule, postUsQuantRule, getKrCapitalBudget, postKrCapitalBudget, postKrCapitalTokenResetAll, postKrCapitalTokenResetOne, postUsCapitalTokenResetAll, postUsCapitalTokenResetOne } from "./capitalAPI";
+import { getKrCapital, getUsCapital, postKrCapitalTokenMinusAll, postKrCapitalTokenMinusOne, postKrCapitalTokenPlusAll, postKrCapitalTokenPlusOne, postUsCapitalTokenMinusAll, postUsCapitalTokenMinusOne, postUsCapitalTokenPlusAll, postUsCapitalTokenPlusOne, postKrCapitalGroupCreate, postKrCapitalGroupUpdate, postKrCapitalGroupDelete, postKrCapitalStockGroup, postKrCapitalStocksGroup, postKrCapitalLikesCopy, postUsCapitalGroupCreate, postUsCapitalGroupUpdate, postUsCapitalGroupDelete, postUsCapitalStockGroup, postUsCapitalStocksGroup, postUsCapitalLikesCopy, getKrQuantRule, postKrQuantRule, getUsQuantRule, postUsQuantRule, getKrCapitalBudget, postKrCapitalBudget, postKrCapitalTokenResetAll, postKrCapitalTokenResetOne, postUsCapitalTokenResetAll, postUsCapitalTokenResetOne, postKrCapitalStockRemove, postUsCapitalStockRemove } from "./capitalAPI";
 
 /** 예약(가상) 그룹 id — 좋아요(찜) 종목 그룹 */
 export const LIKES_GROUP_ID = "__likes__";
@@ -694,6 +694,24 @@ export const capitalSlice = createAppSlice({
                 rejected: (state) => { state.krBudget.saveState = "rejected"; },
             }
         ),
+
+        // ── 미지정 종목 제거 ──
+        reqPostKrCapitalStockRemove: create.asyncThunk(
+            async ({ key, ticker }: { key?: string, ticker: string }) => postKrCapitalStockRemove(key, ticker),
+            {
+                pending: (state) => { state.krGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
+                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+            }
+        ),
+        reqPostUsCapitalStockRemove: create.asyncThunk(
+            async ({ key, ticker }: { key?: string, ticker: string }) => postUsCapitalStockRemove(key, ticker),
+            {
+                pending: (state) => { state.usGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
+                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+            }
+        ),
     }),
     selectors: {
         selectKrCapital: (state) => state.krCapital,
@@ -720,8 +738,8 @@ export const capitalSlice = createAppSlice({
 
 export const { reqGetKrCapital, reqPostKrCapitalTokenPlusAll, reqPostKrCapitalTokenPlusOne, reqPostKrCapitalTokenMinusAll, reqPostKrCapitalTokenMinusOne, reqPostKrCapitalTokenResetAll, reqPostKrCapitalTokenResetOne } = capitalSlice.actions;
 export const { selectKrCapital, selectKrCapitalTokenPlusAll, selectKrCapitalTokenPlusOne, selectKrCapitalTokenMinusAll, selectKrCapitalTokenMinusOne, selectKrCapitalTokenResetAll, selectKrCapitalTokenResetOne } = capitalSlice.selectors;
-export const { reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate, reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup, reqPostKrCapitalStocksGroup, reqPostKrCapitalLikesCopy } = capitalSlice.actions;
-export const { reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate, reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup, reqPostUsCapitalStocksGroup, reqPostUsCapitalLikesCopy } = capitalSlice.actions;
+export const { reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate, reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup, reqPostKrCapitalStocksGroup, reqPostKrCapitalLikesCopy, reqPostKrCapitalStockRemove } = capitalSlice.actions;
+export const { reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate, reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup, reqPostUsCapitalStocksGroup, reqPostUsCapitalLikesCopy, reqPostUsCapitalStockRemove } = capitalSlice.actions;
 export const { selectKrGroupOp, selectUsGroupOp } = capitalSlice.selectors;
 export const { reqGetKrQuantRule, reqPostKrQuantRule, reqGetUsQuantRule, reqPostUsQuantRule } = capitalSlice.actions;
 export const { selectKrQuantRule, selectUsQuantRule } = capitalSlice.selectors;


### PR DESCRIPTION
## 변경 요약

세 가지 기능을 포함합니다.

### 1. 미지정 종목 제거 버튼 (`stockListTable.tsx`, `capitalAPI.tsx`, `capitalSlice.tsx`)

미지정(group_id=null) 섹션의 각 종목에 X 버튼을 추가합니다:
- 확인 다이얼로그 → `/kr(us)/capital/stock/{ticker}/remove` 호출 → capital 재조회
- 데스크탑 테이블: Refill 셀 우측에 X 버튼
- 모바일 카드: StatusBadge 옆에 X 버튼
- `StockListTable`에 optional `onDeleteStock?: (ticker: string) => void` prop 추가 → 미지정 섹션에만 전달

### 2. 미지정 종목 자동매매 상태 표시 수정 (`stockListTable.tsx`)

`groupActive` 기본값을 `true` → `false`로 변경:
```tsx
// 변경 전
const groupActive = g ? g.is_trading_active !== false : true;

// 변경 후
const groupActive = g ? g.is_trading_active !== false : false;
```
미지정 섹션에 속한 종목들은 자동매매 `off` 상태로 표시됩니다.

### 3. 잔고 테이블 전량 매도 버튼 (`balanceKrView.tsx`, `balanceUsView.tsx`, 보유잔고 컴포넌트)

- 모바일 카드뷰: 보유수량 > 0이면 "전량 매도" 버튼 표시
- 데스크탑 테이블: hover 시 Action 컬럼에 "전량" 버튼 표시
- 클릭 시 주문 모달이 매도 모드 + 전체 수량으로 사전 입력되어 열림
- 모달 내 수량 입력 라벨 옆에 "전량 (N주)" 퀵필 버튼 추가 (매도 모드 + 잔고 있을 때)

## 검증
- `npx tsc --noEmit`: 에러 0

## 변경 파일
- `cf-idiotquant/lib/features/capital/capitalAPI.tsx`
- `cf-idiotquant/lib/features/capital/capitalSlice.tsx`
- `cf-idiotquant/components/balance/stockListTable.tsx`
- `cf-idiotquant/components/balance/balanceKrView.tsx`
- `cf-idiotquant/components/balance/balanceUsView.tsx`
- (전량 매도 관련 추가 파일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZmvL8hb5ZiuEZczunWvB9)_