### PR TITLE
feat: balance 페이지 데스크탑도 탭뷰로 (스크롤 대신 탭 전환)

### DIFF
--- a/cf-idiotquant/components/balance/balanceShell.tsx
+++ b/cf-idiotquant/components/balance/balanceShell.tsx
@@ -89,9 +89,9 @@ export function BalanceShell({
         {/* 섹션 네비게이션 */}
         <SectionNav sections={navSections} mobileTab={mobileTab} onMobileTabChange={onMobileTabChange} />
 
-        {/* 섹션 본문 (모바일은 탭 단위로 표시) */}
+        {/* 섹션 본문 (데스크탑·모바일 모두 탭 단위로 활성 섹션만 표시) */}
         {sections.map(s => (
-          <div key={s.id} className={cn(mobileTab !== s.id && "hidden md:block")}>
+          <div key={s.id} className={cn(mobileTab !== s.id && "hidden")}>
             {s.node}
           </div>
         ))}

--- a/cf-idiotquant/components/balance/sectionNav.tsx
+++ b/cf-idiotquant/components/balance/sectionNav.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
 import { cn } from "@/lib/utils";
 
 // =========================================================================
@@ -24,43 +23,6 @@ export function SectionNav({
   mobileTab?: string;
   onMobileTabChange?: (id: string) => void;
 }) {
-  const [activeId, setActiveId] = useState<string>("");
-
-  const handleNavClick = useCallback((id: string) => {
-    const element = document.getElementById(id);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth", block: "start" });
-      setActiveId(id);
-    }
-  }, []);
-
-  useEffect(() => {
-    const observerOptions = {
-      threshold: 0.3,
-      rootMargin: "-60px 0px -40% 0px",
-    };
-
-    const observers: IntersectionObserver[] = [];
-
-    sections.forEach(({ id }) => {
-      const element = document.getElementById(id);
-      if (!element) return;
-
-      const observer = new IntersectionObserver(([entry]) => {
-        if (entry.isIntersecting) {
-          setActiveId(id);
-        }
-      }, observerOptions);
-
-      observer.observe(element);
-      observers.push(observer);
-    });
-
-    return () => {
-      observers.forEach(obs => obs.disconnect());
-    };
-  }, [sections]);
-
   return (
     <nav className="sticky top-0 z-30 bg-white/90 dark:bg-[#1f1e1b]/90 backdrop-blur-xl border-b border-neutral-200/70 dark:border-[#35332e] transition-colors duration-300">
       <div className="max-w-7xl mx-auto px-4">
@@ -84,15 +46,15 @@ export function SectionNav({
           ))}
         </div>
 
-        {/* 데스크탑 스크롤 네비 */}
+        {/* 데스크탑 탭 네비 */}
         <div className="hidden md:flex items-center gap-2 overflow-x-auto scrollbar-hide py-3 md:py-4">
           {sections.map(({ id, label, icon }) => (
             <button
               key={id}
-              onClick={() => handleNavClick(id)}
+              onClick={() => onMobileTabChange?.(id)}
               className={cn(
                 "flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs whitespace-nowrap transition-all shrink-0",
-                activeId === id
+                mobileTab === id
                   ? "bg-[#ede8df]/80 dark:bg-[#35332e] text-neutral-900 dark:text-neutral-50 font-semibold"
                   : "font-medium text-neutral-500 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] hover:text-neutral-900 dark:hover:text-neutral-100"
               )}


### PR DESCRIPTION
## 배경

balance 페이지는 데스크탑에서 모든 섹션(KPI·포트폴리오·잔고·종목관리·조건·주문내역)을 세로로 쌓아 **스크롤**로 보고, 상단 네비는 스크롤-스파이(클릭 시 해당 섹션으로 스크롤)였다. 탭 전환은 **모바일에서만** 동작했다.

이제 **모든 화면 크기에서 활성 탭 한 섹션만** 표시하도록 통일한다.

## 변경 사항

| 파일 | 변경 |
|---|---|
| `components/balance/balanceShell.tsx` | 섹션 표시를 `hidden md:block` → `hidden`으로 변경해 데스크탑에서도 선택 탭만 렌더. |
| `components/balance/sectionNav.tsx` | 데스크탑 네비 클릭을 `scrollIntoView` → `onMobileTabChange`(탭 전환)로 변경, 활성 하이라이트도 `mobileTab` 기준. 스크롤-스파이용 `IntersectionObserver`/`activeId`/`handleNavClick` 및 미사용 훅 import(`useEffect`/`useState`/`useCallback`) 제거. |

- 모바일 탭바(밑줄 스타일)·데스크탑 탭(pill 스타일)은 스타일 그대로 유지하되 둘 다 탭 전환으로 통일.
- 기본 탭은 KPI.

## 검증
- `npx tsc --noEmit` 통과 (에러 0)
- `npm run build` 통과 (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_