### PR TITLE
feat: 점수 설명 상세화·모바일 잘림 방지 + PER 비교 스탯 추가

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -30,6 +30,7 @@ const STATS: Stat[] = [
   },
   { key: "value_score", label: "저평가 점수", get: it => computeValueScore(it).score, fmt: v => `${v}점` },
   { key: "ncav_ratio", label: "NCAV 비율", get: it => safeNum(it.ncav_ratio), fmt: v => `${v.toFixed(2)}x` },
+  { key: "per", label: "PER", get: it => safeNum(it.per), fmt: v => `${v.toFixed(1)}배` },
   { key: "last_price", label: "주가", get: it => safeNum(it.last_price), fmt: v => `${Math.round(v).toLocaleString()}원` },
 ];
 

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -114,10 +114,18 @@ function ScoreInfo() {
         <Info size={13} />
       </button>
       {open && (
-        <span className="absolute z-30 bottom-full left-1/2 -translate-x-1/2 mb-2 w-60 rounded-xl bg-neutral-900 dark:bg-[#242320] border border-neutral-700/60 dark:border-[#35332e] p-3 text-[11px] leading-relaxed text-neutral-200 shadow-xl text-left font-medium">
+        // 모바일(<640px)에선 화면에 고정된 패널로(트리거 위치와 무관하게 항상 화면 안에 보임),
+        // sm 이상에선 아이콘 옆에 뜨는 툴팁으로.
+        <span className="fixed z-30 inset-x-4 bottom-6 sm:absolute sm:inset-x-auto sm:left-0 sm:bottom-full sm:mb-2 sm:w-72 rounded-xl bg-neutral-900 dark:bg-[#242320] border border-neutral-700/60 dark:border-[#35332e] p-3 text-[11px] leading-relaxed text-neutral-200 shadow-xl text-left font-medium break-keep">
           <b className="text-white">저평가 점수 (0~100)</b><br />
-          NCAV·PBR·PER·ROE를 종합해 저평가된 정도를 점수화. 높을수록 저평가 매력이 큽니다.
-          <span className="block mt-1.5 text-neutral-300">🏆 보물 80+ · 🥇 금 65+ · 🥈 은 50+ · 🥉 동 35+ · 🧭 탐색 그 외</span>
+          NCAV·PBR·PER·ROE를 가중 평균해 점수화(값 없는 지표는 제외 후 재분배):
+          <span className="block mt-1.5 space-y-0.5 text-neutral-300">
+            <span className="block">· NCAV 40% — 1.5배↑ 만점, 0.3배↓ 0점</span>
+            <span className="block">· PBR 25% — 0.3↓ 만점, 1.5↑ 0점</span>
+            <span className="block">· PER 20% — 5↓ 만점, 20↑ 0점</span>
+            <span className="block">· ROE 15% — 18%↑ 만점, 3%↓ 0점</span>
+          </span>
+          <span className="block mt-1.5 text-neutral-300">등급: 🏆 보물 80+ · 🥇 금 65+ · 🥈 은 50+ · 🥉 동 35+ · 🧭 탐색 그 외</span>
         </span>
       )}
     </span>


### PR DESCRIPTION
카드 게임 점수 설명 개선 + 비교 스탯 추가.

## 1. 점수 설명에 계산식·조건 추가 + 모바일 잘림 방지 (`8fb27e5`)
- `ScoreInfo` 툴팁(내 덱·게임 종료 화면 공용)에 저평가 점수 산출 상세 추가: 지표별 가중치와 만점/0점 조건 — NCAV 40%(1.5배↑ 만점, 0.3배↓ 0점), PBR 25%(0.3↓ 만점, 1.5↑ 0점), PER 20%(5↓ 만점, 20↑ 0점), ROE 15%(18%↑ 만점, 3%↓ 0점).
- 모바일(<640px)에서는 트리거 아이콘 위치와 무관하게 화면 하단에 고정된 패널로, sm 이상에서는 기존처럼 아이콘 옆 앵커 툴팁으로 반응형 전환해 좁은 화면에서 잘리지 않도록 함.

## 2. 높다/낮다 비교 스탯에 PER 추가 (`d0a11e5`)
- 기존 비교 스탯(시가총액·저평가 점수·NCAV 비율·주가)에 **PER** 추가. PER은 이미 저평가 점수 계산식에 20% 가중치로 포함돼 있었으나, 게임의 스탯 선택 목록에는 없어 비교 대상으로 고를 수 없었음.

## 검증
- `npx tsc --noEmit` 통과 · `npm run build` 통과.
- 모바일 비클리핑은 순수 CSS로 동일 로직을 재현해 픽셀 단위로 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_