### PR TITLE
feat: balance 계좌 선택기를 탭 위 최상단으로 이동 (계좌 단위 그룹 관리)

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -62,7 +62,7 @@ import { type NavSection } from "@/components/balance/sectionNav";
 import { BalanceShell } from "@/components/balance/balanceShell";
 import {
   useToast,
-  SectionHeader, SectionPanel, EmptyRow,
+  SectionHeader, SectionPanel, EmptyRow, AccountSelector,
   KpiCard, MetricChip, TableHeader, OrderTabAction, OrderSectionIcon,
   PnlIcon, pnlIconBg, pnlValueColor, pnlAccentColor,
   formatTime,
@@ -440,6 +440,14 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
       isLoading={isLoading}
       onRefresh={handleRefresh}
       dividerClass="via-[#86efac] dark:via-[#166534]"
+      accountSelector={
+        <AccountSelector
+          balanceKey={balanceKey}
+          setBalanceKey={setBalanceKey}
+          kakaoMemberList={kakaoMemberList}
+          isMaster={isMaster}
+        />
+      }
       navSections={navSections}
       mobileTab={mobileTab}
       onMobileTabChange={setMobileTab}

--- a/cf-idiotquant/components/balance/balanceShell.tsx
+++ b/cf-idiotquant/components/balance/balanceShell.tsx
@@ -23,6 +23,7 @@ export function BalanceShell({
   breadcrumb, title, lastUpdated,
   countryToggle, autoRefresh, onToggleAutoRefresh, isLoading, onRefresh, headerExtra, footerBadge,
   dividerClass,
+  accountSelector,
   navSections, mobileTab, onMobileTabChange,
   sections,
 }: {
@@ -39,6 +40,7 @@ export function BalanceShell({
   headerExtra?: React.ReactNode;
   footerBadge?: React.ReactNode;
   dividerClass: string;
+  accountSelector?: React.ReactNode;
   navSections: NavSection[];
   mobileTab: string;
   onMobileTabChange: (id: string) => void;
@@ -80,6 +82,9 @@ export function BalanceShell({
         </header>
 
         <div className={cn("h-px bg-gradient-to-r from-transparent to-transparent opacity-60", dividerClass)} />
+
+        {/* 계좌 선택 (탭 위 최상단) */}
+        {accountSelector}
 
         {/* 섹션 네비게이션 */}
         <SectionNav sections={navSections} mobileTab={mobileTab} onMobileTabChange={onMobileTabChange} />

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -67,7 +67,7 @@ import { type NavSection } from "@/components/balance/sectionNav";
 import { BalanceShell } from "@/components/balance/balanceShell";
 import {
   useToast,
-  SectionHeader, SectionPanel, EmptyRow,
+  SectionHeader, SectionPanel, EmptyRow, AccountSelector,
   UsdKpiCard, MetricChip, TableHeader, OrderTabAction, OrderSectionIcon,
   PnlIcon, pnlIconBg, pnlValueColor, pnlAccentColor,
   fmtUsd, fmtKrw, formatTime,
@@ -426,6 +426,14 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
       isLoading={isLoading}
       onRefresh={handleRefresh}
       dividerClass="via-[#16a34a] dark:via-[#15803d]"
+      accountSelector={
+        <AccountSelector
+          balanceKey={balanceKey}
+          setBalanceKey={setBalanceKey}
+          kakaoMemberList={kakaoMemberList}
+          isMaster={isMaster}
+        />
+      }
       navSections={navSections}
       mobileTab={mobileTab}
       onMobileTabChange={setMobileTab}

--- a/cf-idiotquant/components/balance/shared.tsx
+++ b/cf-idiotquant/components/balance/shared.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback, memo } from "react";
 import {
   Loader2, X, Check, AlertCircle,
   CheckCircle2, Clock, ArrowUpRight, ArrowDownRight,
-  RefreshCw, Activity, InboxIcon,
+  RefreshCw, Activity, InboxIcon, ChevronDown, Key,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -140,6 +140,43 @@ export function SectionHeader({
         </div>
       </div>
       {action && <div className="shrink-0 self-start sm:self-center">{action}</div>}
+    </div>
+  );
+}
+
+// 계좌 선택기 (MASTER 전용). 탭 위 최상단에 배치해 종목관리·자동매매를 계좌 단위로 전환한다.
+export function AccountSelector({ balanceKey, setBalanceKey, kakaoMemberList, isMaster }: {
+  balanceKey: string;
+  setBalanceKey: (v: string) => void;
+  kakaoMemberList?: any;
+  isMaster: boolean;
+}) {
+  if (!isMaster) return null;
+  const list = Array.isArray(kakaoMemberList?.list) ? kakaoMemberList.list : [];
+  return (
+    <div className="flex flex-wrap items-center gap-3 bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] px-4 py-3 shadow-sm">
+      <div className="flex items-center gap-1.5 px-2.5 py-1 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-lg text-[10px] font-black uppercase">
+        <Key size={12} /> MASTER MODE
+      </div>
+      <span className="text-xs font-semibold text-neutral-500 dark:text-neutral-400">계좌 선택</span>
+      <div className="relative inline-block">
+        <select
+          value={balanceKey}
+          onChange={(e) => setBalanceKey(e.target.value)}
+          className="appearance-none bg-transparent pl-3 pr-8 py-1.5 font-bold text-sm focus:outline-none dark:text-white cursor-pointer border border-neutral-200 dark:border-[#35332e] rounded-lg"
+        >
+          {list.length > 0 ? (
+            list.map((item: any) => (
+              <option key={item.key} value={String(item.key)} className="dark:bg-[#242320]">
+                {item.value?.nickname} ({item.key})
+              </option>
+            ))
+          ) : (
+            <option value="">계좌 목록 로딩 중...</option>
+          )}
+        </select>
+        <ChevronDown size={14} className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none opacity-50" />
+      </div>
     </div>
   );
 }

--- a/cf-idiotquant/components/inquireBalanceResult.tsx
+++ b/cf-idiotquant/components/inquireBalanceResult.tsx
@@ -5,7 +5,6 @@ import {
     Globe,
     TrendingUp,
     RefreshCw,
-    Key,
     Info,
     ChevronUp,
     ChevronDown,
@@ -299,34 +298,8 @@ export default function InquireBalanceResult(props: InquireBalanceResultProps) {
                 </div>
             </div>
 
-            {/* 메인 요약 카드 */}
+            {/* 메인 요약 카드 (계좌 선택기는 페이지 상단 AccountSelector로 이동됨) */}
             <div className="bg-white dark:bg-[#242320] rounded-[2rem] border border-neutral-200 dark:border-[#35332e] shadow-sm overflow-hidden">
-                {session?.user?.name === process.env.NEXT_PUBLIC_MASTER && (
-                    <div className="p-4 border-b border-neutral-100 dark:border-[#35332e] bg-neutral-50/50 dark:bg-[#242320]/50 flex flex-wrap items-center gap-4">
-                        <div className="flex items-center gap-1.5 px-2.5 py-1 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded-lg text-[10px] font-black uppercase">
-                            <Key size={12} /> MASTER MODE
-                        </div>
-                        <div className="relative inline-block">
-                            <select
-                                value={props.balanceKey}
-                                onChange={(e) => props.setBalanceKey(e.target.value)}
-                                className="appearance-none bg-transparent pl-2 pr-8 py-1 font-bold text-sm focus:outline-none dark:text-white cursor-pointer"
-                            >
-                                {Array.isArray(props.kakaoMemberList?.list) ? (
-                                    props.kakaoMemberList.list.map((item: any) => (
-                                        <option key={item.key} value={String(item.key)} className="dark:bg-[#242320]">
-                                            {item.value?.nickname} ({item.key})
-                                        </option>
-                                    ))
-                                ) : (
-                                    <option value="">계좌 목록 로딩 중...</option>
-                                )}
-                            </select>
-                            <ChevronDown size={14} className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none opacity-50" />
-                        </div>
-                    </div>
-                )}
-
                 <div className="grid grid-cols-1 md:grid-cols-3 divide-y md:divide-y-0 md:divide-x border-neutral-100 dark:divide-[#35332e]">
                     <SummaryItem
                         label="평가 손익률"


### PR DESCRIPTION
## 배경

balance 페이지에서 계좌 선택 `<select>`가 **잔고 섹션 카드(`InquireBalanceResult`) 안에만** 있었다. 그래서 종목관리·트레이딩조건 탭에 있을 때 계좌를 바꾸려면 잔고 탭으로 돌아가야 했고, "계좌 단위로 그룹을 관리한다"는 흐름이 잘 드러나지 않았다.

그룹 데이터 자체는 이미 백엔드에서 계좌(`kakaoId`)별로 스코핑되어 있으므로(`capital_tokens.state_json`), 선택기를 항상 보이는 최상단으로 올리는 것만으로 계좌 단위 그룹 관리가 자연스럽게 가능해진다.

## 변경 사항

| 파일 | 변경 |
|---|---|
| `components/balance/shared.tsx` | `AccountSelector` 컴포넌트 추가 (MASTER 전용, `kakaoMemberList` 기반 select). |
| `components/balance/balanceShell.tsx` | `accountSelector` 노드를 `SectionNav`(탭) **바로 위**에 렌더하도록 prop 추가. |
| `components/balance/balanceKrView.tsx` / `balanceUsView.tsx` | 페이지 상단에 `AccountSelector` 주입 (`balanceKey`/`setBalanceKey`/`kakaoMemberList`/`isMaster`). |
| `components/inquireBalanceResult.tsx` | 잔고 카드 안의 중복 선택기 제거(이동). orphan 임포트 `Key` 정리. |

- 계좌 선택기가 탭 위 최상단에 상시 노출 → 종목관리 탭을 포함한 모든 탭에서 계좌 전환 시 해당 계좌의 그룹·종목이 바로 표시.
- 데스크탑/모바일 모두 탭과 무관하게 항상 보임.
- 백엔드 변경 없음 (그룹은 이미 계좌별 스코핑).

## 검증

- `npx tsc --noEmit` 통과 (에러 0)
- `npm run build` 통과 (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_