### PR TITLE
fix(build): .npmrc legacy-peer-deps=true — next-on-pages ERESOLVE 빌드 실패 해결

### DIFF
--- a/cf-idiotquant/.npmrc
+++ b/cf-idiotquant/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## 문제 (실제 배포 빌드 로그)
Cloudflare 빌드의 `npm install && npx @cloudflare/next-on-pages@1` 단계에서 **ERESOLVE**로 실패:

```
npm error ERESOLVE unable to resolve dependency tree
  Found: @cloudflare/workers-types@4.20260702.1
    peerOptional @cloudflare/workers-types@^4 from @cloudflare/next-on-pages@1.13.16
  Could not resolve:
    peerOptional @cloudflare/workers-types@^5.20260706.1 from wrangler@4.108.0
      peer wrangler@^3||^4 from @cloudflare/next-on-pages@1.13.16
```

원인: `@cloudflare/next-on-pages@1.13.16`(구버전)이 peer로 **최신 wrangler@4.108**을 끌어오는데, next-on-pages는 `workers-types ^4`를, wrangler@4.108은 `^5`를 요구 → peerOptional 충돌. `npx`가 next-on-pages를 새로 설치할 때 발생(프로젝트 package.json과 무관).

## 변경
`cf-idiotquant/.npmrc` 추가:
```
legacy-peer-deps=true
```
→ npx 설치가 peer 충돌을 무시하고 진행.

## 검증
임시 디렉토리에서 재현:
- `.npmrc` 없이 `npm install @cloudflare/next-on-pages@1 --dry-run` → **ERESOLVE** (동일 에러)
- `legacy-peer-deps=true` 추가 후 → **added 81 packages, EXIT 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_