### PR TITLE
fix: 종목 작업 실패 사유를 토스트로 노출 (모바일 진단 가능)

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -354,6 +354,13 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
     }
   }, [krGroupOp?.state]);
 
+  // 그룹 작업 실패 시 사유 노출 (모바일에서 원인 확인용)
+  useEffect(() => {
+    if (krGroupOp?.state === "rejected") {
+      addToast("error", krGroupOp.error || "종목 작업에 실패했습니다.");
+    }
+  }, [krGroupOp?.state]);
+
   const doTokenPlusAll = (num: number) => dispatch(reqPostKrCapitalTokenPlusAll({ key: balanceKey, num }));
   const doTokenPlusOne = (num: number, ticker: string) => ticker && dispatch(reqPostKrCapitalTokenPlusOne({ key: balanceKey, num, ticker }));
   const doTokenMinusAll = (num: number) => dispatch(reqPostKrCapitalTokenMinusAll({ key: balanceKey, num }));

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -322,6 +322,13 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
     }
   }, [usGroupOp?.state]);
 
+  // 그룹 작업 실패 시 사유 노출 (모바일에서 원인 확인용)
+  useEffect(() => {
+    if (usGroupOp?.state === "rejected") {
+      addToast("error", usGroupOp.error || "종목 작업에 실패했습니다.");
+    }
+  }, [usGroupOp?.state]);
+
   const doTokenPlusAll = (num: number) => dispatch(reqPostUsCapitalTokenPlusAll({ key: balanceKey, num }));
   const doTokenPlusOne = (num: number, ticker: string) => ticker && dispatch(reqPostUsCapitalTokenPlusOne({ key: balanceKey, num, ticker }));
   const doTokenMinusAll = (num: number) => dispatch(reqPostUsCapitalTokenMinusAll({ key: balanceKey, num }));

--- a/cf-idiotquant/lib/features/capital/capitalSlice.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalSlice.tsx
@@ -119,6 +119,7 @@ export interface KrUsCapitalType {
 
 interface CapitalTokenRefillType {
     state: "init" | "pending" | "fulfilled" | "rejected";
+    error?: string;
 }
 
 export interface CapitalType {
@@ -489,7 +490,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.krGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.krGroupOp.state = "rejected"; state.krGroupOp.error = action.error?.message; },
             }
         ),
         reqPostKrCapitalStocksGroup: create.asyncThunk(
@@ -497,7 +498,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.krGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.krGroupOp.state = "rejected"; state.krGroupOp.error = action.error?.message; },
             }
         ),
         reqPostKrCapitalLikesCopy: create.asyncThunk(
@@ -505,7 +506,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.krGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.krGroupOp.state = "rejected"; state.krGroupOp.error = action.error?.message; },
             }
         ),
         reqPostKrCapitalGroupUpdate: create.asyncThunk(
@@ -513,7 +514,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.krGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.krGroupOp.state = "rejected"; state.krGroupOp.error = action.error?.message; },
             }
         ),
         reqPostKrCapitalGroupDelete: create.asyncThunk(
@@ -521,7 +522,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.krGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.krGroupOp.state = "rejected"; state.krGroupOp.error = action.error?.message; },
             }
         ),
         reqPostKrCapitalStockGroup: create.asyncThunk(
@@ -529,7 +530,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.krGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.krGroupOp.state = "rejected"; state.krGroupOp.error = action.error?.message; },
             }
         ),
 
@@ -539,7 +540,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.usGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.usGroupOp.state = "rejected"; state.usGroupOp.error = action.error?.message; },
             }
         ),
         reqPostUsCapitalStocksGroup: create.asyncThunk(
@@ -547,7 +548,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.usGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.usGroupOp.state = "rejected"; state.usGroupOp.error = action.error?.message; },
             }
         ),
         reqPostUsCapitalLikesCopy: create.asyncThunk(
@@ -555,7 +556,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.usGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.usGroupOp.state = "rejected"; state.usGroupOp.error = action.error?.message; },
             }
         ),
         reqPostUsCapitalGroupUpdate: create.asyncThunk(
@@ -563,7 +564,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.usGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.usGroupOp.state = "rejected"; state.usGroupOp.error = action.error?.message; },
             }
         ),
         reqPostUsCapitalGroupDelete: create.asyncThunk(
@@ -571,7 +572,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.usGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.usGroupOp.state = "rejected"; state.usGroupOp.error = action.error?.message; },
             }
         ),
         reqPostUsCapitalStockGroup: create.asyncThunk(
@@ -579,7 +580,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.usGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.usGroupOp.state = "rejected"; state.usGroupOp.error = action.error?.message; },
             }
         ),
 
@@ -702,7 +703,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.krGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.krGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.krGroupOp.state = "rejected"; state.krGroupOp.error = action.error?.message; },
             }
         ),
         reqPostUsCapitalStockRemove: create.asyncThunk(
@@ -710,7 +711,7 @@ export const capitalSlice = createAppSlice({
             {
                 pending: (state) => { state.usGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
-                rejected: (state) => { state.usGroupOp.state = "rejected"; },
+                rejected: (state, action) => { state.usGroupOp.state = "rejected"; state.usGroupOp.error = action.error?.message; },
             }
         ),
     }),

--- a/cf-idiotquant/lib/features/koreaInvestment/koreaInvestmentAPI.tsx
+++ b/cf-idiotquant/lib/features/koreaInvestment/koreaInvestmentAPI.tsx
@@ -224,13 +224,20 @@ export async function postKoreaInvestmentRequest(
     };
     
     const res = await fetch(url, options);
+    const text = await res.text();
 
     if (!res.ok) {
-        const errorData = await res.json().catch(() => ({}));
-        throw new Error(errorData.message || "프록시 서버 통신 실패 (POST: 500)");
+        let message = text;
+        try { message = JSON.parse(text)?.message || text; } catch { /* 평문 응답 */ }
+        throw new Error(message || `프록시 서버 통신 실패 (POST: ${res.status})`);
     }
 
-    return res.json();
+    try {
+        return JSON.parse(text);
+    } catch {
+        // 백엔드가 JSON이 아닌 평문(예: 권한 거부 'need to valid id')을 200으로 반환한 경우
+        throw new Error(text || "서버 응답을 해석할 수 없습니다.");
+    }
 }
 
 /**


### PR DESCRIPTION
## 배경

balance 페이지 종목관리 탭에서 **미지정 종목 삭제(X)를 눌러도 아무 일이 일어나지 않는** 증상 제보.

원인 추적 결과, 삭제 로직 자체는 정상이나 **요청이 실패했을 때 화면에 아무 표시가 없어** 원인 파악이 불가능했음:
- worker는 권한 거부 시 평문 `need to valid id`를 status 200으로 반환
- 프론트 POST 헬퍼가 이를 `res.json()`으로 파싱하다 조용히 `throw` → thunk `rejected`
- 그런데 `rejected` 상태에 대한 UI 피드백이 없어 사용자에겐 "무반응"으로만 보임

모바일에선 DevTools를 못 쓰므로, **실패 사유를 화면 토스트로 노출**하도록 수정.

## 변경 사항

| 파일 | 변경 |
|---|---|
| `lib/features/koreaInvestment/koreaInvestmentAPI.tsx` | POST 응답을 `text`로 받아 JSON 파싱 실패 시 **본문을 에러 메시지로 throw** (평문 `need to valid id` 등이 그대로 surface). 에러 메시지에 실제 status code 포함. |
| `lib/features/capital/capitalSlice.tsx` | 그룹 작업 `rejected` 핸들러가 `action.error.message`를 `krGroupOp/usGroupOp.error`에 저장. `CapitalTokenRefillType`에 `error?: string` 추가. |
| `components/balance/balanceKrView.tsx` / `balanceUsView.tsx` | 그룹 작업 `rejected` 시 에러 토스트 표시 (KR/US). |

미지정 종목 삭제뿐 아니라 그룹 생성·이동·삭제 등 **모든 capital 그룹 작업**에 공통 적용됨.

## 기대 동작 (모바일에서 X 클릭 시)

- `need to valid id` 토스트 → 계정 role이 admin 아님 (권한 불일치)
- `프록시 서버 통신 실패 (POST: 404)` 류 → worker 미배포
- 토스트 없이 정상 제거 → 정상 동작

## 검증

- `npx tsc --noEmit` 통과 (에러 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_