### PR TITLE
fix: 적자·자본잠식 등 음수 지표를 0점 페널티로 (점수 부풀림 방지)

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -124,7 +124,7 @@ function ScoreInfo() {
         // sm 이상(하단 탭바 없음)에선 아이콘 옆에 뜨는 툴팁으로.
         <span className="fixed z-50 inset-x-4 bottom-20 sm:absolute sm:z-30 sm:inset-x-auto sm:left-0 sm:bottom-full sm:mb-2 sm:w-72 rounded-xl bg-neutral-900 dark:bg-[#242320] border border-neutral-700/60 dark:border-[#35332e] p-3 text-[11px] leading-relaxed text-neutral-200 shadow-xl text-left font-medium break-keep">
           <b className="text-white">저평가 점수 (0~100)</b><br />
-          NCAV·PBR·PER·ROE를 가중 평균해 점수화(값 없는 지표는 제외 후 재분배):
+          NCAV·PBR·PER·ROE를 가중 평균해 점수화(값 없는 지표는 제외, 적자·자본잠식 등 음수 지표는 0점):
           <span className="block mt-1.5 space-y-0.5 text-neutral-300">
             <span className="block">· NCAV 40% — 1.5배↑ 만점, 0.3배↓ 0점</span>
             <span className="block">· PBR 25% — 0.3↓ 만점, 1.5↑ 0점</span>

--- a/cf-idiotquant/lib/utils/valueScore.ts
+++ b/cf-idiotquant/lib/utils/valueScore.ts
@@ -29,13 +29,6 @@ const num = (v: unknown) => {
   return Number.isFinite(x) ? x : NaN;
 };
 
-function mkPart(
-  key: ValuePart["key"], label: string, weight: number,
-  value: number, available: boolean, sub: number, fmt: (v: number) => string,
-): ValuePart {
-  return { key, label, weight, available, sub: available ? sub : 0, valueStr: available ? fmt(value) : "—" };
-}
-
 export function computeValueScore(item: any): ValueScore {
   const ncav = num(item?.ncav_ratio);
   const pbr = num(item?.pbr);
@@ -44,14 +37,36 @@ export function computeValueScore(item: any): ValueScore {
   const bps = num(item?.bps);
   const roe = bps > 0 && Number.isFinite(eps) ? (eps / bps) * 100 : NaN;
 
+  // 값이 존재하면(finite) 계산에 포함. 음수/0(적자 PER·음수 PBR·자본잠식 등)은 "제외"가 아니라
+  // 서브점수 0으로 페널티 — 나쁜 펀더멘털이 빠지면서 점수가 부풀려지는 문제를 막는다.
+  // 값이 아예 없을(NaN) 때만 제외하고 남은 가중치로 정규화한다.
   const parts: ValuePart[] = [
-    mkPart("ncav", "NCAV", 0.40, ncav, Number.isFinite(ncav) && ncav > 0, clamp01((ncav - 0.3) / (1.5 - 0.3)), v => `${v.toFixed(2)}x`), // 1.5x↑ 만점
-    mkPart("pbr", "PBR", 0.25, pbr, Number.isFinite(pbr) && pbr > 0, clamp01((1.5 - pbr) / (1.5 - 0.3)), v => v.toFixed(2)),             // 0.3↓ 만점
-    mkPart("per", "PER", 0.20, per, Number.isFinite(per) && per > 0, clamp01((20 - per) / (20 - 5)), v => v.toFixed(1)),                 // 5↓ 만점
-    mkPart("roe", "ROE", 0.15, roe, Number.isFinite(roe), clamp01((roe - 3) / (18 - 3)), v => `${v.toFixed(1)}%`),                       // 18%↑ 만점
+    {
+      key: "ncav", label: "NCAV", weight: 0.40,               // 1.5x↑ 만점
+      available: Number.isFinite(ncav),
+      sub: ncav > 0 ? clamp01((ncav - 0.3) / (1.5 - 0.3)) : 0,
+      valueStr: Number.isFinite(ncav) ? `${ncav.toFixed(2)}x` : "—",
+    },
+    {
+      key: "pbr", label: "PBR", weight: 0.25,                 // 0.3↓ 만점, 음수(자본잠식)는 0점
+      available: Number.isFinite(pbr),
+      sub: pbr > 0 ? clamp01((1.5 - pbr) / (1.5 - 0.3)) : 0,
+      valueStr: Number.isFinite(pbr) ? pbr.toFixed(2) : "—",
+    },
+    {
+      key: "per", label: "PER", weight: 0.20,                 // 5↓ 만점, 적자(음수)는 0점
+      available: Number.isFinite(per),
+      sub: per > 0 ? clamp01((20 - per) / (20 - 5)) : 0,
+      valueStr: Number.isFinite(per) ? per.toFixed(1) : "—",
+    },
+    {
+      key: "roe", label: "ROE", weight: 0.15,                 // 18%↑ 만점, 자본잠식(bps≤0)·적자는 0점
+      available: Number.isFinite(eps) && Number.isFinite(bps) && bps !== 0,
+      sub: bps > 0 ? clamp01((roe - 3) / (18 - 3)) : 0,
+      valueStr: bps > 0 ? `${roe.toFixed(1)}%` : (Number.isFinite(bps) && bps < 0 ? "자본잠식" : "—"),
+    },
   ];
 
-  // 값 없는 지표는 제외하고 남은 지표의 가중치로 정규화
   const avail = parts.filter(p => p.available);
   const wsum = avail.reduce((a, p) => a + p.weight, 0);
   const score = wsum > 0 ? Math.round((avail.reduce((a, p) => a + p.weight * p.sub, 0) / wsum) * 100) : 0;


### PR DESCRIPTION
## 문제
EDGC(코스닥 245620) 등 **적자 + 자본잠식** 종목이 게임 점수 **100점**으로 나옴.

기존 로직은 "양수인 지표만" 계산에 포함 → 적자(PER<0)·자본잠식(BPS≤0)·음수 PBR이 전부 **제외**되고, NCAV 하나만 남아 그게 만점이면 100점이 됨. 나쁜 지표가 페널티 없이 빠지면서 점수가 부풀려짐.

## 수정 (`lib/utils/valueScore.ts`)
- 값이 **존재하면(finite)** 계산에 포함 → 음수/0(적자 PER·음수 PBR·자본잠식 BPS)은 **서브점수 0점**으로 페널티.
- 값이 **아예 없을(NaN) 때만** 제외 후 남은 가중치로 정규화.
- ROE `valueStr`에 자본잠식(bps<0) 표기 추가.
- 게임 점수 설명 툴팁에 "음수 지표는 0점" 문구 반영.

## 검증
| 종목 유형 | 기존 | 수정 후 |
|---|---|---|
| EDGC (적자·자본잠식, NCAV 1.72x) | 100 | **40 (동)** |
| 정상 가치주 (전 지표 양수) | 89 | **89** (변화 없음) |
| 적자지만 자본 건전 | — | **63 (금)** |
| NCAV만 결측 | — | **81** (재분배) |

`npx tsc --noEmit` 통과. 프론트엔드 전용(워커 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_