### PR TITLE
fix(build): images.domains → remotePatterns 이전 (Next 16 배포 빌드 대응)

### DIFF
--- a/cf-idiotquant/next.config.mjs
+++ b/cf-idiotquant/next.config.mjs
@@ -30,15 +30,14 @@ const nextConfig = {
                 port: '',
                 pathname: '/**',
             },
-        ],
-        domains: [
-            'cdn.pixabay.com',
-            'encrypted-tbn0.gstatic.com',
-            'encrypted-tbn1.gstatic.com',
-            'encrypted-tbn2.gstatic.com',
-            'encrypted-tbn3.gstatic.com',
-            'mud-kage.kakao.com',
-            'example.com',
+            // 기존 images.domains → remotePatterns 로 이전 (Next 16 에서 domains 제거됨)
+            { protocol: 'https', hostname: 'cdn.pixabay.com' },
+            { protocol: 'https', hostname: 'encrypted-tbn0.gstatic.com' },
+            { protocol: 'https', hostname: 'encrypted-tbn1.gstatic.com' },
+            { protocol: 'https', hostname: 'encrypted-tbn2.gstatic.com' },
+            { protocol: 'https', hostname: 'encrypted-tbn3.gstatic.com' },
+            { protocol: 'https', hostname: 'mud-kage.kakao.com' },
+            { protocol: 'https', hostname: 'example.com' },
         ],
     },
     env: {


### PR DESCRIPTION
## 문제
배포 빌드 실패. `next.config.mjs`의 deprecated `images.domains` 사용이 원인으로 추정.

`package.json`이 `next: ^16.2.6`(캐럿)이라 **배포 시 fresh `npm install`이 더 최신 16.x를 받으면 `images.domains` 설정 키가 제거돼 하드 에러**가 남. 로컬은 lockfile이 16.2.6으로 고정돼 경고로만 통과("로컬은 되는데 배포는 실패"가 설명됨).

## 변경 (`next.config.mjs`)
`images.domains`의 7개 도메인을 `images.remotePatterns`로 이전하고 `domains` 키 제거:
- cdn.pixabay.com, encrypted-tbn0~3.gstatic.com, mud-kage.kakao.com, example.com

## 검증
- `rm -rf .next && npm run build` EXIT 0, `images.domains` deprecated 경고 사라짐.
- `npx tsc --noEmit` 통과.

> 남은 `middleware → proxy` 경고는 비차단(동작함). 배포 에러가 이 쪽이면 별도 대응.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_