### PR TITLE
fix(balance): 자동매매 흐름 요약의 '활성 대상'을 활성 그룹 기준으로

### DIFF
--- a/cf-idiotquant/components/balance/tradingFlowSummary.tsx
+++ b/cf-idiotquant/components/balance/tradingFlowSummary.tsx
@@ -38,13 +38,14 @@ export default function TradingFlowSummary({
   const unassigned = operating.filter(s => !s.group_id || !realGroups.some(g => g.id === s.group_id));
 
   const isOn = tradingActive === true;
-  const hasActiveTarget = activeGroups.length > 0 || unassigned.length > 0;
+  // 매매 대상은 '활성 그룹' 소속 종목만 (미지정 종목은 워커에서 제외). 프론트 stockListTable 집계와 일치.
+  const hasActiveTarget = activeGroups.length > 0;
   const hasStocks = operating.length > 0;
   const budgetOk = !budget || budget.monthly_budget_krw > 0;
 
   const steps: FlowStep[] = [
     { key: "trading", label: "자동매매", ok: isOn, detail: tradingActive === null ? "—" : isOn ? "ON" : "OFF" },
-    { key: "target", label: "활성 대상", ok: hasActiveTarget, detail: `그룹 ${activeGroups.length}/${realGroups.length}${unassigned.length ? ` · 미지정 ${unassigned.length}` : ""}` },
+    { key: "target", label: "활성 대상", ok: hasActiveTarget, detail: `그룹 ${activeGroups.length}/${realGroups.length}${unassigned.length ? ` · 미지정 ${unassigned.length}(제외)` : ""}` },
     { key: "stocks", label: "운용 종목", ok: hasStocks, detail: `${operating.length}종목` },
     ...(budget ? [{ key: "budget", label: "월 예산", ok: budget.monthly_budget_krw > 0, detail: budget.monthly_budget_krw > 0 ? won(budget.monthly_budget_krw) : "미설정" }] : []),
   ];
@@ -54,7 +55,7 @@ export default function TradingFlowSummary({
   const missing: string[] = [];
   if (!isOn) missing.push("자동매매 ON");
   if (!hasStocks) missing.push("운용 종목 추가");
-  if (!hasActiveTarget) missing.push("그룹 ON 또는 미지정 종목");
+  if (!hasActiveTarget) missing.push("그룹 ON");
   if (budget && budget.monthly_budget_krw <= 0) missing.push("월 예산 설정");
 
   // 조건 요약 (상위 N종목 · NCAV ≥ x · 종목당 틱 배분)


### PR DESCRIPTION
## 배경
워커가 자동매매 활성화를 **활성 그룹 기준**으로 복원(idiotquant-worker PR 짝)하면서, 미지정 종목은 더 이상 매매 대상이 아님. 그런데 `tradingFlowSummary`는 여전히 미지정 종목을 "활성 대상"으로 카운트해 워커와 모순됐음("현황 vs 실제" 불일치).

## 변경 (`components/balance/tradingFlowSummary.tsx`)
- `hasActiveTarget`를 `activeGroups.length > 0` 로 변경 — 미지정 종목(`unassigned`)을 활성 대상 판정에서 제외.
- "활성 대상" 단계 detail에서 미지정 개수를 `미지정 N(제외)`로 표기해 **운용 목록엔 있으나 매매 대상이 아님**을 명확히 함.
- 미충족 안내 문구 `그룹 ON 또는 미지정 종목` → `그룹 ON`.

프론트 stockListTable의 "매매중" 집계(활성 그룹 소속만) 및 워커 동작과 일치.

## 검증
- `npx tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_