### PR TITLE
fix: 그룹 조건+예산 저장을 단일 요청으로 (lost-update race 제거)

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -378,8 +378,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
   const doCopyLikes = (tickers: string[], groupId: string | null) => dispatch(reqPostKrCapitalLikesCopy({ key: balanceKey, tickers, groupId }));
   const doDeleteStock = (ticker: string) => dispatch(reqPostKrCapitalStockRemove({ key: balanceKey, ticker }));
   const doBulkRemove = (tickers: string[]) => dispatch(reqPostKrCapitalStocksRemove({ key: balanceKey, tickers }));
-  const doSaveGroupQuantRule = (groupId: string, rule: QuantRule | null) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { quant_rule: rule } }));
-  const doSaveGroupBudget = (groupId: string, budget: number | null) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { budget_krw: budget } }));
+  const doSaveGroupSettings = (groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: settings }));
   const doSaveQuantRule = (rule: any) => dispatch(reqPostKrQuantRule({ key: balanceKey, rule }));
   const doSaveBudget = (monthly_budget_krw: number) => dispatch(reqPostKrCapitalBudget({ key: balanceKey, monthly_budget_krw }));
 
@@ -647,8 +646,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                 onCopyLikes={doCopyLikes}
                 onDeleteStock={doDeleteStock}
                 onBulkRemove={doBulkRemove}
-                onSaveGroupQuantRule={doSaveGroupQuantRule}
-                onSaveGroupBudget={doSaveGroupBudget}
+                onSaveGroupSettings={doSaveGroupSettings}
                 likedList={krLikedList}
                 countryTradingActive={tradingStatus.KR === true}
                 quantRule={krQuantRule.rule}

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -346,8 +346,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
   const doCopyLikes = (tickers: string[], groupId: string | null) => dispatch(reqPostUsCapitalLikesCopy({ key: balanceKey, tickers, groupId }));
   const doDeleteStock = (ticker: string) => dispatch(reqPostUsCapitalStockRemove({ key: balanceKey, ticker }));
   const doBulkRemove = (tickers: string[]) => dispatch(reqPostUsCapitalStocksRemove({ key: balanceKey, tickers }));
-  const doSaveGroupQuantRule = (groupId: string, rule: QuantRule | null) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { quant_rule: rule } }));
-  const doSaveGroupBudget = (groupId: string, budget: number | null) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { budget_krw: budget } }));
+  const doSaveGroupSettings = (groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: settings }));
   const doSaveQuantRule = (rule: any) => dispatch(reqPostUsQuantRule({ key: balanceKey, rule }));
 
   const out2 = kiBalance?.output2?.[0];
@@ -681,8 +680,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
                 onCopyLikes={doCopyLikes}
                 onDeleteStock={doDeleteStock}
                 onBulkRemove={doBulkRemove}
-                onSaveGroupQuantRule={doSaveGroupQuantRule}
-                onSaveGroupBudget={doSaveGroupBudget}
+                onSaveGroupSettings={doSaveGroupSettings}
                 likedList={usLikedList}
                 countryTradingActive={tradingStatus.US === true}
                 quantRule={usQuantRule.rule}

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -145,8 +145,7 @@ interface Props {
   onCopyLikes?: (tickers: string[], groupId: string | null) => void;
   onDeleteStock?: (ticker: string) => void;
   onBulkRemove?: (tickers: string[]) => void;
-  onSaveGroupQuantRule?: (groupId: string, rule: QuantRule | null) => void;
-  onSaveGroupBudget?: (groupId: string, budget: number | null) => void;
+  onSaveGroupSettings?: (groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => void;
   // 좋아요(찜) 그룹
   likedList?: LikedStockItem[];
   onToggleLikesTrading?: (isActive: boolean) => void;
@@ -225,8 +224,7 @@ export default function StockListTable({
   onCopyLikes,
   onDeleteStock,
   onBulkRemove,
-  onSaveGroupQuantRule,
-  onSaveGroupBudget,
+  onSaveGroupSettings,
   likedList = [],
   onToggleLikesTrading,
   countryTradingActive = false,
@@ -652,8 +650,7 @@ export default function StockListTable({
           monthlyPerStock={monthlyPerStock}
           groupQuantRule={g.quant_rule}
           groupBudget={g.budget_krw}
-          onSaveGroupQuantRule={isMaster && onSaveGroupQuantRule ? (rule) => onSaveGroupQuantRule(g.id, rule) : undefined}
-          onSaveGroupBudget={isMaster && onSaveGroupBudget ? (budget) => onSaveGroupBudget(g.id, budget) : undefined}
+          onSaveGroupSettings={isMaster && onSaveGroupSettings ? (settings) => onSaveGroupSettings(g.id, settings) : undefined}
         />
       ))}
 
@@ -770,8 +767,7 @@ interface GroupSectionProps {
   onDeleteStock?: (ticker: string) => void;
   groupQuantRule?: QuantRule;
   groupBudget?: number;
-  onSaveGroupQuantRule?: (rule: QuantRule | null) => void;
-  onSaveGroupBudget?: (budget: number | null) => void;
+  onSaveGroupSettings?: (settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => void;
 }
 
 function GroupSection({
@@ -779,7 +775,7 @@ function GroupSection({
   conditionChips, editing, editingName, onEditNameChange, onStartRename, onCommitRename, onDelete,
   emptyText, collapsed, onToggleCollapse, picked, onTogglePick, onPickMany,
   doTokenPlusOne, doTokenMinusOne, doTokenResetOne, openDetail, monthlyPerStock = 0, onDeleteStock,
-  groupQuantRule, groupBudget, onSaveGroupQuantRule, onSaveGroupBudget,
+  groupQuantRule, groupBudget, onSaveGroupSettings,
 }: GroupSectionProps) {
   const [showRuleEditor, setShowRuleEditor] = useState(false);
   const [draftActiveCount, setDraftActiveCount] = useState<string>("");
@@ -872,7 +868,7 @@ function GroupSection({
             </div>
           )}
           {/* 그룹별 트레이딩 조건 편집 버튼 */}
-          {onSaveGroupQuantRule && tradingActive && (
+          {onSaveGroupSettings && tradingActive && (
             <button
               onClick={() => {
                 setDraftActiveCount(String(groupQuantRule?.active_count ?? ""));
@@ -928,7 +924,7 @@ function GroupSection({
       </div>
 
       {/* 그룹별 트레이딩 조건 인라인 편집 패널 */}
-      {showRuleEditor && onSaveGroupQuantRule && (
+      {showRuleEditor && onSaveGroupSettings && (
         <div className="border-b border-neutral-100 dark:border-[#35332e] bg-[#f8fdf9] dark:bg-[#1a2a1a]/50 px-4 py-3">
           <div className="flex flex-wrap items-end gap-3">
             <span className="text-[11px] font-bold text-[#16a34a] uppercase tracking-wider shrink-0">그룹 조건 설정</span>
@@ -957,24 +953,22 @@ function GroupSection({
                 className="w-20 rounded border border-neutral-300 dark:border-[#4a4641] bg-white dark:bg-[#1a1915] px-2 py-1 text-xs"
               />
             </div>
-            {onSaveGroupBudget && (
-              <div className="flex items-center gap-1.5">
-                <label className="text-[11px] text-neutral-500 shrink-0">월 예산(원)</label>
-                <input
-                  type="number"
-                  min={0}
-                  step={10000}
-                  value={draftBudget}
-                  onChange={e => setDraftBudget(e.target.value)}
-                  placeholder="계좌예산 분배"
-                  className="w-28 rounded border border-neutral-300 dark:border-[#4a4641] bg-white dark:bg-[#1a1915] px-2 py-1 text-xs"
-                />
-              </div>
-            )}
+            <div className="flex items-center gap-1.5">
+              <label className="text-[11px] text-neutral-500 shrink-0">월 예산(원)</label>
+              <input
+                type="number"
+                min={0}
+                step={10000}
+                value={draftBudget}
+                onChange={e => setDraftBudget(e.target.value)}
+                placeholder="계좌예산 분배"
+                className="w-28 rounded border border-neutral-300 dark:border-[#4a4641] bg-white dark:bg-[#1a1915] px-2 py-1 text-xs"
+              />
+            </div>
             <div className="flex items-center gap-1.5 ml-auto">
               {(groupQuantRule || groupBudget != null) && (
                 <button
-                  onClick={() => { onSaveGroupQuantRule(null); onSaveGroupBudget?.(null); setShowRuleEditor(false); }}
+                  onClick={() => { onSaveGroupSettings({ quant_rule: null, budget_krw: null }); setShowRuleEditor(false); }}
                   className="rounded px-2.5 py-1 text-xs text-neutral-500 hover:text-red-600 border border-neutral-200 dark:border-[#4a4641]"
                 >
                   초기화
@@ -993,11 +987,11 @@ function GroupSection({
                   if (!isNaN(ac) && ac > 0) rule.active_count = ac;
                   const nr = parseFloat(draftNcavRatio);
                   if (!isNaN(nr)) rule.ncav_ratio = nr;
-                  onSaveGroupQuantRule(Object.keys(rule).length > 0 ? rule : null);
-                  if (onSaveGroupBudget) {
-                    const b = parseInt(draftBudget, 10);
-                    onSaveGroupBudget(!isNaN(b) && b > 0 ? b : null);
-                  }
+                  const b = parseInt(draftBudget, 10);
+                  onSaveGroupSettings({
+                    quant_rule: Object.keys(rule).length > 0 ? rule : null,
+                    budget_krw: !isNaN(b) && b > 0 ? b : null,
+                  });
                   setShowRuleEditor(false);
                 }}
                 className="rounded px-2.5 py-1 text-xs font-bold bg-[#16a34a] text-white hover:bg-[#15803d]"


### PR DESCRIPTION
## 배경

그룹 조건 편집 패널에서 저장 시 `onSaveGroupQuantRule` + `onSaveGroupBudget` **두 thunk를 동시 dispatch**했음. 둘 다 같은 `capital_token`을 읽고 쓰는 **lost-update race**라, 한쪽 변경이 덮어써지거나 재조회가 꼬여 **그룹이 잠깐 비어 보이는** 문제가 있었음. (실제 데이터 손실은 아니나 혼란 유발.)

## 변경 사항

- `onSaveGroupQuantRule` / `onSaveGroupBudget` 두 콜백을 **`onSaveGroupSettings` 하나로 통합**. `quant_rule` + `budget_krw`를 **한 번의 `CapitalGroupUpdate` 요청**으로 원자적 저장.
- `stockListTable`: 저장/초기화/입력 패널을 단일 콜백으로 정리.
- `balanceKr/UsView`: `doSaveGroupSettings` 단일 핸들러.

## 검증
- `npx tsc --noEmit` 통과 (에러 0).

## 참고
- 짝이 되는 worker의 `budget_krw` 저장 지원은 이미 main(#59)에 반영됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_