### PR TITLE
feat: 종목 일괄 삭제 + 그룹별 월 예산 설정 UI

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -379,6 +379,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
   const doDeleteStock = (ticker: string) => dispatch(reqPostKrCapitalStockRemove({ key: balanceKey, ticker }));
   const doBulkRemove = (tickers: string[]) => dispatch(reqPostKrCapitalStocksRemove({ key: balanceKey, tickers }));
   const doSaveGroupQuantRule = (groupId: string, rule: QuantRule | null) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { quant_rule: rule } }));
+  const doSaveGroupBudget = (groupId: string, budget: number | null) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { budget_krw: budget } }));
   const doSaveQuantRule = (rule: any) => dispatch(reqPostKrQuantRule({ key: balanceKey, rule }));
   const doSaveBudget = (monthly_budget_krw: number) => dispatch(reqPostKrCapitalBudget({ key: balanceKey, monthly_budget_krw }));
 
@@ -647,6 +648,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                 onDeleteStock={doDeleteStock}
                 onBulkRemove={doBulkRemove}
                 onSaveGroupQuantRule={doSaveGroupQuantRule}
+                onSaveGroupBudget={doSaveGroupBudget}
                 likedList={krLikedList}
                 countryTradingActive={tradingStatus.KR === true}
                 quantRule={krQuantRule.rule}

--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -38,7 +38,7 @@ import {
   selectKrCapitalTokenResetAll, selectKrCapitalTokenResetOne,
   reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate,
   reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup, reqPostKrCapitalStocksGroup, reqPostKrCapitalLikesCopy,
-  reqPostKrCapitalStockRemove,
+  reqPostKrCapitalStockRemove, reqPostKrCapitalStocksRemove,
   selectKrGroupOp,
   reqGetKrQuantRule, reqPostKrQuantRule, selectKrQuantRule,
   reqGetKrCapitalBudget, reqPostKrCapitalBudget, selectKrBudget,
@@ -377,6 +377,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
   const doBulkMove = (tickers: string[], groupId: string | null) => dispatch(reqPostKrCapitalStocksGroup({ key: balanceKey, tickers, groupId }));
   const doCopyLikes = (tickers: string[], groupId: string | null) => dispatch(reqPostKrCapitalLikesCopy({ key: balanceKey, tickers, groupId }));
   const doDeleteStock = (ticker: string) => dispatch(reqPostKrCapitalStockRemove({ key: balanceKey, ticker }));
+  const doBulkRemove = (tickers: string[]) => dispatch(reqPostKrCapitalStocksRemove({ key: balanceKey, tickers }));
   const doSaveGroupQuantRule = (groupId: string, rule: QuantRule | null) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { quant_rule: rule } }));
   const doSaveQuantRule = (rule: any) => dispatch(reqPostKrQuantRule({ key: balanceKey, rule }));
   const doSaveBudget = (monthly_budget_krw: number) => dispatch(reqPostKrCapitalBudget({ key: balanceKey, monthly_budget_krw }));
@@ -644,6 +645,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                 onBulkMove={doBulkMove}
                 onCopyLikes={doCopyLikes}
                 onDeleteStock={doDeleteStock}
+                onBulkRemove={doBulkRemove}
                 onSaveGroupQuantRule={doSaveGroupQuantRule}
                 likedList={krLikedList}
                 countryTradingActive={tradingStatus.KR === true}

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -347,6 +347,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
   const doDeleteStock = (ticker: string) => dispatch(reqPostUsCapitalStockRemove({ key: balanceKey, ticker }));
   const doBulkRemove = (tickers: string[]) => dispatch(reqPostUsCapitalStocksRemove({ key: balanceKey, tickers }));
   const doSaveGroupQuantRule = (groupId: string, rule: QuantRule | null) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { quant_rule: rule } }));
+  const doSaveGroupBudget = (groupId: string, budget: number | null) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { budget_krw: budget } }));
   const doSaveQuantRule = (rule: any) => dispatch(reqPostUsQuantRule({ key: balanceKey, rule }));
 
   const out2 = kiBalance?.output2?.[0];
@@ -681,6 +682,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
                 onDeleteStock={doDeleteStock}
                 onBulkRemove={doBulkRemove}
                 onSaveGroupQuantRule={doSaveGroupQuantRule}
+                onSaveGroupBudget={doSaveGroupBudget}
                 likedList={usLikedList}
                 countryTradingActive={tradingStatus.US === true}
                 quantRule={usQuantRule.rule}

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -45,7 +45,7 @@ import {
   selectUsCapitalTokenResetAll, selectUsCapitalTokenResetOne,
   reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate,
   reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup, reqPostUsCapitalStocksGroup, reqPostUsCapitalLikesCopy,
-  reqPostUsCapitalStockRemove,
+  reqPostUsCapitalStockRemove, reqPostUsCapitalStocksRemove,
   selectUsGroupOp,
   reqGetUsQuantRule, reqPostUsQuantRule, selectUsQuantRule,
 } from "@/lib/features/capital/capitalSlice";
@@ -345,6 +345,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
   const doBulkMove = (tickers: string[], groupId: string | null) => dispatch(reqPostUsCapitalStocksGroup({ key: balanceKey, tickers, groupId }));
   const doCopyLikes = (tickers: string[], groupId: string | null) => dispatch(reqPostUsCapitalLikesCopy({ key: balanceKey, tickers, groupId }));
   const doDeleteStock = (ticker: string) => dispatch(reqPostUsCapitalStockRemove({ key: balanceKey, ticker }));
+  const doBulkRemove = (tickers: string[]) => dispatch(reqPostUsCapitalStocksRemove({ key: balanceKey, tickers }));
   const doSaveGroupQuantRule = (groupId: string, rule: QuantRule | null) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { quant_rule: rule } }));
   const doSaveQuantRule = (rule: any) => dispatch(reqPostUsQuantRule({ key: balanceKey, rule }));
 
@@ -678,6 +679,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
                 onBulkMove={doBulkMove}
                 onCopyLikes={doCopyLikes}
                 onDeleteStock={doDeleteStock}
+                onBulkRemove={doBulkRemove}
                 onSaveGroupQuantRule={doSaveGroupQuantRule}
                 likedList={usLikedList}
                 countryTradingActive={tradingStatus.US === true}

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -144,6 +144,7 @@ interface Props {
   onBulkMove?: (tickers: string[], groupId: string | null) => void;
   onCopyLikes?: (tickers: string[], groupId: string | null) => void;
   onDeleteStock?: (ticker: string) => void;
+  onBulkRemove?: (tickers: string[]) => void;
   onSaveGroupQuantRule?: (groupId: string, rule: QuantRule | null) => void;
   // 좋아요(찜) 그룹
   likedList?: LikedStockItem[];
@@ -222,6 +223,7 @@ export default function StockListTable({
   onBulkMove,
   onCopyLikes,
   onDeleteStock,
+  onBulkRemove,
   onSaveGroupQuantRule,
   likedList = [],
   onToggleLikesTrading,
@@ -375,6 +377,14 @@ export default function StockListTable({
     if (tickers.length === 0) return;
     onCopyLikes?.(tickers, groupId);
     clearPick();
+  };
+  const doBulkRemove = () => {
+    const tickers = pickedSymbols;
+    if (tickers.length === 0) return;
+    if (window.confirm(`선택한 ${tickers.length}개 종목을 제거할까요?`)) {
+      onBulkRemove?.(tickers);
+      clearPick();
+    }
   };
   const doCreateGroupFromPicked = () => {
     const tickers = pickedSymbols;
@@ -568,6 +578,15 @@ export default function StockListTable({
           >
             <FolderPlus className="w-3.5 h-3.5" /> 새 그룹
           </button>
+          {onBulkRemove && (
+            <button
+              onClick={doBulkRemove}
+              title="선택한 종목을 운용 목록에서 제거"
+              className="inline-flex shrink-0 items-center gap-1 rounded-md border border-red-300 bg-white px-2.5 py-1.5 text-xs font-bold text-red-500 hover:bg-red-50 dark:border-red-900 dark:bg-[#1a1915] dark:hover:bg-red-950"
+            >
+              <Trash2 className="w-3.5 h-3.5" /> 삭제
+            </button>
+          )}
         </div>
       )}
 

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -146,6 +146,7 @@ interface Props {
   onDeleteStock?: (ticker: string) => void;
   onBulkRemove?: (tickers: string[]) => void;
   onSaveGroupQuantRule?: (groupId: string, rule: QuantRule | null) => void;
+  onSaveGroupBudget?: (groupId: string, budget: number | null) => void;
   // 좋아요(찜) 그룹
   likedList?: LikedStockItem[];
   onToggleLikesTrading?: (isActive: boolean) => void;
@@ -225,6 +226,7 @@ export default function StockListTable({
   onDeleteStock,
   onBulkRemove,
   onSaveGroupQuantRule,
+  onSaveGroupBudget,
   likedList = [],
   onToggleLikesTrading,
   countryTradingActive = false,
@@ -649,7 +651,9 @@ export default function StockListTable({
           openDetail={openDetail}
           monthlyPerStock={monthlyPerStock}
           groupQuantRule={g.quant_rule}
+          groupBudget={g.budget_krw}
           onSaveGroupQuantRule={isMaster && onSaveGroupQuantRule ? (rule) => onSaveGroupQuantRule(g.id, rule) : undefined}
+          onSaveGroupBudget={isMaster && onSaveGroupBudget ? (budget) => onSaveGroupBudget(g.id, budget) : undefined}
         />
       ))}
 
@@ -765,7 +769,9 @@ interface GroupSectionProps {
   monthlyPerStock?: number;
   onDeleteStock?: (ticker: string) => void;
   groupQuantRule?: QuantRule;
+  groupBudget?: number;
   onSaveGroupQuantRule?: (rule: QuantRule | null) => void;
+  onSaveGroupBudget?: (budget: number | null) => void;
 }
 
 function GroupSection({
@@ -773,11 +779,12 @@ function GroupSection({
   conditionChips, editing, editingName, onEditNameChange, onStartRename, onCommitRename, onDelete,
   emptyText, collapsed, onToggleCollapse, picked, onTogglePick, onPickMany,
   doTokenPlusOne, doTokenMinusOne, doTokenResetOne, openDetail, monthlyPerStock = 0, onDeleteStock,
-  groupQuantRule, onSaveGroupQuantRule,
+  groupQuantRule, groupBudget, onSaveGroupQuantRule, onSaveGroupBudget,
 }: GroupSectionProps) {
   const [showRuleEditor, setShowRuleEditor] = useState(false);
   const [draftActiveCount, setDraftActiveCount] = useState<string>("");
   const [draftNcavRatio, setDraftNcavRatio] = useState<string>("");
+  const [draftBudget, setDraftBudget] = useState<string>("");
   const showRefill = isMaster && rows.some(r => r.movable);
   const showCheck = isMaster && rows.length > 0; // 모든 행 선택 가능(좋아요는 복사용)
   const selectableTickers = useMemo(() => rows.map(r => r.symbol), [rows]);
@@ -870,6 +877,7 @@ function GroupSection({
               onClick={() => {
                 setDraftActiveCount(String(groupQuantRule?.active_count ?? ""));
                 setDraftNcavRatio(String(groupQuantRule?.ncav_ratio ?? ""));
+                setDraftBudget(groupBudget != null ? String(groupBudget) : "");
                 setShowRuleEditor(v => !v);
               }}
               title="이 그룹의 트레이딩 조건 설정"
@@ -949,10 +957,24 @@ function GroupSection({
                 className="w-20 rounded border border-neutral-300 dark:border-[#4a4641] bg-white dark:bg-[#1a1915] px-2 py-1 text-xs"
               />
             </div>
+            {onSaveGroupBudget && (
+              <div className="flex items-center gap-1.5">
+                <label className="text-[11px] text-neutral-500 shrink-0">월 예산(원)</label>
+                <input
+                  type="number"
+                  min={0}
+                  step={10000}
+                  value={draftBudget}
+                  onChange={e => setDraftBudget(e.target.value)}
+                  placeholder="계좌예산 분배"
+                  className="w-28 rounded border border-neutral-300 dark:border-[#4a4641] bg-white dark:bg-[#1a1915] px-2 py-1 text-xs"
+                />
+              </div>
+            )}
             <div className="flex items-center gap-1.5 ml-auto">
-              {groupQuantRule && (
+              {(groupQuantRule || groupBudget != null) && (
                 <button
-                  onClick={() => { onSaveGroupQuantRule(null); setShowRuleEditor(false); }}
+                  onClick={() => { onSaveGroupQuantRule(null); onSaveGroupBudget?.(null); setShowRuleEditor(false); }}
                   className="rounded px-2.5 py-1 text-xs text-neutral-500 hover:text-red-600 border border-neutral-200 dark:border-[#4a4641]"
                 >
                   초기화
@@ -972,6 +994,10 @@ function GroupSection({
                   const nr = parseFloat(draftNcavRatio);
                   if (!isNaN(nr)) rule.ncav_ratio = nr;
                   onSaveGroupQuantRule(Object.keys(rule).length > 0 ? rule : null);
+                  if (onSaveGroupBudget) {
+                    const b = parseInt(draftBudget, 10);
+                    onSaveGroupBudget(!isNaN(b) && b > 0 ? b : null);
+                  }
                   setShowRuleEditor(false);
                 }}
                 className="rounded px-2.5 py-1 text-xs font-bold bg-[#16a34a] text-white hover:bg-[#15803d]"

--- a/cf-idiotquant/lib/features/capital/capitalAPI.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalAPI.tsx
@@ -148,3 +148,7 @@ export const postKrCapitalStockRemove: any = async (key: string, ticker: string)
     postKoreaInvestmentRequest(`/kr/capital/stock/${ticker}/remove?kakao-id=${key}`, {});
 export const postUsCapitalStockRemove: any = async (key: string, ticker: string) =>
     postKoreaInvestmentRequest(`/us/capital/stock/${ticker}/remove?kakao-id=${key}`, {});
+export const postKrCapitalStocksRemove: any = async (key: string, tickers: string[]) =>
+    postKoreaInvestmentRequest(`/kr/capital/stocks/remove?kakao-id=${key}`, {}, { tickers });
+export const postUsCapitalStocksRemove: any = async (key: string, tickers: string[]) =>
+    postKoreaInvestmentRequest(`/us/capital/stocks/remove?kakao-id=${key}`, {}, { tickers });

--- a/cf-idiotquant/lib/features/capital/capitalAPI.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalAPI.tsx
@@ -77,7 +77,7 @@ export const postUsCapitalTokenMinusOne: any = async (key: string, num: number, 
 // ============================================================================
 // 종목 그룹 관리 API (KR / US)
 // ============================================================================
-type GroupUpdates = { name?: string; is_trading_active?: boolean };
+type GroupUpdates = { name?: string; is_trading_active?: boolean; quant_rule?: object | null; budget_krw?: number | null };
 
 // KR
 export const postKrCapitalGroupCreate: any = async (key: string, name: string, tickers?: string[]) =>

--- a/cf-idiotquant/lib/features/capital/capitalSlice.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalSlice.tsx
@@ -1,6 +1,6 @@
 import { PayloadAction } from "@reduxjs/toolkit";
 import { createAppSlice } from "@/lib/createAppSlice";
-import { getKrCapital, getUsCapital, postKrCapitalTokenMinusAll, postKrCapitalTokenMinusOne, postKrCapitalTokenPlusAll, postKrCapitalTokenPlusOne, postUsCapitalTokenMinusAll, postUsCapitalTokenMinusOne, postUsCapitalTokenPlusAll, postUsCapitalTokenPlusOne, postKrCapitalGroupCreate, postKrCapitalGroupUpdate, postKrCapitalGroupDelete, postKrCapitalStockGroup, postKrCapitalStocksGroup, postKrCapitalLikesCopy, postUsCapitalGroupCreate, postUsCapitalGroupUpdate, postUsCapitalGroupDelete, postUsCapitalStockGroup, postUsCapitalStocksGroup, postUsCapitalLikesCopy, getKrQuantRule, postKrQuantRule, getUsQuantRule, postUsQuantRule, getKrCapitalBudget, postKrCapitalBudget, postKrCapitalTokenResetAll, postKrCapitalTokenResetOne, postUsCapitalTokenResetAll, postUsCapitalTokenResetOne, postKrCapitalStockRemove, postUsCapitalStockRemove } from "./capitalAPI";
+import { getKrCapital, getUsCapital, postKrCapitalTokenMinusAll, postKrCapitalTokenMinusOne, postKrCapitalTokenPlusAll, postKrCapitalTokenPlusOne, postUsCapitalTokenMinusAll, postUsCapitalTokenMinusOne, postUsCapitalTokenPlusAll, postUsCapitalTokenPlusOne, postKrCapitalGroupCreate, postKrCapitalGroupUpdate, postKrCapitalGroupDelete, postKrCapitalStockGroup, postKrCapitalStocksGroup, postKrCapitalLikesCopy, postUsCapitalGroupCreate, postUsCapitalGroupUpdate, postUsCapitalGroupDelete, postUsCapitalStockGroup, postUsCapitalStocksGroup, postUsCapitalLikesCopy, getKrQuantRule, postKrQuantRule, getUsQuantRule, postUsQuantRule, getKrCapitalBudget, postKrCapitalBudget, postKrCapitalTokenResetAll, postKrCapitalTokenResetOne, postUsCapitalTokenResetAll, postUsCapitalTokenResetOne, postKrCapitalStockRemove, postUsCapitalStockRemove, postKrCapitalStocksRemove, postUsCapitalStocksRemove } from "./capitalAPI";
 
 /** 예약(가상) 그룹 id — 좋아요(찜) 종목 그룹 */
 export const LIKES_GROUP_ID = "__likes__";
@@ -714,6 +714,23 @@ export const capitalSlice = createAppSlice({
                 rejected: (state, action) => { state.usGroupOp.state = "rejected"; state.usGroupOp.error = action.error?.message; },
             }
         ),
+        // ── 종목 일괄 제거 ──
+        reqPostKrCapitalStocksRemove: create.asyncThunk(
+            async ({ key, tickers }: { key?: string, tickers: string[] }) => postKrCapitalStocksRemove(key, tickers),
+            {
+                pending: (state) => { state.krGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
+                rejected: (state, action) => { state.krGroupOp.state = "rejected"; state.krGroupOp.error = action.error?.message; },
+            }
+        ),
+        reqPostUsCapitalStocksRemove: create.asyncThunk(
+            async ({ key, tickers }: { key?: string, tickers: string[] }) => postUsCapitalStocksRemove(key, tickers),
+            {
+                pending: (state) => { state.usGroupOp.state = "pending"; },
+                fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },
+                rejected: (state, action) => { state.usGroupOp.state = "rejected"; state.usGroupOp.error = action.error?.message; },
+            }
+        ),
     }),
     selectors: {
         selectKrCapital: (state) => state.krCapital,
@@ -740,8 +757,8 @@ export const capitalSlice = createAppSlice({
 
 export const { reqGetKrCapital, reqPostKrCapitalTokenPlusAll, reqPostKrCapitalTokenPlusOne, reqPostKrCapitalTokenMinusAll, reqPostKrCapitalTokenMinusOne, reqPostKrCapitalTokenResetAll, reqPostKrCapitalTokenResetOne } = capitalSlice.actions;
 export const { selectKrCapital, selectKrCapitalTokenPlusAll, selectKrCapitalTokenPlusOne, selectKrCapitalTokenMinusAll, selectKrCapitalTokenMinusOne, selectKrCapitalTokenResetAll, selectKrCapitalTokenResetOne } = capitalSlice.selectors;
-export const { reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate, reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup, reqPostKrCapitalStocksGroup, reqPostKrCapitalLikesCopy, reqPostKrCapitalStockRemove } = capitalSlice.actions;
-export const { reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate, reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup, reqPostUsCapitalStocksGroup, reqPostUsCapitalLikesCopy, reqPostUsCapitalStockRemove } = capitalSlice.actions;
+export const { reqPostKrCapitalGroupCreate, reqPostKrCapitalGroupUpdate, reqPostKrCapitalGroupDelete, reqPostKrCapitalStockGroup, reqPostKrCapitalStocksGroup, reqPostKrCapitalLikesCopy, reqPostKrCapitalStockRemove, reqPostKrCapitalStocksRemove } = capitalSlice.actions;
+export const { reqPostUsCapitalGroupCreate, reqPostUsCapitalGroupUpdate, reqPostUsCapitalGroupDelete, reqPostUsCapitalStockGroup, reqPostUsCapitalStocksGroup, reqPostUsCapitalLikesCopy, reqPostUsCapitalStockRemove, reqPostUsCapitalStocksRemove } = capitalSlice.actions;
 export const { selectKrGroupOp, selectUsGroupOp } = capitalSlice.selectors;
 export const { reqGetKrQuantRule, reqPostKrQuantRule, reqGetUsQuantRule, reqPostUsQuantRule } = capitalSlice.actions;
 export const { selectKrQuantRule, selectUsQuantRule } = capitalSlice.selectors;

--- a/cf-idiotquant/lib/features/capital/capitalSlice.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalSlice.tsx
@@ -92,6 +92,7 @@ export interface StockGroup {
     name: string;
     is_trading_active: boolean;
     quant_rule?: QuantRule;
+    budget_krw?: number;   // 그룹별 월 예산(DCA 리필). 미설정 시 계좌예산 fallback.
 }
 
 export interface UsCapitalStockItem {
@@ -510,7 +511,7 @@ export const capitalSlice = createAppSlice({
             }
         ),
         reqPostKrCapitalGroupUpdate: create.asyncThunk(
-            async ({ key, groupId, updates }: { key?: string, groupId: string, updates: { name?: string, is_trading_active?: boolean, quant_rule?: QuantRule | null } }) => postKrCapitalGroupUpdate(key, groupId, updates),
+            async ({ key, groupId, updates }: { key?: string, groupId: string, updates: { name?: string, is_trading_active?: boolean, quant_rule?: QuantRule | null, budget_krw?: number | null } }) => postKrCapitalGroupUpdate(key, groupId, updates),
             {
                 pending: (state) => { state.krGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
@@ -560,7 +561,7 @@ export const capitalSlice = createAppSlice({
             }
         ),
         reqPostUsCapitalGroupUpdate: create.asyncThunk(
-            async ({ key, groupId, updates }: { key?: string, groupId: string, updates: { name?: string, is_trading_active?: boolean, quant_rule?: QuantRule | null } }) => postUsCapitalGroupUpdate(key, groupId, updates),
+            async ({ key, groupId, updates }: { key?: string, groupId: string, updates: { name?: string, is_trading_active?: boolean, quant_rule?: QuantRule | null, budget_krw?: number | null } }) => postUsCapitalGroupUpdate(key, groupId, updates),
             {
                 pending: (state) => { state.usGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },


### PR DESCRIPTION
## 개요

미지정 종목 일괄 삭제와 그룹별 월 예산 입력 UI (worker 변경과 짝).

## 변경 사항

### 1. 종목 일괄 삭제 (`35f0720`)
- `postKr/UsCapitalStocksRemove` API + `reqPostKr/UsCapitalStocksRemove` thunk (기존 `krGroupOp`/`usGroupOp` 상태 재사용 → 완료 시 자동 재조회·실패 시 토스트 그대로 적용).
- 선택 작업 바에 빨간 **"삭제"** 버튼 추가. 미지정 섹션의 "전체선택" 체크 → 삭제로 미지정 전체를 한 번에 제거 가능.
- 백엔드 `POST /capital/stocks/remove`(body tickers[]) 호출.

### 2. 그룹별 월 예산 설정 UI (`242a7b5`)
- 그룹 조건 편집 패널에 **"월 예산(원)"** 입력칸 추가. 설정 시 해당 그룹 DCA 리필이 그 예산으로 분배, 비우면 계좌예산 fallback.
- `StockGroup`/group-update thunk/`GroupUpdates` 타입에 `budget_krw` 추가.
- `balanceKr/UsView`: `doSaveGroupBudget` → `reqPostKr/UsCapitalGroupUpdate({ budget_krw })`.

## 검증
- `npx tsc --noEmit` 통과 (에러 0).

## 의존성
그룹 예산/일괄삭제의 실제 동작은 짝이 되는 **worker PR 머지 + 배포** 후 적용됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_