### PR TITLE
feat: 카드 게임 전역 네비 노출 + 항해 종료 시 놓친 종목 정보 표시

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -11,7 +11,7 @@ import { useEffect, useMemo, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { ArrowUp, ArrowDown, RotateCcw, Layers, TrendingUp, Sparkles, ChevronLeft, Lock } from "lucide-react";
+import { ArrowUp, ArrowDown, RotateCcw, Layers, TrendingUp, Sparkles, ChevronLeft, ChevronRight, Lock } from "lucide-react";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { reqGetNcavDailyList, selectNcavDailyList } from "@/lib/features/algorithmTrade/algorithmTradeSlice";
 import { computeValueScore } from "@/lib/utils/valueScore";
@@ -78,6 +78,52 @@ function Card({ item, stat, value }: { item: any; stat: Stat; value: React.React
   );
 }
 
+const fmtCap = (v: number) => (v >= 10000 ? `${(v / 10000).toFixed(1)}조` : `${Math.round(v).toLocaleString()}억`);
+
+// 항해 종료 시 틀린 종목 정보 카드 (무엇을 놓쳤는지 + 그 종목 지표 학습)
+function MissedInfo({ missed }: { missed: any }) {
+  const c = missed.challenger;
+  const ncav = safeNum(c.ncav_ratio), pbr = safeNum(c.pbr);
+  const metrics = [
+    { label: "점수", value: `${computeValueScore(c).score}` },
+    { label: "시총", value: fmtCap(safeNum(c.market_cap)) },
+    { label: "NCAV", value: ncav > 0 ? `${ncav.toFixed(2)}x` : "—" },
+    { label: "PBR", value: pbr > 0 ? pbr.toFixed(2) : "—" },
+  ];
+  return (
+    <div className="mt-5 text-left rounded-2xl border border-neutral-200 dark:border-[#35332e] bg-[#faf9f7] dark:bg-[#1a1915] p-4">
+      <p className="text-[11px] font-black text-rose-500 mb-2">아깝게 놓친 종목</p>
+      <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-3 break-keep leading-relaxed">
+        <b className="text-neutral-800 dark:text-neutral-200">{c.name}</b>의 {missed.statLabel}
+        <b className="text-neutral-700 dark:text-neutral-300"> {missed.challengerStr}</b>은{" "}
+        {missed.anchor.name}({missed.anchorStr})보다{" "}
+        <b className={missed.higherSide === "challenger" ? "text-[#16a34a]" : "text-rose-500"}>
+          {missed.higherSide === "challenger" ? "높았어요" : "낮았어요"}
+        </b>.
+      </p>
+      <div className="flex items-center gap-2 mb-3">
+        <Medal item={c} lg />
+        <div className="min-w-0">
+          <p className="font-black text-sm text-neutral-900 dark:text-white truncate">{c.name}</p>
+          <p className="text-[10px] text-neutral-400 font-mono">{c.ticker}</p>
+        </div>
+      </div>
+      <div className="grid grid-cols-4 gap-2 mb-3">
+        {metrics.map(m => (
+          <div key={m.label} className="rounded-lg bg-white dark:bg-[#242320] p-2 text-center">
+            <p className="text-[9px] font-bold text-neutral-400 uppercase tracking-wide">{m.label}</p>
+            <p className="text-xs font-black tabular-nums text-neutral-800 dark:text-neutral-200 mt-0.5">{m.value}</p>
+          </div>
+        ))}
+      </div>
+      <Link href={`/analyze?ticker=${encodeURIComponent(c.name)}&from=game`}
+        className="inline-flex items-center gap-1 text-xs font-bold text-[#16a34a] hover:underline">
+        이 종목 분석하기 <ChevronRight size={12} />
+      </Link>
+    </div>
+  );
+}
+
 type Phase = "loading" | "guessing" | "revealed" | "over";
 
 export default function GamePage() {
@@ -104,6 +150,7 @@ export default function GamePage() {
   const [dropPrompt, setDropPrompt] = useState(false); // 카드가 떴지만 로그인 필요
   const [deck, setDeck] = useState<DeckCardSnapshot[]>([]);
   const [showDeck, setShowDeck] = useState(false);
+  const [missed, setMissed] = useState<any | null>(null); // 항해 종료 시 틀린 종목 정보
 
   useEffect(() => { dispatch(reqGetNcavDailyList("latest")); }, [dispatch]);
 
@@ -140,7 +187,7 @@ export default function GamePage() {
     const a = draw();
     if (!a) return;
     setAnchor(a); setChallenger(draw(a.ticker));
-    setStreak(0); setLastWin(null); setDropped(false); setDropPrompt(false); setPhase("guessing");
+    setStreak(0); setLastWin(null); setDropped(false); setDropPrompt(false); setMissed(null); setPhase("guessing");
   }, [draw]);
 
   const started = useRef(false);
@@ -161,6 +208,15 @@ export default function GamePage() {
         const ns = s + 1;
         if (ns > best) { setBest(ns); try { localStorage.setItem(bestKey, String(ns)); } catch { } }
         return ns;
+      });
+    } else {
+      // 틀린 라운드 정보 스냅샷 (statKey 변경과 무관하게 종료 화면에서 표시)
+      setMissed({
+        challenger, anchor,
+        statLabel: stat.label,
+        anchorStr: stat.fmt(av),
+        challengerStr: stat.fmt(cv),
+        higherSide: cv >= av ? "challenger" : "anchor",
       });
     }
 
@@ -250,6 +306,7 @@ export default function GamePage() {
                 <p className="text-xs text-neutral-400 mt-2">
                   {isLoggedIn ? <>발굴한 카드는 <b>내 덱({deck.length})</b>에 쌓였습니다.</> : "로그인하면 발굴한 카드를 덱에 모을 수 있어요."}
                 </p>
+                {missed && <MissedInfo missed={missed} />}
                 <button onClick={start}
                   className="mt-5 inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white font-bold text-sm shadow-md">
                   <RotateCcw size={15} /> 다시 시작

--- a/cf-idiotquant/components/navigation.tsx
+++ b/cf-idiotquant/components/navigation.tsx
@@ -17,6 +17,7 @@ import {
   DollarSign,
   ShieldCheck,
   History,
+  Gamepad2,
 } from "lucide-react";
 
 /* ─── NAV CONFIG ──────────────────────────────────────────────────── */
@@ -32,6 +33,7 @@ type NavItem = {
 const MAIN_NAV: NavItem[] = [
   { label: "홈",        href: "/",           icon: Home,       exact: true  },
   { label: "종목 발굴", href: "/screener",    icon: Filter,     badge: "Pro" },
+  { label: "카드 게임", href: "/game",        icon: Gamepad2,   badge: "New" },
   { label: "전략 히스토리", href: "/backtest", icon: History, adminOnly: true },
   { label: "적정 주가", href: "/analyze",     icon: Search                  },
   { label: "수익 계산", href: "/calculator",  icon: Calculator              },
@@ -306,6 +308,7 @@ export function NavbarWithSimpleLinks() {
       <nav className="md:hidden fixed bottom-0 left-0 right-0 h-[64px] z-40 bg-white/95 dark:bg-[#1f1e1b]/95 backdrop-blur-xl border-t border-neutral-200/70 dark:border-[#3a3834] flex items-center px-3">
         <TabItem href="/"           label="홈"     icon={Home}       isActive={pathname === "/"} />
         <TabItem href="/screener"   label="발굴"   icon={Filter}     isActive={pathname.startsWith("/screener")} />
+        <TabItem href="/game"       label="게임"   icon={Gamepad2}   isActive={pathname.startsWith("/game")} />
         {isAdmin && (
           <TabItem href="/backtest"   label="히스토리" icon={History}  isActive={pathname.startsWith("/backtest")} />
         )}


### PR DESCRIPTION
## 1. 진입 위치 자연스럽게 — 전역 네비에 카드 게임 노출
`components/navigation.tsx`:
- **데스크탑 사이드바 `MAIN_NAV`**에 `카드 게임`(/game) 추가 (Gamepad2 아이콘, **New 배지**), 종목 발굴 아래.
- **모바일 하단 탭바**에 `게임` 탭 추가.
- → 모든 페이지에서 자연스럽게 진입 (기존 홈 배너·푸터 링크는 유지).

## 2. 항해 종료 시 놓친 종목 정보
오답으로 게임 종료 시 **"아깝게 놓친 종목"** 카드 표시:
- **비교 결과**: "OO의 {스탯}({값})은 △△({값})보다 **높았어요/낮았어요**" — 정답 방향 안내.
- **놓친 종목 카드**: 점수/메달 + 이름·티커.
- **핵심 지표 4종**: 저평가 점수 · 시총 · NCAV · PBR.
- **"이 종목 분석하기"** → `/analyze` 링크로 학습 연결.
- statKey 변경과 무관하게 오답 시점 값을 **스냅샷**으로 저장.

## 검증
- `npx tsc --noEmit` 통과 · `npm run build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_