### PR TITLE
perf: balance 페이지 렌더/번들 최적화

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -51,7 +51,13 @@ import StockListTable from "@/components/balance/stockListTable";
 import QuantRuleEditor from "@/components/balance/quantRuleEditor";
 import RefillSettings from "@/components/balance/refillSettings";
 import TradingFlowSummary from "@/components/balance/tradingFlowSummary";
-import { PortfolioChartSection } from "@/components/balance/portfolioChart";
+import dynamic from "next/dynamic";
+import { ChartSectionSkeleton } from "@/components/balance/shared";
+// recharts(무거움)를 초기 번들에서 제외 — 차트 섹션 표시 시점에 로드
+const PortfolioChartSection = dynamic(
+  () => import("@/components/balance/portfolioChart").then(m => ({ default: m.PortfolioChartSection })),
+  { ssr: false, loading: () => <ChartSectionSkeleton /> }
+);
 import { type NavSection } from "@/components/balance/sectionNav";
 import { BalanceShell } from "@/components/balance/balanceShell";
 import {
@@ -361,24 +367,25 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
     }
   }, [krGroupOp?.state]);
 
-  const doTokenPlusAll = (num: number) => dispatch(reqPostKrCapitalTokenPlusAll({ key: balanceKey, num }));
-  const doTokenPlusOne = (num: number, ticker: string) => ticker && dispatch(reqPostKrCapitalTokenPlusOne({ key: balanceKey, num, ticker }));
-  const doTokenMinusAll = (num: number) => dispatch(reqPostKrCapitalTokenMinusAll({ key: balanceKey, num }));
-  const doTokenMinusOne = (num: number, ticker: string) => ticker && dispatch(reqPostKrCapitalTokenMinusOne({ key: balanceKey, num, ticker }));
-  const doTokenResetAll = () => dispatch(reqPostKrCapitalTokenResetAll({ key: balanceKey }));
-  const doTokenResetOne = (ticker: string) => ticker && dispatch(reqPostKrCapitalTokenResetOne({ key: balanceKey, ticker }));
+  // StockListTable(memo)에 전달되는 핸들러 — useCallback으로 참조 고정해 잔고 자동새로고침 등에서 테이블 재렌더 방지
+  const doTokenPlusAll = useCallback((num: number) => dispatch(reqPostKrCapitalTokenPlusAll({ key: balanceKey, num })), [dispatch, balanceKey]);
+  const doTokenPlusOne = useCallback((num: number, ticker: string) => { if (ticker) dispatch(reqPostKrCapitalTokenPlusOne({ key: balanceKey, num, ticker })); }, [dispatch, balanceKey]);
+  const doTokenMinusAll = useCallback((num: number) => dispatch(reqPostKrCapitalTokenMinusAll({ key: balanceKey, num })), [dispatch, balanceKey]);
+  const doTokenMinusOne = useCallback((num: number, ticker: string) => { if (ticker) dispatch(reqPostKrCapitalTokenMinusOne({ key: balanceKey, num, ticker })); }, [dispatch, balanceKey]);
+  const doTokenResetAll = useCallback(() => dispatch(reqPostKrCapitalTokenResetAll({ key: balanceKey })), [dispatch, balanceKey]);
+  const doTokenResetOne = useCallback((ticker: string) => { if (ticker) dispatch(reqPostKrCapitalTokenResetOne({ key: balanceKey, ticker })); }, [dispatch, balanceKey]);
 
   // 그룹 관리 핸들러
-  const doCreateGroup = (name: string, tickers?: string[]) => dispatch(reqPostKrCapitalGroupCreate({ key: balanceKey, name, tickers }));
-  const doRenameGroup = (groupId: string, name: string) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { name } }));
-  const doToggleGroupTrading = (groupId: string, isActive: boolean) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { is_trading_active: isActive } }));
-  const doDeleteGroup = (groupId: string) => dispatch(reqPostKrCapitalGroupDelete({ key: balanceKey, groupId }));
-  const doMoveStock = (ticker: string, groupId: string | null) => dispatch(reqPostKrCapitalStockGroup({ key: balanceKey, ticker, groupId }));
-  const doBulkMove = (tickers: string[], groupId: string | null) => dispatch(reqPostKrCapitalStocksGroup({ key: balanceKey, tickers, groupId }));
-  const doCopyLikes = (tickers: string[], groupId: string | null) => dispatch(reqPostKrCapitalLikesCopy({ key: balanceKey, tickers, groupId }));
-  const doDeleteStock = (ticker: string) => dispatch(reqPostKrCapitalStockRemove({ key: balanceKey, ticker }));
-  const doBulkRemove = (tickers: string[]) => dispatch(reqPostKrCapitalStocksRemove({ key: balanceKey, tickers }));
-  const doSaveGroupSettings = (groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: settings }));
+  const doCreateGroup = useCallback((name: string, tickers?: string[]) => dispatch(reqPostKrCapitalGroupCreate({ key: balanceKey, name, tickers })), [dispatch, balanceKey]);
+  const doRenameGroup = useCallback((groupId: string, name: string) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { name } })), [dispatch, balanceKey]);
+  const doToggleGroupTrading = useCallback((groupId: string, isActive: boolean) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: { is_trading_active: isActive } })), [dispatch, balanceKey]);
+  const doDeleteGroup = useCallback((groupId: string) => dispatch(reqPostKrCapitalGroupDelete({ key: balanceKey, groupId })), [dispatch, balanceKey]);
+  const doMoveStock = useCallback((ticker: string, groupId: string | null) => dispatch(reqPostKrCapitalStockGroup({ key: balanceKey, ticker, groupId })), [dispatch, balanceKey]);
+  const doBulkMove = useCallback((tickers: string[], groupId: string | null) => dispatch(reqPostKrCapitalStocksGroup({ key: balanceKey, tickers, groupId })), [dispatch, balanceKey]);
+  const doCopyLikes = useCallback((tickers: string[], groupId: string | null) => dispatch(reqPostKrCapitalLikesCopy({ key: balanceKey, tickers, groupId })), [dispatch, balanceKey]);
+  const doDeleteStock = useCallback((ticker: string) => dispatch(reqPostKrCapitalStockRemove({ key: balanceKey, ticker })), [dispatch, balanceKey]);
+  const doBulkRemove = useCallback((tickers: string[]) => dispatch(reqPostKrCapitalStocksRemove({ key: balanceKey, tickers })), [dispatch, balanceKey]);
+  const doSaveGroupSettings = useCallback((groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: settings })), [dispatch, balanceKey]);
   const doSaveQuantRule = (rule: any) => dispatch(reqPostKrQuantRule({ key: balanceKey, rule }));
   const doSaveBudget = (monthly_budget_krw: number) => dispatch(reqPostKrCapitalBudget({ key: balanceKey, monthly_budget_krw }));
 

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -56,7 +56,13 @@ import InquireBalanceResult from "@/components/inquireBalanceResult";
 import QuantRuleEditor from "@/components/balance/quantRuleEditor";
 import TradingFlowSummary from "@/components/balance/tradingFlowSummary";
 import StockListTable from "@/components/balance/stockListTable";
-import { PortfolioChartSection } from "@/components/balance/portfolioChart";
+import dynamic from "next/dynamic";
+import { ChartSectionSkeleton } from "@/components/balance/shared";
+// recharts(무거움)를 초기 번들에서 제외 — 차트 섹션 표시 시점에 로드
+const PortfolioChartSection = dynamic(
+  () => import("@/components/balance/portfolioChart").then(m => ({ default: m.PortfolioChartSection })),
+  { ssr: false, loading: () => <ChartSectionSkeleton /> }
+);
 import { type NavSection } from "@/components/balance/sectionNav";
 import { BalanceShell } from "@/components/balance/balanceShell";
 import {
@@ -329,24 +335,25 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
     }
   }, [usGroupOp?.state]);
 
-  const doTokenPlusAll = (num: number) => dispatch(reqPostUsCapitalTokenPlusAll({ key: balanceKey, num }));
-  const doTokenPlusOne = (num: number, ticker: string) => ticker && dispatch(reqPostUsCapitalTokenPlusOne({ key: balanceKey, num, ticker }));
-  const doTokenMinusAll = (num: number) => dispatch(reqPostUsCapitalTokenMinusAll({ key: balanceKey, num }));
-  const doTokenMinusOne = (num: number, ticker: string) => ticker && dispatch(reqPostUsCapitalTokenMinusOne({ key: balanceKey, num, ticker }));
-  const doTokenResetAll = () => dispatch(reqPostUsCapitalTokenResetAll({ key: balanceKey }));
-  const doTokenResetOne = (ticker: string) => ticker && dispatch(reqPostUsCapitalTokenResetOne({ key: balanceKey, ticker }));
+  // StockListTable(memo)에 전달되는 핸들러 — useCallback으로 참조 고정해 잔고 자동새로고침 등에서 테이블 재렌더 방지
+  const doTokenPlusAll = useCallback((num: number) => dispatch(reqPostUsCapitalTokenPlusAll({ key: balanceKey, num })), [dispatch, balanceKey]);
+  const doTokenPlusOne = useCallback((num: number, ticker: string) => { if (ticker) dispatch(reqPostUsCapitalTokenPlusOne({ key: balanceKey, num, ticker })); }, [dispatch, balanceKey]);
+  const doTokenMinusAll = useCallback((num: number) => dispatch(reqPostUsCapitalTokenMinusAll({ key: balanceKey, num })), [dispatch, balanceKey]);
+  const doTokenMinusOne = useCallback((num: number, ticker: string) => { if (ticker) dispatch(reqPostUsCapitalTokenMinusOne({ key: balanceKey, num, ticker })); }, [dispatch, balanceKey]);
+  const doTokenResetAll = useCallback(() => dispatch(reqPostUsCapitalTokenResetAll({ key: balanceKey })), [dispatch, balanceKey]);
+  const doTokenResetOne = useCallback((ticker: string) => { if (ticker) dispatch(reqPostUsCapitalTokenResetOne({ key: balanceKey, ticker })); }, [dispatch, balanceKey]);
 
   // 그룹 관리 핸들러
-  const doCreateGroup = (name: string, tickers?: string[]) => dispatch(reqPostUsCapitalGroupCreate({ key: balanceKey, name, tickers }));
-  const doRenameGroup = (groupId: string, name: string) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { name } }));
-  const doToggleGroupTrading = (groupId: string, isActive: boolean) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { is_trading_active: isActive } }));
-  const doDeleteGroup = (groupId: string) => dispatch(reqPostUsCapitalGroupDelete({ key: balanceKey, groupId }));
-  const doMoveStock = (ticker: string, groupId: string | null) => dispatch(reqPostUsCapitalStockGroup({ key: balanceKey, ticker, groupId }));
-  const doBulkMove = (tickers: string[], groupId: string | null) => dispatch(reqPostUsCapitalStocksGroup({ key: balanceKey, tickers, groupId }));
-  const doCopyLikes = (tickers: string[], groupId: string | null) => dispatch(reqPostUsCapitalLikesCopy({ key: balanceKey, tickers, groupId }));
-  const doDeleteStock = (ticker: string) => dispatch(reqPostUsCapitalStockRemove({ key: balanceKey, ticker }));
-  const doBulkRemove = (tickers: string[]) => dispatch(reqPostUsCapitalStocksRemove({ key: balanceKey, tickers }));
-  const doSaveGroupSettings = (groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: settings }));
+  const doCreateGroup = useCallback((name: string, tickers?: string[]) => dispatch(reqPostUsCapitalGroupCreate({ key: balanceKey, name, tickers })), [dispatch, balanceKey]);
+  const doRenameGroup = useCallback((groupId: string, name: string) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { name } })), [dispatch, balanceKey]);
+  const doToggleGroupTrading = useCallback((groupId: string, isActive: boolean) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: { is_trading_active: isActive } })), [dispatch, balanceKey]);
+  const doDeleteGroup = useCallback((groupId: string) => dispatch(reqPostUsCapitalGroupDelete({ key: balanceKey, groupId })), [dispatch, balanceKey]);
+  const doMoveStock = useCallback((ticker: string, groupId: string | null) => dispatch(reqPostUsCapitalStockGroup({ key: balanceKey, ticker, groupId })), [dispatch, balanceKey]);
+  const doBulkMove = useCallback((tickers: string[], groupId: string | null) => dispatch(reqPostUsCapitalStocksGroup({ key: balanceKey, tickers, groupId })), [dispatch, balanceKey]);
+  const doCopyLikes = useCallback((tickers: string[], groupId: string | null) => dispatch(reqPostUsCapitalLikesCopy({ key: balanceKey, tickers, groupId })), [dispatch, balanceKey]);
+  const doDeleteStock = useCallback((ticker: string) => dispatch(reqPostUsCapitalStockRemove({ key: balanceKey, ticker })), [dispatch, balanceKey]);
+  const doBulkRemove = useCallback((tickers: string[]) => dispatch(reqPostUsCapitalStocksRemove({ key: balanceKey, tickers })), [dispatch, balanceKey]);
+  const doSaveGroupSettings = useCallback((groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: settings })), [dispatch, balanceKey]);
   const doSaveQuantRule = (rule: any) => dispatch(reqPostUsQuantRule({ key: balanceKey, rule }));
 
   const out2 = kiBalance?.output2?.[0];

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -205,7 +205,7 @@ function normalizeLiked(lk: LikedStockItem, status?: EffStatus): DisplayRow {
   };
 }
 
-export default function StockListTable({
+function StockListTable({
   data,
   doTokenPlusAll,
   doTokenPlusOne,
@@ -1293,3 +1293,7 @@ function StatItem({ label, value, icon }: { label: string; value: string; icon: 
     </div>
   );
 }
+
+// 부모(balance 뷰)의 잦은 상태 변화(잔고 자동새로고침·토스트 등)에서 대형 테이블 재렌더를 차단.
+// 모든 함수 prop은 뷰에서 useCallback으로 참조가 고정되어 있어야 memo가 유효하다.
+export default React.memo(StockListTable);


### PR DESCRIPTION
1) StockListTable(1,300줄·130+행) 재렌더 차단:
   - React.memo로 export. 잔고 30초 자동새로고침·토스트 등 부모 상태 변화마다 페이지에서 가장 큰 컴포넌트가 통째로 재렌더되던 것을 차단.
   - KR/US 뷰에서 테이블에 전달하는 핸들러 16개를 useCallback([dispatch, balanceKey]) 으로 참조 고정 (memo 유효 조건). 나머지 prop은 redux/useState/useMemo ref라 안정적.

2) recharts 초기 번들 제외:
   - PortfolioChartSection을 next/dynamic(ssr:false, ChartSectionSkeleton 로딩)으로 지연 로딩. 차트 라이브러리가 balance 첫 로드 JS에서 빠져 초기 로딩 개선.


Claude-Session: https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P