### PR TITLE
feat: 종목 카드 게임화 — 대항해시대 배너 + 저평가 점수/메달 + 높다낮다 카드게임

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+// =========================================================================
+// 종목 카드: 높다/낮다 (Higher-Lower) — 덱 빌딩 게임 1탄
+// 두 종목 카드를 스탯(시가총액·저평가점수·NCAV·주가)으로 비교해 맞히면 연승.
+// 비교한 카드는 랜덤으로 "내 덱리스트"(localStorage)에 수집 → 이후 게임의 밑천.
+// =========================================================================
+
+import { useEffect, useMemo, useState, useCallback, useRef } from "react";
+import Link from "next/link";
+import { ArrowUp, ArrowDown, RotateCcw, Layers, TrendingUp, Sparkles, ChevronLeft } from "lucide-react";
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { reqGetNcavDailyList, selectNcavDailyList } from "@/lib/features/algorithmTrade/algorithmTradeSlice";
+import { computeValueScore } from "@/lib/utils/valueScore";
+import { cn } from "@/lib/utils";
+
+const safeNum = (v: any): number => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
+
+// 비교 가능한 스탯 정의
+type Stat = { key: string; label: string; get: (it: any) => number; fmt: (v: number) => string };
+const STATS: Stat[] = [
+  {
+    key: "market_cap", label: "시가총액", get: it => safeNum(it.market_cap),
+    fmt: v => v >= 10000 ? `${(v / 10000).toFixed(1)}조` : `${Math.round(v).toLocaleString()}억`,
+  },
+  { key: "value_score", label: "저평가 점수", get: it => computeValueScore(it).score, fmt: v => `${v}점` },
+  { key: "ncav_ratio", label: "NCAV 비율", get: it => safeNum(it.ncav_ratio), fmt: v => `${v.toFixed(2)}x` },
+  { key: "last_price", label: "주가", get: it => safeNum(it.last_price), fmt: v => `${Math.round(v).toLocaleString()}원` },
+];
+
+const DECK_KEY = "iq:deck:v1";        // 내 덱리스트 (소유 카드) — 이후 게임들이 공유
+const DROP_CHANCE = 0.4;              // 비교한 카드가 덱에 들어올 확률
+
+type DeckCard = { ticker: string; name: string; market_cap: number; last_price: number; ncav_ratio: number; pbr: number; per: number; eps: number; bps: number; at: number };
+
+function loadDeck(): DeckCard[] {
+  try { return JSON.parse(localStorage.getItem(DECK_KEY) || "[]"); } catch { return []; }
+}
+function toCard(it: any): DeckCard {
+  return {
+    ticker: String(it.ticker), name: String(it.name),
+    market_cap: safeNum(it.market_cap), last_price: safeNum(it.last_price),
+    ncav_ratio: safeNum(it.ncav_ratio), pbr: safeNum(it.pbr), per: safeNum(it.per),
+    eps: safeNum(it.eps), bps: safeNum(it.bps), at: Date.now(),
+  };
+}
+
+// 메달 톤
+const MEDAL_TONE: Record<string, string> = {
+  treasure: "bg-amber-100 text-amber-700 ring-amber-300 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-800",
+  gold: "bg-yellow-50 text-yellow-700 ring-yellow-300 dark:bg-yellow-950/30 dark:text-yellow-300 dark:ring-yellow-800",
+  silver: "bg-neutral-100 text-neutral-600 ring-neutral-300 dark:bg-[#2c2b27] dark:text-neutral-300 dark:ring-[#4a4641]",
+  bronze: "bg-orange-50 text-orange-700 ring-orange-200 dark:bg-orange-950/30 dark:text-orange-300 dark:ring-orange-900",
+  muted: "bg-neutral-50 text-neutral-400 ring-neutral-200 dark:bg-[#242320] dark:text-neutral-500 dark:ring-[#35332e]",
+};
+
+function Medal({ item, lg }: { item: any; lg?: boolean }) {
+  const v = computeValueScore(item);
+  return (
+    <span className={cn("inline-flex items-center gap-1 rounded-full ring-1 ring-inset font-black tabular-nums",
+      lg ? "px-2.5 py-1 text-sm" : "px-1.5 py-0.5 text-[11px]", MEDAL_TONE[v.tone])}>
+      <span aria-hidden>{v.medal}</span>{v.score}
+    </span>
+  );
+}
+
+// 종목 카드
+function Card({ item, stat, value }: { item: any; stat: Stat; value: React.ReactNode }) {
+  return (
+    <div className="w-full rounded-3xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] shadow-sm p-5 sm:p-6 flex flex-col items-center text-center">
+      <Medal item={item} lg />
+      <p className="mt-3 font-black text-lg sm:text-xl text-neutral-900 dark:text-white leading-tight break-keep">{item.name}</p>
+      <p className="text-[11px] text-neutral-400 font-mono tracking-wider">{item.ticker}</p>
+      <div className="my-4 h-px w-16 bg-neutral-100 dark:bg-[#35332e]" />
+      <p className="text-[10px] font-bold text-neutral-400 uppercase tracking-widest">{stat.label}</p>
+      <div className="mt-1 text-2xl sm:text-3xl font-black tabular-nums text-[#16a34a] dark:text-[#16a34a] min-h-[2.5rem] flex items-center">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+type Phase = "loading" | "guessing" | "revealed" | "over";
+
+export default function GamePage() {
+  const dispatch = useAppDispatch();
+  const ncav = useAppSelector(selectNcavDailyList);
+
+  const [statKey, setStatKey] = useState("market_cap");
+  const stat = useMemo(() => STATS.find(s => s.key === statKey)!, [statKey]);
+
+  const [anchor, setAnchor] = useState<any | null>(null);
+  const [challenger, setChallenger] = useState<any | null>(null);
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [streak, setStreak] = useState(0);
+  const [best, setBest] = useState(0);
+  const [lastWin, setLastWin] = useState<boolean | null>(null);
+  const [dropped, setDropped] = useState(false);          // 이번 라운드에 카드 획득했는지
+  const [deck, setDeck] = useState<DeckCard[]>([]);
+  const [showDeck, setShowDeck] = useState(false);
+
+  useEffect(() => { dispatch(reqGetNcavDailyList("latest")); setDeck(loadDeck()); }, [dispatch]);
+
+  // 현재 스탯으로 비교 가능한 종목 풀
+  const pool = useMemo(() => {
+    const list = Array.isArray(ncav.list) ? ncav.list : [];
+    return list.filter((it: any) => it?.name && it?.ticker && stat.get(it) > 0);
+  }, [ncav.list, stat]);
+
+  const bestKey = `iq:game:best:hl:${statKey}`;
+  useEffect(() => { setBest(safeNum(typeof window !== "undefined" ? localStorage.getItem(bestKey) : 0)); }, [bestKey]);
+
+  const draw = useCallback((excludeTicker?: string) => {
+    if (pool.length < 2) return null;
+    for (let i = 0; i < 30; i++) {
+      const c = pool[Math.floor(Math.random() * pool.length)];
+      if (c.ticker !== excludeTicker) return c;
+    }
+    return pool[0];
+  }, [pool]);
+
+  const start = useCallback(() => {
+    const a = draw();
+    if (!a) return;
+    setAnchor(a); setChallenger(draw(a.ticker)); setStreak(0); setLastWin(null); setDropped(false); setPhase("guessing");
+  }, [draw]);
+
+  // 풀 준비되면 시작
+  const started = useRef(false);
+  useEffect(() => {
+    if (!started.current && pool.length >= 2) { started.current = true; start(); }
+  }, [pool, start]);
+
+  // 비교한 카드를 랜덤으로 덱에 수집 (중복 티커는 제외)
+  const maybeCollect = useCallback((it: any) => {
+    if (Math.random() >= DROP_CHANCE) return false;
+    let added = false;
+    setDeck(prev => {
+      if (prev.some(c => c.ticker === String(it.ticker))) return prev;
+      added = true;
+      const next = [toCard(it), ...prev];
+      try { localStorage.setItem(DECK_KEY, JSON.stringify(next)); } catch { }
+      return next;
+    });
+    return added;
+  }, []);
+
+  const guess = useCallback((dir: "higher" | "lower") => {
+    if (phase !== "guessing" || !anchor || !challenger) return;
+    const av = stat.get(anchor), cv = stat.get(challenger);
+    const win = dir === "higher" ? cv >= av : cv <= av;   // 동점은 승리 처리
+    setLastWin(win);
+    setDropped(maybeCollect(challenger));
+    setPhase("revealed");
+    if (win) {
+      setStreak(s => {
+        const ns = s + 1;
+        if (ns > best) { setBest(ns); try { localStorage.setItem(bestKey, String(ns)); } catch { } }
+        return ns;
+      });
+    }
+  }, [phase, anchor, challenger, stat, best, bestKey, maybeCollect]);
+
+  const next = useCallback(() => {
+    if (!lastWin) return;
+    setAnchor(challenger);
+    setChallenger(draw(challenger?.ticker));
+    setDropped(false); setLastWin(null); setPhase("guessing");
+  }, [lastWin, challenger, draw]);
+
+  useEffect(() => { if (phase === "revealed" && lastWin === false) setPhase("over"); }, [phase, lastWin]);
+
+  const isLoading = ncav.state === "pending" || ncav.state === "init" || pool.length < 2;
+
+  return (
+    <div className="min-h-screen bg-[#faf9f7] dark:bg-[#1a1915] transition-colors">
+      <div className="max-w-2xl mx-auto px-4 py-6 sm:py-10">
+
+        {/* 헤더 */}
+        <div className="flex items-center justify-between mb-6">
+          <Link href="/" className="inline-flex items-center gap-1 text-xs font-bold text-neutral-500 dark:text-neutral-400 hover:text-[#16a34a]">
+            <ChevronLeft size={14} /> 홈
+          </Link>
+          <h1 className="text-sm font-black text-neutral-900 dark:text-white">종목 카드 · 높다/낮다</h1>
+          <button onClick={() => setShowDeck(v => !v)}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] text-xs font-bold text-neutral-600 dark:text-neutral-300">
+            <Layers size={13} className="text-[#16a34a]" /> 내 덱 {deck.length}
+          </button>
+        </div>
+
+        {/* 덱리스트 뷰 */}
+        {showDeck ? (
+          <DeckView deck={deck} onClose={() => setShowDeck(false)} />
+        ) : isLoading ? (
+          <div className="py-24 text-center text-sm text-neutral-400">카드 데이터를 불러오는 중…</div>
+        ) : (
+          <>
+            {/* 스탯 선택 */}
+            <div className="flex flex-wrap items-center justify-center gap-2 mb-5">
+              {STATS.map(s => (
+                <button key={s.key}
+                  onClick={() => { setStatKey(s.key); started.current = false; }}
+                  className={cn("px-3 py-1.5 rounded-lg text-xs font-bold border transition-all",
+                    s.key === statKey
+                      ? "bg-[#16a34a] border-[#16a34a] text-white shadow-sm"
+                      : "bg-white dark:bg-[#242320] border-neutral-200 dark:border-[#35332e] text-neutral-500 dark:text-neutral-400 hover:border-[#86efac]")}>
+                  {s.label}
+                </button>
+              ))}
+            </div>
+
+            {/* 스코어 */}
+            <div className="flex items-center justify-center gap-6 mb-5 text-center">
+              <div>
+                <p className="text-2xl font-black tabular-nums text-[#16a34a]">{streak}</p>
+                <p className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider">연승</p>
+              </div>
+              <div className="h-8 w-px bg-neutral-200 dark:bg-[#35332e]" />
+              <div>
+                <p className="text-2xl font-black tabular-nums text-neutral-700 dark:text-neutral-200">{best}</p>
+                <p className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider">최고 기록</p>
+              </div>
+            </div>
+
+            {phase === "over" ? (
+              <div className="rounded-3xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] p-8 text-center animate-in fade-in zoom-in-95 duration-300">
+                <p className="text-3xl mb-2">🚢</p>
+                <p className="font-black text-lg text-neutral-900 dark:text-white">항해 종료!</p>
+                <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">이번 연승 <b className="text-[#16a34a]">{streak}</b> · 최고 {best}</p>
+                <p className="text-xs text-neutral-400 mt-2">발굴한 카드는 <b>내 덱({deck.length})</b>에 쌓였습니다.</p>
+                <button onClick={start}
+                  className="mt-5 inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white font-bold text-sm shadow-md">
+                  <RotateCcw size={15} /> 다시 시작
+                </button>
+              </div>
+            ) : anchor && challenger ? (
+              <>
+                <div className="grid grid-cols-2 gap-3 sm:gap-4 items-stretch">
+                  <Card item={anchor} stat={stat} value={stat.fmt(stat.get(anchor))} />
+                  <Card item={challenger} stat={stat}
+                    value={phase === "revealed"
+                      ? <span className="animate-in zoom-in-75 duration-300">{stat.fmt(stat.get(challenger))}</span>
+                      : <span className="text-neutral-300 dark:text-neutral-600">?</span>} />
+                </div>
+
+                {/* 획득 알림 */}
+                <div className="h-6 mt-2 text-center">
+                  {phase === "revealed" && dropped && (
+                    <span className="inline-flex items-center gap-1 text-xs font-bold text-amber-600 dark:text-amber-400 animate-in fade-in slide-in-from-bottom-1">
+                      <Sparkles size={12} /> 카드 획득! {challenger.name} 이(가) 덱에 추가됨
+                    </span>
+                  )}
+                  {phase === "revealed" && lastWin && !dropped && (
+                    <span className="text-xs font-bold text-[#16a34a] animate-in fade-in">정답! ✔</span>
+                  )}
+                </div>
+
+                {/* 액션 */}
+                {phase === "guessing" ? (
+                  <div className="mt-3">
+                    <p className="text-center text-xs text-neutral-400 mb-3">
+                      오른쪽 <b className="text-neutral-600 dark:text-neutral-300">{challenger.name}</b> 의 {stat.label}은 왼쪽보다?
+                    </p>
+                    <div className="grid grid-cols-2 gap-3">
+                      <button onClick={() => guess("higher")}
+                        className="flex items-center justify-center gap-2 py-4 rounded-2xl bg-[#16a34a] hover:bg-[#15803d] text-white font-black shadow-md active:scale-[0.98] transition-all">
+                        <ArrowUp size={18} /> 높다
+                      </button>
+                      <button onClick={() => guess("lower")}
+                        className="flex items-center justify-center gap-2 py-4 rounded-2xl bg-neutral-800 hover:bg-neutral-900 dark:bg-[#35332e] dark:hover:bg-[#413f39] text-white font-black shadow-md active:scale-[0.98] transition-all">
+                        <ArrowDown size={18} /> 낮다
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button onClick={next}
+                    className="mt-3 w-full flex items-center justify-center gap-2 py-4 rounded-2xl bg-[#16a34a] hover:bg-[#15803d] text-white font-black shadow-md animate-in fade-in">
+                    다음 카드 <TrendingUp size={16} />
+                  </button>
+                )}
+              </>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// 덱리스트 뷰
+function DeckView({ deck, onClose }: { deck: DeckCard[]; onClose: () => void }) {
+  const sorted = useMemo(() => [...deck].sort((a, b) => computeValueScore(b).score - computeValueScore(a).score), [deck]);
+  return (
+    <div className="animate-in fade-in duration-200">
+      <div className="flex items-center justify-between mb-4">
+        <p className="font-black text-neutral-900 dark:text-white">내 덱 <span className="text-[#16a34a]">{deck.length}</span>장</p>
+        <button onClick={onClose} className="text-xs font-bold text-neutral-500 hover:text-[#16a34a]">게임으로 ▶</button>
+      </div>
+      {deck.length === 0 ? (
+        <p className="py-20 text-center text-sm text-neutral-400">아직 카드가 없어요. 게임을 하며 카드를 수집하세요!</p>
+      ) : (
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+          {sorted.map(c => (
+            <div key={c.ticker} className="rounded-2xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] p-4 text-center">
+              <Medal item={c} />
+              <p className="mt-2 font-bold text-sm text-neutral-900 dark:text-white truncate">{c.name}</p>
+              <p className="text-[10px] text-neutral-400 font-mono">{c.ticker}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -196,6 +196,61 @@ function StepTagArt() {
 
 const STEP_ARTS = [StepScanArt, StepFunnelArt, StepTagArt];
 
+// 대항해시대 네덜란드 범선(East Indiaman) — "가치를 향한 항해" 테마 배너.
+// 실제 사진 대신 라이선스·네트워크 제약이 없는 자체 인라인 SVG 실루엣.
+function ShipArt() {
+  // 돛(순풍에 부푼 사각돛) 하나를 그리는 헬퍼: 상·하 활대에 걸리고 우현으로 부풂
+  const sail = (x1: number, x2: number, yt: number, yb: number, bulge: number) =>
+    `M${x1},${yt} L${x2},${yt} Q${x2 + bulge},${(yt + yb) / 2} ${x2},${yb} L${x1},${yb} Q${x1 + bulge},${(yt + yb) / 2} ${x1},${yt} Z`;
+  const HULL = "#123c2e";
+  return (
+    <svg viewBox="0 0 960 300" fill="none" role="img" aria-label="가치를 향한 항해를 상징하는 대항해시대 네덜란드 범선"
+      preserveAspectRatio="xMidYMid slice" className="w-full h-full">
+      {/* 태양 */}
+      <circle cx="742" cy="104" r="48" fill="#f59e0b" opacity="0.85" />
+      <circle cx="742" cy="104" r="48" fill="#fbbf24" opacity="0.25" />
+
+      {/* 선체 */}
+      <path d="M320,208 L612,208 L590,240 Q468,252 348,240 Z" fill={HULL} />
+      {/* 선미루 */}
+      <path d="M582,208 L612,208 L612,186 Q600,182 588,186 Z" fill={HULL} />
+      {/* 현측 장식선 */}
+      <path d="M338,220 L596,220" stroke="#fcd34d" strokeWidth="2.5" opacity="0.7" />
+
+      {/* 마스트 */}
+      <line x1="395" y1="208" x2="395" y2="70" stroke={HULL} strokeWidth="5" />
+      <line x1="468" y1="208" x2="468" y2="44" stroke={HULL} strokeWidth="6" />
+      <line x1="541" y1="208" x2="541" y2="80" stroke={HULL} strokeWidth="5" />
+      {/* 활대 */}
+      <line x1="352" y1="92" x2="438" y2="92" stroke={HULL} strokeWidth="3.5" />
+      <line x1="416" y1="66" x2="520" y2="66" stroke={HULL} strokeWidth="4" />
+      <line x1="505" y1="100" x2="577" y2="100" stroke={HULL} strokeWidth="3.5" />
+      {/* 선수 사장(bowsprit) */}
+      <line x1="330" y1="206" x2="284" y2="182" stroke={HULL} strokeWidth="4" />
+
+      {/* 돛 */}
+      <path d={sail(363, 427, 96, 132, 20)} fill="#fdf7e6" stroke={HULL} strokeWidth="2" />
+      <path d={sail(352, 438, 138, 188, 26)} fill="#fbf3dd" stroke={HULL} strokeWidth="2" />
+      <path d={sail(428, 508, 70, 116, 24)} fill="#fdf7e6" stroke={HULL} strokeWidth="2" />
+      <path d={sail(416, 520, 124, 180, 30)} fill="#fbf3dd" stroke={HULL} strokeWidth="2" />
+      <path d={sail(513, 569, 104, 134, 18)} fill="#fdf7e6" stroke={HULL} strokeWidth="2" />
+      <path d={sail(505, 577, 142, 186, 22)} fill="#fbf3dd" stroke={HULL} strokeWidth="2" />
+      {/* 선수 삼각돛 */}
+      <path d="M330,204 L292,182 L330,168 Z" fill="#fdf7e6" stroke={HULL} strokeWidth="2" />
+
+      {/* 페넌트 깃발 */}
+      <path d="M468,44 l30,7 l-30,7 Z" fill="#16a34a" />
+      <path d="M395,70 l22,5 l-22,5 Z" fill="#16a34a" />
+      <path d="M541,80 l22,5 l-22,5 Z" fill="#16a34a" />
+
+      {/* 앞바다 물결 (선체 하부와 겹쳐 물에 떠 보이게) */}
+      <path d="M0,238 Q120,228 240,238 T480,238 T720,238 T960,238 V300 H0 Z" fill="#16a34a" opacity="0.18" />
+      <path d="M0,252 Q160,242 320,252 T640,252 T960,252 V300 H0 Z" fill="#16a34a" opacity="0.30" />
+      <path d="M0,268 Q140,258 280,268 T560,268 T840,268 T960,268 V300 H0 Z" fill="#15803d" opacity="0.45" />
+    </svg>
+  );
+}
+
 function useCountUp(target: number, duration = 1000) {
   const [count, setCount] = useState(0);
   const rafRef = useRef<number | null>(null);
@@ -421,6 +476,11 @@ export default function HomePage() {
             </div>
           </div>
         )}
+      </section>
+
+      {/* ── SHIP BANNER (대항해시대 테마) ─────────────────────────── */}
+      <section className="relative h-40 sm:h-56 overflow-hidden border-b border-neutral-200/70 dark:border-[#3a3834] bg-gradient-to-b from-[#eaf5ee] to-white dark:from-[#0e2019] dark:to-[#1a1915]">
+        <ShipArt />
       </section>
 
       {/* ── TODAY'S PICKS ─────────────────────────────────────────── */}

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -478,10 +478,13 @@ export default function HomePage() {
         )}
       </section>
 
-      {/* ── SHIP BANNER (대항해시대 테마) ─────────────────────────── */}
-      <section className="relative h-40 sm:h-56 overflow-hidden border-b border-neutral-200/70 dark:border-[#3a3834] bg-gradient-to-b from-[#eaf5ee] to-white dark:from-[#0e2019] dark:to-[#1a1915]">
+      {/* ── SHIP BANNER (대항해시대 테마 · 카드 게임 입구) ─────────── */}
+      <Link href="/game" className="group relative flex h-40 sm:h-56 overflow-hidden border-b border-neutral-200/70 dark:border-[#3a3834] bg-gradient-to-b from-[#eaf5ee] to-white dark:from-[#0e2019] dark:to-[#1a1915]">
         <ShipArt />
-      </section>
+        <span className="absolute bottom-3 left-1/2 -translate-x-1/2 inline-flex items-center gap-1.5 px-3.5 py-1.5 rounded-full bg-white/85 dark:bg-[#242320]/85 backdrop-blur border border-neutral-200 dark:border-[#35332e] text-xs font-black text-[#15803d] dark:text-[#16a34a] shadow-sm group-hover:scale-105 transition-transform">
+          🃏 종목 카드 게임 시작 <ChevronRight size={13} />
+        </span>
+      </Link>
 
       {/* ── TODAY'S PICKS ─────────────────────────────────────────── */}
       <section className="py-10 px-5 md:py-14">
@@ -718,6 +721,7 @@ export default function HomePage() {
               { label: "발굴", href: "/screener" },
               { label: "분석", href: "/analyze" },
               { label: "계산기", href: "/calculator" },
+              { label: "🃏 게임", href: "/game" },
             ].map(l => (
               <Link key={l.label} href={l.href}
                 className="text-xs text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 transition-colors font-medium"

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -16,6 +16,7 @@ import {
     reqGetMyLikes, reqToggleLike,
 } from "@/lib/features/stockLikes/stockLikesSlice";
 import { cn } from "@/lib/utils";
+import { computeValueScore, type ValueTone } from "@/lib/utils/valueScore";
 import { CopyStockButtons, type CopyStock } from "@/components/copyStockButtons";
 import { STRATEGY_LABEL, STRATEGY_BADGE, STRATEGY_PRESETS_CLIENT as STRATEGY_PRESETS, MKTCAP_PRESETS } from "@/lib/constants/strategies";
 
@@ -28,7 +29,7 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 // 상수 & 타입
 // =========================================================================
 const DAILY_PAGE_SIZE = 30;
-type DiscoverySortKey = "ticker" | "ncav_ratio" | "per" | "pbr" | "roe" | "market_cap" | "last_price";
+type DiscoverySortKey = "value_score" | "ticker" | "ncav_ratio" | "per" | "pbr" | "roe" | "market_cap" | "last_price";
 type SortOrder = "asc" | "desc";
 
 // 밸류에이션 필터 프리셋 (0 = 미적용)
@@ -121,6 +122,32 @@ function SortableHeader({ label, sortKey: key, currentKey, order, onToggle, rele
 }
 
 // =========================================================================
+// ValueMedal — 저평가 점수 + 메달 (게임 스코어)
+// =========================================================================
+const MEDAL_TONE: Record<ValueTone, string> = {
+    treasure: "bg-amber-100 text-amber-700 ring-amber-300 dark:bg-amber-950/40 dark:text-amber-300 dark:ring-amber-800",
+    gold: "bg-yellow-50 text-yellow-700 ring-yellow-300 dark:bg-yellow-950/30 dark:text-yellow-300 dark:ring-yellow-800",
+    silver: "bg-neutral-100 text-neutral-600 ring-neutral-300 dark:bg-[#2c2b27] dark:text-neutral-300 dark:ring-[#4a4641]",
+    bronze: "bg-orange-50 text-orange-700 ring-orange-200 dark:bg-orange-950/30 dark:text-orange-300 dark:ring-orange-900",
+    muted: "bg-neutral-50 text-neutral-400 ring-neutral-200 dark:bg-[#242320] dark:text-neutral-500 dark:ring-[#35332e]",
+};
+function ValueMedal({ item, size = "sm" }: { item: any; size?: "sm" | "lg" }) {
+    const v = computeValueScore(item);
+    return (
+        <span
+            className={cn(
+                "inline-flex items-center gap-1 rounded-full ring-1 ring-inset font-black tabular-nums shrink-0",
+                size === "lg" ? "px-2.5 py-1 text-sm" : "px-1.5 py-0.5 text-[11px]",
+                MEDAL_TONE[v.tone]
+            )}
+            title={`저평가 점수 ${v.score}/100 · ${v.label}등급 (NCAV·PBR·PER·ROE 종합)`}
+        >
+            <span aria-hidden>{v.medal}</span>{v.score}
+        </span>
+    );
+}
+
+// =========================================================================
 // TableRow — 데스크탑
 // =========================================================================
 const TableRow = memo(function TableRow({ item, onClick, isLiked, onToggleLike, highlight }: {
@@ -139,9 +166,12 @@ const TableRow = memo(function TableRow({ item, onClick, isLiked, onToggleLike, 
             className="group grid grid-cols-[minmax(160px,2.5fr)_minmax(110px,1fr)_88px_68px_68px_68px_112px] gap-4 items-center px-6 py-5 hover:bg-[#f0fdf4]/40 dark:hover:bg-[#242320]/50 cursor-pointer transition-colors border-b border-neutral-100 dark:border-[#35332e] last:border-0"
             onClick={() => onClick(item.ticker, item.name)}
         >
-            <div className="min-w-0">
-                <p className="font-bold text-sm text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
-                <p className="text-[11px] text-neutral-400 font-mono mt-0.5 tracking-wider">{item.ticker}</p>
+            <div className="min-w-0 flex items-center gap-2">
+                <ValueMedal item={item} />
+                <div className="min-w-0">
+                    <p className="font-bold text-sm text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
+                    <p className="text-[11px] text-neutral-400 font-mono mt-0.5 tracking-wider">{item.ticker}</p>
+                </div>
             </div>
 
             <div className="flex flex-wrap gap-1">
@@ -237,6 +267,9 @@ const StockRowCard = memo(function StockRowCard({ item, onClick, isLiked, onTogg
         >
             <div className="flex items-start justify-between gap-2 mb-4">
                 <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 mb-1">
+                        <ValueMedal item={item} size="lg" />
+                    </div>
                     <p className="font-bold text-base text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
                     <p className="text-[11px] text-neutral-400 font-mono tracking-wider mt-0.5">{item.ticker}</p>
                 </div>
@@ -344,7 +377,7 @@ const FilterDivider = () => <div className="w-px h-4 bg-neutral-200 dark:bg-[#4a
 // =========================================================================
 // 메인 스크리너
 // =========================================================================
-const VALID_SORT_KEYS: DiscoverySortKey[] = ["ticker", "ncav_ratio", "per", "pbr", "roe", "market_cap", "last_price"];
+const VALID_SORT_KEYS: DiscoverySortKey[] = ["value_score", "ticker", "ncav_ratio", "per", "pbr", "roe", "market_cap", "last_price"];
 
 function ScreenerContent() {
     const dispatch = useAppDispatch();
@@ -390,7 +423,7 @@ function ScreenerContent() {
     const [showGuide, setShowGuide] = useState(false);
     const [sortKey, setSortKey] = useState<DiscoverySortKey>(() => {
         const s = (searchParams.get('sort') ?? saved.sort) as DiscoverySortKey;
-        return VALID_SORT_KEYS.includes(s) ? s : 'ncav_ratio';
+        return VALID_SORT_KEYS.includes(s) ? s : 'value_score';
     });
     const [sortOrder, setSortOrder] = useState<SortOrder>(() =>
         (searchParams.get('order') ?? saved.order) === 'asc' ? 'asc' : 'desc'
@@ -445,7 +478,7 @@ function ScreenerContent() {
             params.set('strategies', Array.from(activeStrategyIds).join(','));
         if (filterMode !== 'OR')
             params.set('mode', filterMode);
-        if (sortKey !== 'ncav_ratio')
+        if (sortKey !== 'value_score')
             params.set('sort', sortKey);
         if (sortOrder !== 'desc')
             params.set('order', sortOrder);
@@ -475,7 +508,7 @@ function ScreenerContent() {
         const snapshot: Record<string, any> = {};
         if (activeStrategyIds.size > 0) snapshot.strategies = Array.from(activeStrategyIds);
         if (filterMode !== 'OR') snapshot.mode = filterMode;
-        if (sortKey !== 'ncav_ratio') snapshot.sort = sortKey;
+        if (sortKey !== 'value_score') snapshot.sort = sortKey;
         if (sortOrder !== 'desc') snapshot.order = sortOrder;
         const excludeArr = [
             excludeHoldings ? 'holdings' : null,
@@ -632,6 +665,11 @@ function ScreenerContent() {
         });
 
         list.sort((a, b) => {
+            if (sortKey === "value_score") {
+                const sa = computeValueScore(a).score;
+                const sb = computeValueScore(b).score;
+                return sortOrder === "asc" ? sa - sb : sb - sa;
+            }
             if (sortKey === "ticker") {
                 return sortOrder === "asc"
                     ? (a.ticker ?? "").localeCompare(b.ticker ?? "")
@@ -691,7 +729,7 @@ function ScreenerContent() {
 
     const activeFilterCount = [excludeHoldings, excludeDeficit, excludePreferred, minMarketCap > 0, maxPbr > 0, maxPer > 0, minRoe > 0, minNcav > 0].filter(Boolean).length;
     const isAllActive = activeStrategyIds.size === 0;
-    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || excludePreferred || minMarketCap > 0 || maxPbr > 0 || maxPer > 0 || minRoe > 0 || minNcav > 0 || sortKey !== 'ncav_ratio' || sortOrder !== 'desc' || showLikedOnly;
+    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || excludePreferred || minMarketCap > 0 || maxPbr > 0 || maxPer > 0 || minRoe > 0 || minNcav > 0 || sortKey !== 'value_score' || sortOrder !== 'desc' || showLikedOnly;
     const isFiltered = !showLikedOnly && filteredList.length !== ncavDailyList.list.length;
 
     return (
@@ -809,6 +847,21 @@ function ScreenerContent() {
 
                     {/* 둘째 줄: 관심 + 결과 수 + 전략 안내 + 초기화 */}
                     <div className="flex items-center gap-2 pb-3">
+                        {/* 저평가 점수순 정렬 (게임 리더보드) */}
+                        <button
+                            onClick={() => { setSortKey("value_score"); setSortOrder("desc"); setDisplayCount(DAILY_PAGE_SIZE); }}
+                            title="저평가 점수 높은 순으로 정렬 (NCAV·PBR·PER·ROE 종합)"
+                            className={cn(
+                                "shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-bold border transition-all whitespace-nowrap",
+                                sortKey === "value_score"
+                                    ? "bg-[#16a34a] border-[#16a34a] text-white shadow-sm"
+                                    : "border-neutral-200 dark:border-[#3a3834] text-neutral-600 dark:text-neutral-400 hover:border-[#86efac] dark:hover:border-[#15803d] hover:text-[#16a34a] bg-white dark:bg-[#242320]"
+                            )}
+                        >
+                            <span aria-hidden>🏆</span>
+                            점수순
+                        </button>
+
                         {/* 관심 종목 필터 */}
                         <button
                             onClick={() => {

--- a/cf-idiotquant/lib/utils/valueScore.ts
+++ b/cf-idiotquant/lib/utils/valueScore.ts
@@ -1,0 +1,48 @@
+// 저평가 점수 (게임 스코어 + 데이터 정제)
+// NCAV·PBR·PER·ROE 기준을 각각 0~1 서브점수로 환산해 가중 평균한 뒤 0~100 점수로.
+// 데이터가 없는 지표는 제외하고 남은 지표의 가중치로 정규화한다.
+
+export type ValueTone = "treasure" | "gold" | "silver" | "bronze" | "muted";
+
+export interface ValueScore {
+  score: number;          // 0~100
+  grade: "S" | "A" | "B" | "C" | "D";
+  medal: string;          // 이모지
+  label: string;          // 등급 한글
+  tone: ValueTone;
+}
+
+const clamp01 = (x: number) => (x < 0 ? 0 : x > 1 ? 1 : x);
+const num = (v: unknown) => {
+  const x = Number(v);
+  return Number.isFinite(x) ? x : NaN;
+};
+
+export function computeValueScore(item: any): ValueScore {
+  const ncav = num(item?.ncav_ratio);
+  const pbr = num(item?.pbr);
+  const per = num(item?.per);
+  const eps = num(item?.eps);
+  const bps = num(item?.bps);
+  const roe = bps > 0 && Number.isFinite(eps) ? (eps / bps) * 100 : NaN;
+
+  // { 가중치, 서브점수(0~1) }
+  const parts: { w: number; s: number }[] = [];
+  if (Number.isFinite(ncav) && ncav > 0) parts.push({ w: 0.40, s: clamp01((ncav - 0.3) / (1.5 - 0.3)) }); // NCAV 1.5x↑ 만점
+  if (Number.isFinite(pbr) && pbr > 0) parts.push({ w: 0.25, s: clamp01((1.5 - pbr) / (1.5 - 0.3)) });     // PBR 0.3↓ 만점
+  if (Number.isFinite(per) && per > 0) parts.push({ w: 0.20, s: clamp01((20 - per) / (20 - 5)) });         // PER 5↓ 만점
+  if (Number.isFinite(roe)) parts.push({ w: 0.15, s: clamp01((roe - 3) / (18 - 3)) });                     // ROE 18%↑ 만점
+
+  const wsum = parts.reduce((a, p) => a + p.w, 0);
+  const score = wsum > 0 ? Math.round((parts.reduce((a, p) => a + p.w * p.s, 0) / wsum) * 100) : 0;
+
+  return { score, ...tier(score) };
+}
+
+function tier(score: number): Omit<ValueScore, "score"> {
+  if (score >= 80) return { grade: "S", medal: "🏆", label: "보물", tone: "treasure" };
+  if (score >= 65) return { grade: "A", medal: "🥇", label: "금", tone: "gold" };
+  if (score >= 50) return { grade: "B", medal: "🥈", label: "은", tone: "silver" };
+  if (score >= 35) return { grade: "C", medal: "🥉", label: "동", tone: "bronze" };
+  return { grade: "D", medal: "🧭", label: "탐색", tone: "muted" };
+}

--- a/cf-idiotquant/middleware.ts
+++ b/cf-idiotquant/middleware.ts
@@ -42,7 +42,8 @@ export default auth((req: any) => {
         path === "/" ||
         path === "/search" ||
         path === "/analyze" ||
-        path === "/screener"
+        path === "/screener" ||
+        path === "/game"
     ) {
         return NextResponse.next();
     }


### PR DESCRIPTION
스크리너를 "게임처럼" 쓰게 만드는 방향의 3개 작업. 종목을 카드로 다루는 덱 빌딩 게임의 토대.

## 1. 대항해시대 범선 배너 (`ed6965a`)
- 홈 히어로 아래에 "가치를 향한 항해" 테마의 3돛 East Indiaman 실루엣 배너(자체 인라인 SVG). 외부 이미지 호스트가 egress 정책으로 차단돼 실제 사진 대신 라이선스·네트워크 제약 없는 SVG로 제작. 라이트·다크 대응. Playwright로 렌더 확인.
- 이 배너를 카드 게임 입구로 링크.

## 2. 저평가 점수 + 메달 (`098df6e`)
- `lib/utils/valueScore.ts`: NCAV·PBR·PER·ROE를 0~1 서브점수로 환산해 가중 평균(있는 지표만 정규화) → **0~100 저평가 점수** + 등급 메달(🏆보물/🥇금/🥈은/🥉동/🧭탐색).
- 스크리너 데스크탑/모바일 각 행에 `ValueMedal` 표시. 복잡한 지표를 한 눈에 읽히는 하나의 점수로 압축(데이터 정제 + 게임 스코어).
- 정렬에 `value_score` 추가 + 기본 정렬로(점수 리더보드). 툴바에 `🏆 점수순` 칩.

## 3. 종목 카드 게임 1탄 — 높다/낮다 + 덱 수집 (`77bbb10`)
- `/game` 신규 페이지(공개). 두 종목 카드를 스탯(시가총액·저평가점수·NCAV·주가)으로 **높다/낮다** 비교해 맞히면 연승. 최고 기록 localStorage.
- 비교한 카드를 랜덤(40%)으로 **"내 덱리스트"**(localStorage `iq:deck:v1`)에 수집 → 덱 뷰에서 점수순 확인. 이후 게임들이 같은 덱 공유(덱 빌딩 밑천).
- `middleware.ts`에 `/game` 공개 추가. 홈 푸터·배너에서 진입.
- 데이터는 기존 공개 `/scan/daily` 재활용 — 백엔드 변경 없음.

## 검증
- `npx tsc --noEmit` 통과 · `npm run build` 통과.
- 점수 로직 실측(딥밸류 95🏆 / 우량 71🥇 / 평범 22🧭 / 고평가 0🧭).
- `/game` 로컬 Chromium 렌더 확인 — 정상 마운트, 런타임 에러 없음(실데이터는 배포 환경에서 로드).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_