### PR TITLE
fix: 미지정 그룹 종목 삭제 버튼 isMaster 제한 제거

### DIFF
--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -656,7 +656,7 @@ export default function StockListTable({
         doTokenResetOne={doTokenResetOne}
         openDetail={openDetail}
         monthlyPerStock={monthlyPerStock}
-        onDeleteStock={onDeleteStock}
+        onDeleteStock={isMaster && onDeleteStock ? onDeleteStock : undefined}
       />
 
       {/* 상세 분석 모달 */}

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -656,7 +656,7 @@ export default function StockListTable({
         doTokenResetOne={doTokenResetOne}
         openDetail={openDetail}
         monthlyPerStock={monthlyPerStock}
-        onDeleteStock={isMaster && onDeleteStock ? onDeleteStock : undefined}
+        onDeleteStock={onDeleteStock}
       />
 
       {/* 상세 분석 모달 */}


### PR DESCRIPTION
## 변경 요약

`stockListTable.tsx` 미지정 섹션의 삭제 버튼에서 `isMaster &&` 조건을 제거합니다.

### 문제

```tsx
// 변경 전 — isMaster(session.user.name === NEXT_PUBLIC_MASTER)가 false면 버튼 미표시
onDeleteStock={isMaster && onDeleteStock ? onDeleteStock : undefined}
```

`NEXT_PUBLIC_MASTER` 환경변수가 빌드 시 설정되지 않거나, `session.user.name`과 일치하지 않으면 admin 유저도 삭제 버튼을 볼 수 없었습니다.

### 수정

```tsx
// 변경 후 — onDeleteStock prop이 있으면 버튼 표시
onDeleteStock={onDeleteStock}
```

### 보안 근거

- balance 페이지 자체가 admin 전용 (페이지 레벨 인증)
- worker API `/kr/capital/stock/{ticker}/remove`도 `user.role === "admin"` 체크
- 프론트의 `isMaster` 게이트는 불필요한 이중 제한이었음

## 변경 파일

- `cf-idiotquant/components/balance/stockListTable.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZmvL8hb5ZiuEZczunWvB9

---
_Generated by [Claude Code](https://claude.ai/code/session_01NZmvL8hb5ZiuEZczunWvB9)_