### PR TITLE
feat: 카드 덱 계정별 저장(로그인 유도) + 그룹별 매수/매도 방향 설정

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -3,15 +3,19 @@
 // =========================================================================
 // 종목 카드: 높다/낮다 (Higher-Lower) — 덱 빌딩 게임 1탄
 // 두 종목 카드를 스탯(시가총액·저평가점수·NCAV·주가)으로 비교해 맞히면 연승.
-// 비교한 카드는 랜덤으로 "내 덱리스트"(localStorage)에 수집 → 이후 게임의 밑천.
+// 비교한 카드는 랜덤으로 "내 덱"에 수집 → 계정별 D1 저장(로그인 필요).
+// 비로그인 시 수집 시점에 로그인 유도.
 // =========================================================================
 
 import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import Link from "next/link";
-import { ArrowUp, ArrowDown, RotateCcw, Layers, TrendingUp, Sparkles, ChevronLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { ArrowUp, ArrowDown, RotateCcw, Layers, TrendingUp, Sparkles, ChevronLeft, Lock } from "lucide-react";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { reqGetNcavDailyList, selectNcavDailyList } from "@/lib/features/algorithmTrade/algorithmTradeSlice";
 import { computeValueScore } from "@/lib/utils/valueScore";
+import { getDeck, addDeckCard, type DeckCardSnapshot } from "@/lib/features/deck/deckAPI";
 import { cn } from "@/lib/utils";
 
 const safeNum = (v: any): number => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
@@ -28,20 +32,14 @@ const STATS: Stat[] = [
   { key: "last_price", label: "주가", get: it => safeNum(it.last_price), fmt: v => `${Math.round(v).toLocaleString()}원` },
 ];
 
-const DECK_KEY = "iq:deck:v1";        // 내 덱리스트 (소유 카드) — 이후 게임들이 공유
-const DROP_CHANCE = 0.4;              // 비교한 카드가 덱에 들어올 확률
+const DROP_CHANCE = 0.4; // 비교한 카드가 덱에 들어올 확률
 
-type DeckCard = { ticker: string; name: string; market_cap: number; last_price: number; ncav_ratio: number; pbr: number; per: number; eps: number; bps: number; at: number };
-
-function loadDeck(): DeckCard[] {
-  try { return JSON.parse(localStorage.getItem(DECK_KEY) || "[]"); } catch { return []; }
-}
-function toCard(it: any): DeckCard {
+function toCard(it: any): DeckCardSnapshot {
   return {
     ticker: String(it.ticker), name: String(it.name),
     market_cap: safeNum(it.market_cap), last_price: safeNum(it.last_price),
     ncav_ratio: safeNum(it.ncav_ratio), pbr: safeNum(it.pbr), per: safeNum(it.per),
-    eps: safeNum(it.eps), bps: safeNum(it.bps), at: Date.now(),
+    eps: safeNum(it.eps), bps: safeNum(it.bps),
   };
 }
 
@@ -84,7 +82,14 @@ type Phase = "loading" | "guessing" | "revealed" | "over";
 
 export default function GamePage() {
   const dispatch = useAppDispatch();
+  const router = useRouter();
   const ncav = useAppSelector(selectNcavDailyList);
+  const { data: session } = useSession();
+  const isLoggedIn = !!session;
+
+  const requireLogin = useCallback(() => {
+    router.push(`/login?callbackUrl=${encodeURIComponent("/game")}`);
+  }, [router]);
 
   const [statKey, setStatKey] = useState("market_cap");
   const stat = useMemo(() => STATS.find(s => s.key === statKey)!, [statKey]);
@@ -95,11 +100,23 @@ export default function GamePage() {
   const [streak, setStreak] = useState(0);
   const [best, setBest] = useState(0);
   const [lastWin, setLastWin] = useState<boolean | null>(null);
-  const [dropped, setDropped] = useState(false);          // 이번 라운드에 카드 획득했는지
-  const [deck, setDeck] = useState<DeckCard[]>([]);
+  const [dropped, setDropped] = useState(false);      // 이번 라운드 카드 획득(로그인)
+  const [dropPrompt, setDropPrompt] = useState(false); // 카드가 떴지만 로그인 필요
+  const [deck, setDeck] = useState<DeckCardSnapshot[]>([]);
   const [showDeck, setShowDeck] = useState(false);
 
-  useEffect(() => { dispatch(reqGetNcavDailyList("latest")); setDeck(loadDeck()); }, [dispatch]);
+  useEffect(() => { dispatch(reqGetNcavDailyList("latest")); }, [dispatch]);
+
+  // 로그인 상태면 계정 덱 로드
+  useEffect(() => {
+    if (!isLoggedIn) { setDeck([]); return; }
+    let cancelled = false;
+    getDeck().then(res => {
+      if (cancelled || !res?.success || !Array.isArray(res.data)) return;
+      setDeck(res.data.map((r: any) => ({ ticker: r.ticker, name: r.name, ...(r.card ?? {}) })));
+    }).catch(() => { });
+    return () => { cancelled = true; };
+  }, [isLoggedIn]);
 
   // 현재 스탯으로 비교 가능한 종목 풀
   const pool = useMemo(() => {
@@ -122,36 +139,23 @@ export default function GamePage() {
   const start = useCallback(() => {
     const a = draw();
     if (!a) return;
-    setAnchor(a); setChallenger(draw(a.ticker)); setStreak(0); setLastWin(null); setDropped(false); setPhase("guessing");
+    setAnchor(a); setChallenger(draw(a.ticker));
+    setStreak(0); setLastWin(null); setDropped(false); setDropPrompt(false); setPhase("guessing");
   }, [draw]);
 
-  // 풀 준비되면 시작
   const started = useRef(false);
   useEffect(() => {
     if (!started.current && pool.length >= 2) { started.current = true; start(); }
   }, [pool, start]);
-
-  // 비교한 카드를 랜덤으로 덱에 수집 (중복 티커는 제외)
-  const maybeCollect = useCallback((it: any) => {
-    if (Math.random() >= DROP_CHANCE) return false;
-    let added = false;
-    setDeck(prev => {
-      if (prev.some(c => c.ticker === String(it.ticker))) return prev;
-      added = true;
-      const next = [toCard(it), ...prev];
-      try { localStorage.setItem(DECK_KEY, JSON.stringify(next)); } catch { }
-      return next;
-    });
-    return added;
-  }, []);
 
   const guess = useCallback((dir: "higher" | "lower") => {
     if (phase !== "guessing" || !anchor || !challenger) return;
     const av = stat.get(anchor), cv = stat.get(challenger);
     const win = dir === "higher" ? cv >= av : cv <= av;   // 동점은 승리 처리
     setLastWin(win);
-    setDropped(maybeCollect(challenger));
+    setDropped(false); setDropPrompt(false);
     setPhase("revealed");
+
     if (win) {
       setStreak(s => {
         const ns = s + 1;
@@ -159,13 +163,28 @@ export default function GamePage() {
         return ns;
       });
     }
-  }, [phase, anchor, challenger, stat, best, bestKey, maybeCollect]);
+
+    // 비교한 카드 랜덤 수집 (계정 저장)
+    if (Math.random() < DROP_CHANCE) {
+      if (!isLoggedIn) {
+        setDropPrompt(true);
+      } else {
+        const snap = toCard(challenger);
+        addDeckCard(snap).then(res => {
+          if (res?.added) {
+            setDropped(true);
+            setDeck(prev => prev.some(c => c.ticker === snap.ticker) ? prev : [snap, ...prev]);
+          }
+        }).catch(() => { });
+      }
+    }
+  }, [phase, anchor, challenger, stat, best, bestKey, isLoggedIn]);
 
   const next = useCallback(() => {
     if (!lastWin) return;
     setAnchor(challenger);
     setChallenger(draw(challenger?.ticker));
-    setDropped(false); setLastWin(null); setPhase("guessing");
+    setDropped(false); setDropPrompt(false); setLastWin(null); setPhase("guessing");
   }, [lastWin, challenger, draw]);
 
   useEffect(() => { if (phase === "revealed" && lastWin === false) setPhase("over"); }, [phase, lastWin]);
@@ -185,12 +204,13 @@ export default function GamePage() {
           <button onClick={() => setShowDeck(v => !v)}
             className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] text-xs font-bold text-neutral-600 dark:text-neutral-300">
             <Layers size={13} className="text-[#16a34a]" /> 내 덱 {deck.length}
+            {!isLoggedIn && <Lock size={10} className="opacity-60" />}
           </button>
         </div>
 
-        {/* 덱리스트 뷰 */}
+        {/* 덱 뷰 */}
         {showDeck ? (
-          <DeckView deck={deck} onClose={() => setShowDeck(false)} />
+          <DeckView deck={deck} isLoggedIn={isLoggedIn} onLogin={requireLogin} onClose={() => setShowDeck(false)} />
         ) : isLoading ? (
           <div className="py-24 text-center text-sm text-neutral-400">카드 데이터를 불러오는 중…</div>
         ) : (
@@ -227,7 +247,9 @@ export default function GamePage() {
                 <p className="text-3xl mb-2">🚢</p>
                 <p className="font-black text-lg text-neutral-900 dark:text-white">항해 종료!</p>
                 <p className="text-sm text-neutral-500 dark:text-neutral-400 mt-1">이번 연승 <b className="text-[#16a34a]">{streak}</b> · 최고 {best}</p>
-                <p className="text-xs text-neutral-400 mt-2">발굴한 카드는 <b>내 덱({deck.length})</b>에 쌓였습니다.</p>
+                <p className="text-xs text-neutral-400 mt-2">
+                  {isLoggedIn ? <>발굴한 카드는 <b>내 덱({deck.length})</b>에 쌓였습니다.</> : "로그인하면 발굴한 카드를 덱에 모을 수 있어요."}
+                </p>
                 <button onClick={start}
                   className="mt-5 inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white font-bold text-sm shadow-md">
                   <RotateCcw size={15} /> 다시 시작
@@ -243,14 +265,20 @@ export default function GamePage() {
                       : <span className="text-neutral-300 dark:text-neutral-600">?</span>} />
                 </div>
 
-                {/* 획득 알림 */}
-                <div className="h-6 mt-2 text-center">
+                {/* 획득 / 로그인 유도 */}
+                <div className="min-h-[1.75rem] mt-2 text-center">
                   {phase === "revealed" && dropped && (
                     <span className="inline-flex items-center gap-1 text-xs font-bold text-amber-600 dark:text-amber-400 animate-in fade-in slide-in-from-bottom-1">
                       <Sparkles size={12} /> 카드 획득! {challenger.name} 이(가) 덱에 추가됨
                     </span>
                   )}
-                  {phase === "revealed" && lastWin && !dropped && (
+                  {phase === "revealed" && dropPrompt && (
+                    <button onClick={requireLogin}
+                      className="inline-flex items-center gap-1.5 text-xs font-bold text-[#16a34a] animate-in fade-in hover:underline">
+                      <Lock size={12} /> 카드가 나왔어요! 로그인하고 덱에 담기 →
+                    </button>
+                  )}
+                  {phase === "revealed" && lastWin && !dropped && !dropPrompt && (
                     <span className="text-xs font-bold text-[#16a34a] animate-in fade-in">정답! ✔</span>
                   )}
                 </div>
@@ -287,8 +315,8 @@ export default function GamePage() {
   );
 }
 
-// 덱리스트 뷰
-function DeckView({ deck, onClose }: { deck: DeckCard[]; onClose: () => void }) {
+// 덱 뷰
+function DeckView({ deck, isLoggedIn, onLogin, onClose }: { deck: DeckCardSnapshot[]; isLoggedIn: boolean; onLogin: () => void; onClose: () => void }) {
   const sorted = useMemo(() => [...deck].sort((a, b) => computeValueScore(b).score - computeValueScore(a).score), [deck]);
   return (
     <div className="animate-in fade-in duration-200">
@@ -296,7 +324,16 @@ function DeckView({ deck, onClose }: { deck: DeckCard[]; onClose: () => void }) 
         <p className="font-black text-neutral-900 dark:text-white">내 덱 <span className="text-[#16a34a]">{deck.length}</span>장</p>
         <button onClick={onClose} className="text-xs font-bold text-neutral-500 hover:text-[#16a34a]">게임으로 ▶</button>
       </div>
-      {deck.length === 0 ? (
+      {!isLoggedIn ? (
+        <div className="py-16 text-center">
+          <Lock size={22} className="mx-auto text-neutral-300 dark:text-neutral-600 mb-3" />
+          <p className="text-sm font-bold text-neutral-700 dark:text-neutral-300">덱은 계정에 저장됩니다</p>
+          <p className="text-xs text-neutral-400 mt-1 mb-4">로그인하면 발굴한 카드가 기기와 상관없이 보관돼요.</p>
+          <button onClick={onLogin} className="inline-flex items-center gap-1.5 px-5 py-2.5 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white font-bold text-sm">
+            로그인하고 덱 시작
+          </button>
+        </div>
+      ) : deck.length === 0 ? (
         <p className="py-20 text-center text-sm text-neutral-400">아직 카드가 없어요. 게임을 하며 카드를 수집하세요!</p>
       ) : (
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">

--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -385,7 +385,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
   const doCopyLikes = useCallback((tickers: string[], groupId: string | null) => dispatch(reqPostKrCapitalLikesCopy({ key: balanceKey, tickers, groupId })), [dispatch, balanceKey]);
   const doDeleteStock = useCallback((ticker: string) => dispatch(reqPostKrCapitalStockRemove({ key: balanceKey, ticker })), [dispatch, balanceKey]);
   const doBulkRemove = useCallback((tickers: string[]) => dispatch(reqPostKrCapitalStocksRemove({ key: balanceKey, tickers })), [dispatch, balanceKey]);
-  const doSaveGroupSettings = useCallback((groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: settings })), [dispatch, balanceKey]);
+  const doSaveGroupSettings = useCallback((groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null; side?: "buy" | "sell" }) => dispatch(reqPostKrCapitalGroupUpdate({ key: balanceKey, groupId, updates: settings })), [dispatch, balanceKey]);
   const doSaveQuantRule = (rule: any) => dispatch(reqPostKrQuantRule({ key: balanceKey, rule }));
   const doSaveBudget = (monthly_budget_krw: number) => dispatch(reqPostKrCapitalBudget({ key: balanceKey, monthly_budget_krw }));
 

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -353,7 +353,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
   const doCopyLikes = useCallback((tickers: string[], groupId: string | null) => dispatch(reqPostUsCapitalLikesCopy({ key: balanceKey, tickers, groupId })), [dispatch, balanceKey]);
   const doDeleteStock = useCallback((ticker: string) => dispatch(reqPostUsCapitalStockRemove({ key: balanceKey, ticker })), [dispatch, balanceKey]);
   const doBulkRemove = useCallback((tickers: string[]) => dispatch(reqPostUsCapitalStocksRemove({ key: balanceKey, tickers })), [dispatch, balanceKey]);
-  const doSaveGroupSettings = useCallback((groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: settings })), [dispatch, balanceKey]);
+  const doSaveGroupSettings = useCallback((groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null; side?: "buy" | "sell" }) => dispatch(reqPostUsCapitalGroupUpdate({ key: balanceKey, groupId, updates: settings })), [dispatch, balanceKey]);
   const doSaveQuantRule = (rule: any) => dispatch(reqPostUsQuantRule({ key: balanceKey, rule }));
 
   const out2 = kiBalance?.output2?.[0];

--- a/cf-idiotquant/components/balance/stockListTable.tsx
+++ b/cf-idiotquant/components/balance/stockListTable.tsx
@@ -145,7 +145,7 @@ interface Props {
   onCopyLikes?: (tickers: string[], groupId: string | null) => void;
   onDeleteStock?: (ticker: string) => void;
   onBulkRemove?: (tickers: string[]) => void;
-  onSaveGroupSettings?: (groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => void;
+  onSaveGroupSettings?: (groupId: string, settings: { quant_rule: QuantRule | null; budget_krw: number | null; side?: "buy" | "sell" }) => void;
   // 좋아요(찜) 그룹
   likedList?: LikedStockItem[];
   onToggleLikesTrading?: (isActive: boolean) => void;
@@ -650,6 +650,7 @@ function StockListTable({
           monthlyPerStock={monthlyPerStock}
           groupQuantRule={g.quant_rule}
           groupBudget={g.budget_krw}
+          groupSide={g.side}
           onSaveGroupSettings={isMaster && onSaveGroupSettings ? (settings) => onSaveGroupSettings(g.id, settings) : undefined}
         />
       ))}
@@ -767,7 +768,8 @@ interface GroupSectionProps {
   onDeleteStock?: (ticker: string) => void;
   groupQuantRule?: QuantRule;
   groupBudget?: number;
-  onSaveGroupSettings?: (settings: { quant_rule: QuantRule | null; budget_krw: number | null }) => void;
+  groupSide?: "buy" | "sell";
+  onSaveGroupSettings?: (settings: { quant_rule: QuantRule | null; budget_krw: number | null; side?: "buy" | "sell" }) => void;
 }
 
 function GroupSection({
@@ -775,12 +777,13 @@ function GroupSection({
   conditionChips, editing, editingName, onEditNameChange, onStartRename, onCommitRename, onDelete,
   emptyText, collapsed, onToggleCollapse, picked, onTogglePick, onPickMany,
   doTokenPlusOne, doTokenMinusOne, doTokenResetOne, openDetail, monthlyPerStock = 0, onDeleteStock,
-  groupQuantRule, groupBudget, onSaveGroupSettings,
+  groupQuantRule, groupBudget, groupSide, onSaveGroupSettings,
 }: GroupSectionProps) {
   const [showRuleEditor, setShowRuleEditor] = useState(false);
   const [draftActiveCount, setDraftActiveCount] = useState<string>("");
   const [draftNcavRatio, setDraftNcavRatio] = useState<string>("");
   const [draftBudget, setDraftBudget] = useState<string>("");
+  const [draftSide, setDraftSide] = useState<"buy" | "sell">("buy");
   const showRefill = isMaster && rows.some(r => r.movable);
   const showCheck = isMaster && rows.length > 0; // 모든 행 선택 가능(좋아요는 복사용)
   const selectableTickers = useMemo(() => rows.map(r => r.symbol), [rows]);
@@ -826,6 +829,16 @@ function GroupSection({
             />
           ) : (
             <h3 className="text-sm font-bold text-neutral-900 dark:text-neutral-100 truncate">{title}</h3>
+          )}
+          {!hideTrading && groupSide && (
+            <span className={cn(
+              "shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-black",
+              groupSide === "sell"
+                ? "bg-rose-500 text-white"
+                : "bg-[#16a34a]/10 text-[#16a34a]"
+            )}>
+              {groupSide === "sell" ? "매도" : "매수"}
+            </span>
           )}
           {onStartRename && !editing && (
             <button onClick={onStartRename} className="text-neutral-300 hover:text-neutral-600 dark:hover:text-neutral-200">
@@ -874,6 +887,7 @@ function GroupSection({
                 setDraftActiveCount(String(groupQuantRule?.active_count ?? ""));
                 setDraftNcavRatio(String(groupQuantRule?.ncav_ratio ?? ""));
                 setDraftBudget(groupBudget != null ? String(groupBudget) : "");
+                setDraftSide(groupSide === "sell" ? "sell" : "buy");
                 setShowRuleEditor(v => !v);
               }}
               title="이 그룹의 트레이딩 조건 설정"
@@ -928,6 +942,21 @@ function GroupSection({
         <div className="border-b border-neutral-100 dark:border-[#35332e] bg-[#f8fdf9] dark:bg-[#1a2a1a]/50 px-4 py-3">
           <div className="flex flex-wrap items-end gap-3">
             <span className="text-[11px] font-bold text-[#16a34a] uppercase tracking-wider shrink-0">그룹 조건 설정</span>
+            <div className="flex items-center gap-1.5">
+              <label className="text-[11px] text-neutral-500 shrink-0">방향</label>
+              <div className="inline-flex rounded-lg border border-neutral-300 dark:border-[#4a4641] overflow-hidden">
+                <button type="button" onClick={() => setDraftSide("buy")}
+                  className={cn("px-2.5 py-1 text-xs font-bold transition-colors",
+                    draftSide === "buy" ? "bg-[#16a34a] text-white" : "bg-white dark:bg-[#1a1915] text-neutral-500")}>
+                  매수
+                </button>
+                <button type="button" onClick={() => setDraftSide("sell")}
+                  className={cn("px-2.5 py-1 text-xs font-bold transition-colors",
+                    draftSide === "sell" ? "bg-rose-500 text-white" : "bg-white dark:bg-[#1a1915] text-neutral-500")}>
+                  매도
+                </button>
+              </div>
+            </div>
             <div className="flex items-center gap-1.5">
               <label className="text-[11px] text-neutral-500 shrink-0">활성 종목 수</label>
               <input
@@ -991,6 +1020,7 @@ function GroupSection({
                   onSaveGroupSettings({
                     quant_rule: Object.keys(rule).length > 0 ? rule : null,
                     budget_krw: !isNaN(b) && b > 0 ? b : null,
+                    side: draftSide,
                   });
                   setShowRuleEditor(false);
                 }}

--- a/cf-idiotquant/lib/features/capital/capitalAPI.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalAPI.tsx
@@ -77,7 +77,7 @@ export const postUsCapitalTokenMinusOne: any = async (key: string, num: number, 
 // ============================================================================
 // 종목 그룹 관리 API (KR / US)
 // ============================================================================
-type GroupUpdates = { name?: string; is_trading_active?: boolean; quant_rule?: object | null; budget_krw?: number | null };
+type GroupUpdates = { name?: string; is_trading_active?: boolean; quant_rule?: object | null; budget_krw?: number | null; side?: "buy" | "sell" };
 
 // KR
 export const postKrCapitalGroupCreate: any = async (key: string, name: string, tickers?: string[]) =>

--- a/cf-idiotquant/lib/features/capital/capitalSlice.tsx
+++ b/cf-idiotquant/lib/features/capital/capitalSlice.tsx
@@ -93,6 +93,7 @@ export interface StockGroup {
     is_trading_active: boolean;
     quant_rule?: QuantRule;
     budget_krw?: number;   // 그룹별 월 예산(DCA 리필). 미설정 시 계좌예산 fallback.
+    side?: "buy" | "sell"; // 그룹별 매수/매도 방향. 미설정 시 buy.
 }
 
 export interface UsCapitalStockItem {
@@ -511,7 +512,7 @@ export const capitalSlice = createAppSlice({
             }
         ),
         reqPostKrCapitalGroupUpdate: create.asyncThunk(
-            async ({ key, groupId, updates }: { key?: string, groupId: string, updates: { name?: string, is_trading_active?: boolean, quant_rule?: QuantRule | null, budget_krw?: number | null } }) => postKrCapitalGroupUpdate(key, groupId, updates),
+            async ({ key, groupId, updates }: { key?: string, groupId: string, updates: { name?: string, is_trading_active?: boolean, quant_rule?: QuantRule | null, budget_krw?: number | null, side?: "buy" | "sell" } }) => postKrCapitalGroupUpdate(key, groupId, updates),
             {
                 pending: (state) => { state.krGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.krGroupOp.state = "fulfilled"; },
@@ -561,7 +562,7 @@ export const capitalSlice = createAppSlice({
             }
         ),
         reqPostUsCapitalGroupUpdate: create.asyncThunk(
-            async ({ key, groupId, updates }: { key?: string, groupId: string, updates: { name?: string, is_trading_active?: boolean, quant_rule?: QuantRule | null, budget_krw?: number | null } }) => postUsCapitalGroupUpdate(key, groupId, updates),
+            async ({ key, groupId, updates }: { key?: string, groupId: string, updates: { name?: string, is_trading_active?: boolean, quant_rule?: QuantRule | null, budget_krw?: number | null, side?: "buy" | "sell" } }) => postUsCapitalGroupUpdate(key, groupId, updates),
             {
                 pending: (state) => { state.usGroupOp.state = "pending"; },
                 fulfilled: (state) => { state.usGroupOp.state = "fulfilled"; },

--- a/cf-idiotquant/lib/features/deck/deckAPI.tsx
+++ b/cf-idiotquant/lib/features/deck/deckAPI.tsx
@@ -1,0 +1,30 @@
+// 카드 게임 덱 API — 계정별 보유 카드 (백엔드 /user/deck)
+
+export interface DeckCardSnapshot {
+    ticker: string;
+    name: string;
+    market_cap: number;
+    last_price: number;
+    ncav_ratio: number;
+    pbr: number;
+    per: number;
+    eps: number;
+    bps: number;
+}
+
+async function deckRequest(subUrl: string, method = "GET", body?: object) {
+    const res = await fetch(`/api/proxy${subUrl}`, {
+        method,
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    return res.json();
+}
+
+// 내 덱 목록: [{ ticker, name, card }]
+export const getDeck = () => deckRequest("/user/deck");
+
+// 카드 추가 (중복은 백엔드에서 무시). added: 신규 추가 여부
+export const addDeckCard = (card: DeckCardSnapshot) =>
+    deckRequest("/user/deck", "POST", { ticker: card.ticker, name: card.name, card });


### PR DESCRIPTION
## 1. 카드 덱을 계정별 백엔드 저장 (`1ee9d17`)
게임에서 수집한 카드를 localStorage 대신 계정별 API(`/user/deck`)로 저장:
- `lib/features/deck/deckAPI.tsx`: `getDeck()`/`addDeckCard()` (프록시 경유, likes와 동일 패턴).
- 게임 페이지: `useSession` 추가. 로그인 시 계정 덱 로드, 카드 수집은 `addDeckCard`로 D1 저장(중복 백엔드 무시).
- **비로그인 시** 카드가 떠도 저장하지 않고 "로그인하고 덱에 담기" 유도. '내 덱' 뷰도 비로그인이면 로그인 CTA.
- 최고 연승 기록만 localStorage 유지(계정 데이터 아님).
- ※ 짝이 되는 worker의 `/user/deck` API(별도 PR) 배포 필요.

## 2. 그룹별 매수/매도 방향 설정 (`1811573`)
자동매매 전량 매도 사고 대응. 그룹 조건 편집 패널에 **매수/매도 토글** 추가:
- `side`("buy"|"sell")를 그룹 설정 저장 경로(`onSaveGroupSettings` → `CapitalGroupUpdate`)에 추가. 타입 체인(`capitalAPI`/`slice`/`StockGroup`) 반영.
- 그룹 헤더에 **매수(초록)/매도(빨강) 배지**로 방향을 명확히 노출.
- 기본 매수. 짝이 되는 worker(별도 PR)가 그룹 `side`로 매수/매도를 결정.

## 검증
- `npx tsc --noEmit` 통과 · `npm run build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_