### PR TITLE
feat(balance·game): 자동매매 현황 활성 그룹 기준 표시 + 게임 카드 3D 상시 노출

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -161,9 +161,10 @@ function usePrefersReducedMotion() {
   return reduce;
 }
 
-// 3D 틸트 + 등급 홀로그램 포일 — 카드에 수집욕구를 주는 인터랙티브 3D 래퍼
-function HoloCard({ tone, radius = "rounded-2xl", className, children }:
-  { tone: string; radius?: string; className?: string; children: React.ReactNode }) {
+// 3D 틸트 + 등급 홀로그램 포일 — 카드에 수집욕구를 주는 인터랙티브 3D 래퍼.
+// 평소엔 은은한 아이들 애니메이션(holo-idle)으로 3D가 드러나고, 포인터가 올라오면 그 방향으로 기울어진다.
+function HoloCard({ tone, radius = "rounded-2xl", idleDelay = 0, className, children }:
+  { tone: string; radius?: string; idleDelay?: number; className?: string; children: React.ReactNode }) {
   const ref = useRef<HTMLDivElement>(null);
   const reduce = usePrefersReducedMotion();
   const [p, setP] = useState({ x: 50, y: 50, active: false });
@@ -182,15 +183,20 @@ function HoloCard({ tone, radius = "rounded-2xl", className, children }:
 
   return (
     <div ref={ref} onPointerMove={onMove} onPointerLeave={onLeave}
-      className={cn("relative transition-transform duration-200 ease-out will-change-transform", className)}
-      style={{ transformStyle: "preserve-3d", transform: tilt ? `perspective(800px) rotateX(${rx}deg) rotateY(${ry}deg) scale(1.03)` : undefined }}>
+      className={cn("relative transition-transform duration-200 ease-out will-change-transform", !reduce && "holo-idle", className)}
+      style={{
+        transformStyle: "preserve-3d",
+        animationDelay: `${-idleDelay}s`,
+        // 포인터 조작 중에는 아이들 애니메이션을 끄고(그래야 인라인 transform 이 적용됨) 포인터 방향으로 기울인다.
+        ...(tilt ? { transform: `perspective(900px) rotateX(${rx}deg) rotateY(${ry}deg) scale(1.04)`, animation: "none" } : {}),
+      }}>
       {children}
       {/* 포인터 추적 하이라이트 */}
       <div aria-hidden style={{ opacity: tilt ? 1 : 0, background: `radial-gradient(circle at ${p.x}% ${p.y}%, rgba(255,255,255,.7), transparent 45%)` }}
         className={cn("pointer-events-none absolute inset-0 transition-opacity duration-200 mix-blend-soft-light", radius)} />
-      {/* 프리미엄 등급 홀로그램 포일 */}
+      {/* 프리미엄 등급 홀로그램 포일 (평소에도 은은히 보이도록 rest opacity 상향) */}
       {holo && (
-        <div aria-hidden style={{ opacity: tilt ? 0.9 : 0.3, backgroundImage: holo, backgroundSize: "220% 220%", backgroundPosition: `${p.x}% ${p.y}%` }}
+        <div aria-hidden style={{ opacity: tilt ? 0.95 : 0.45, backgroundImage: holo, backgroundSize: "220% 220%", backgroundPosition: `${p.x}% ${p.y}%` }}
           className={cn("pointer-events-none absolute inset-0 transition-opacity duration-300 mix-blend-overlay", radius)} />
       )}
     </div>
@@ -198,10 +204,10 @@ function HoloCard({ tone, radius = "rounded-2xl", className, children }:
 }
 
 // 종목 카드
-function Card({ item, stat, value }: { item: any; stat: Stat; value: React.ReactNode }) {
+function Card({ item, stat, value, idleDelay = 0 }: { item: any; stat: Stat; value: React.ReactNode; idleDelay?: number }) {
   const tone = computeValueScore(item).tone;
   return (
-    <HoloCard tone={tone} radius="rounded-3xl" className="w-full h-full">
+    <HoloCard tone={tone} radius="rounded-3xl" idleDelay={idleDelay} className="w-full h-full">
       <div className="w-full h-full rounded-3xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] shadow-sm p-5 sm:p-6 flex flex-col items-center text-center">
         <StockLogo item={item} size={52} />
         <div className="mt-2"><Medal item={item} lg /></div>
@@ -537,8 +543,8 @@ export default function GamePage() {
             ) : anchor && challenger ? (
               <>
                 <div className="grid grid-cols-2 gap-3 sm:gap-4 items-stretch">
-                  <Card item={anchor} stat={STAT} value={STAT.fmt(STAT.get(anchor))} />
-                  <Card item={challenger} stat={STAT}
+                  <Card item={anchor} stat={STAT} value={STAT.fmt(STAT.get(anchor))} idleDelay={0} />
+                  <Card item={challenger} stat={STAT} idleDelay={3}
                     value={phase === "revealed"
                       ? <span className="animate-in zoom-in-75 duration-300">{STAT.fmt(STAT.get(challenger))}</span>
                       : <span className="text-neutral-300 dark:text-neutral-600">?</span>} />
@@ -675,8 +681,8 @@ function DeckView({ deck, isLoggedIn, onLogin, onClose }: { deck: DeckItem[]; is
                 <span className="text-[11px] font-bold text-neutral-400">{cards.reduce((a, x) => a + (x.item.count ?? 1), 0)}장</span>
               </div>
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-                {cards.map(({ item: c }) => (
-                  <HoloCard key={c.ticker} tone={tone} radius="rounded-2xl">
+                {cards.map(({ item: c }, ci) => (
+                  <HoloCard key={c.ticker} tone={tone} radius="rounded-2xl" idleDelay={ci * 0.6}>
                     <div className={cn("relative rounded-2xl border p-4 text-center flex flex-col items-center", TIER_CARD_BG[tone])}>
                       <span className={cn("absolute top-1.5 right-1.5 px-1.5 py-0.5 rounded-full text-[10px] font-black tabular-nums leading-none",
                         (c.count ?? 1) > 1

--- a/cf-idiotquant/app/global.css
+++ b/cf-idiotquant/app/global.css
@@ -26,3 +26,11 @@
 /* ── No scrollbar utility ── */
 .no-scrollbar { scrollbar-width: none; -ms-overflow-style: none; }
 .no-scrollbar::-webkit-scrollbar { display: none; }
+
+/* ── Game card 3D idle (HoloCard) — 정지·모바일에서도 3D가 드러나도록 은은히 부유/회전 ── */
+@keyframes holo-idle {
+  0%, 100% { transform: perspective(900px) rotateX(3deg) rotateY(-7deg) translateY(0); }
+  50%      { transform: perspective(900px) rotateX(-2.5deg) rotateY(7deg) translateY(-5px); }
+}
+.holo-idle { animation: holo-idle 6s ease-in-out infinite; }
+@media (prefers-reduced-motion: reduce) { .holo-idle { animation: none; } }

--- a/cf-idiotquant/components/balance/tradingActivityPanel.tsx
+++ b/cf-idiotquant/components/balance/tradingActivityPanel.tsx
@@ -2,7 +2,23 @@
 
 import { Activity, Clock, RefreshCw, Gauge, Layers, ArrowDownCircle, ArrowUpCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { KrUsCapitalType, TradingActivityState, TradingLog } from "@/lib/features/capital/capitalSlice";
+import { KrUsCapitalType, TradingActivityState, TradingLog, UsCapitalStockItem, LIKES_GROUP_ID } from "@/lib/features/capital/capitalSlice";
+import validCorpCodeArray from "@/public/data/validCorpCodeArray.json";
+import validCorpNameArray from "@/public/data/validCorpNameArray.json";
+
+// KR 종목코드(6자리) → 종목명. stockListTable 과 동일 소스(병렬 배열).
+const KR_CODE_TO_NAME: Record<string, string> = (() => {
+  const codes = validCorpCodeArray as string[];
+  const names = validCorpNameArray as string[];
+  const map: Record<string, string> = {};
+  for (let i = 0; i < codes.length; i++) map[codes[i]] = names[i];
+  return map;
+})();
+const displayName = (symbol: string, name?: string | null) => {
+  const n = (name ?? "").trim();
+  if (n && n !== symbol) return n;
+  return KR_CODE_TO_NAME[symbol] || symbol;
+};
 
 // 자동매매 스케줄 창 (워커 isWithinTimeRange 와 동일): KR 08~18 / US 21~06 KST
 function isWindowOpen(country: "KR" | "US"): boolean {
@@ -52,9 +68,16 @@ export default function TradingActivityPanel({
   const windowLabel = country === "KR" ? "08:00~18:00 KST" : "21:00~06:00 KST";
 
   const stockList = capital?.stock_list ?? [];
-  const isActive = (a?: string) => ["active", "buy", "sell"].includes(a ?? "");
-  const activeTokenSum = stockList.filter(s => isActive(s.action)).reduce((acc, s) => acc + Number(s.token ?? 0), 0);
-  const activeCount = stockList.filter(s => isActive(s.action)).length;
+  // 현재 매매 대상 = 활성 그룹(is_trading_active) 소속 + action==="active".
+  // stockListTable 의 '매매중' 정의 및 워커 makeStockList 활성화 기준과 일치.
+  const gmap = new Map((capital?.groups ?? []).filter(g => g.id !== LIKES_GROUP_ID).map(g => [g.id, g]));
+  const isActiveGroupStock = (s: UsCapitalStockItem) => {
+    const g = s.group_id ? gmap.get(s.group_id) : undefined;
+    return !!g && g.is_trading_active !== false && s.action === "active";
+  };
+  const activeStocks = stockList.filter(isActiveGroupStock);
+  const activeTokenSum = activeStocks.reduce((acc, s) => acc + Number(s.token ?? 0), 0);
+  const activeCount = activeStocks.length;
   const chargeRate = Number(capital?.charge_info?.capital_charge_rate ?? 0);
   const refillIdx = capital?.token_info?.refill_stock_index ?? 0;
 
@@ -104,6 +127,49 @@ export default function TradingActivityPanel({
         <Stat icon={<Gauge size={12} />} label="충전 속도" value={`${won(chargeRate)}`} hint="/ 5분 틱" />
         <Stat icon={<Layers size={12} />} label="활성 토큰 합계" value={won(activeTokenSum)} hint={`활성 ${activeCount}종목`} />
         <Stat icon={<Activity size={12} />} label="리필 인덱스" value={`${refillIdx} / ${stockList.length}`} hint="다음 매수 대상 위치" />
+      </div>
+
+      {/* 현재 매매 대상 (활성 그룹 소속 · action=active) — 워커가 이 종목들을 자동매매 */}
+      <div className="flex items-baseline justify-between mb-2">
+        <p className="text-[11px] font-extrabold uppercase tracking-wider text-[#16a34a]">현재 매매 대상</p>
+        <p className="text-[11px] font-bold text-neutral-400">활성 그룹 {activeCount}종목 · 예산 {won(activeTokenSum)}</p>
+      </div>
+      <div className="overflow-x-auto rounded-xl border border-neutral-200 dark:border-[#35332e] mb-4">
+        <table className="w-full text-sm text-left min-w-[420px]">
+          <thead>
+            <tr className="bg-[#fcfaf7] dark:bg-[#1f1e1b] border-b border-neutral-100 dark:border-[#35332e]">
+              {["종목", "그룹", "NCAV", "예산(토큰)"].map((h, i) => (
+                <th key={h} className={cn("px-3 py-2 text-[10px] font-bold text-neutral-400 uppercase tracking-wider", i >= 2 && "text-right")}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-neutral-50 dark:divide-[#35332e]/40">
+            {activeStocks.length === 0 ? (
+              <tr><td colSpan={4} className="px-3 py-8 text-center text-xs text-neutral-400">활성 그룹에 매매 대상 종목이 없습니다. (그룹 자동매매 ON + 조건 충족 필요)</td></tr>
+            ) : (
+              activeStocks.map((s, i) => {
+                const nm = displayName(s.symbol, s.name);
+                const grp = s.group_id ? gmap.get(s.group_id) : undefined;
+                const ncav = Number(s.ncavRatio);
+                return (
+                  <tr key={`${s.symbol}-${i}`} className="hover:bg-[#faf9f7] dark:hover:bg-[#242320]/50">
+                    <td className="px-3 py-2">
+                      <p className="text-xs font-bold text-neutral-800 dark:text-neutral-100 truncate max-w-[120px]">{nm}</p>
+                      {nm !== s.symbol && <p className="text-[10px] text-neutral-400 font-mono">{s.symbol}</p>}
+                    </td>
+                    <td className="px-3 py-2">
+                      <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold bg-[#f0fdf4] text-[#16a34a] dark:bg-[#14532d]/30 dark:text-[#4ade80] truncate max-w-[90px]">
+                        {grp?.name ?? "-"}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 text-right text-xs font-mono text-neutral-600 dark:text-neutral-300 tabular-nums">{Number.isFinite(ncav) ? `${ncav.toFixed(2)}x` : "-"}</td>
+                    <td className="px-3 py-2 text-right text-xs font-bold text-neutral-800 dark:text-neutral-100 tabular-nums">{won(s.token ?? 0)}</td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
       </div>
 
       {/* 최근 자동 체결 */}


### PR DESCRIPTION
두 개의 독립 변경.

## 1. 자동매매 현황을 활성 그룹 종목 기준으로 (`components/balance/tradingActivityPanel.tsx`)
현황 패널의 활성 집계가 `action`만 보고 **그룹 활성 여부를 확인하지 않아** 비활성 그룹/미지정 종목의 잔여 action이 잘못 잡히던 문제.
- 활성 집계를 **활성 그룹(is_trading_active) 소속 + `action=active`** 로 변경 — stockListTable "매매중" 정의 및 워커 `makeStockList` 활성화 기준과 정확히 일치.
- **"현재 매매 대상" 종목 목록 추가**(종목 / 그룹 / NCAV / 예산) — 워커가 실제 자동매매하는 종목을 그대로 노출. 활성 토큰 합계·활성 종목 수도 이 기준으로 재계산.

## 2. 게임 카드 3D를 정지·모바일에서도 보이게 (`app/(game)/game/page.tsx`, `app/global.css`)
`HoloCard` 틸트가 **포인터 이동 시에만** 발동해 정지 화면·터치 기기에서 3D가 안 보이던 문제.
- **상시 아이들 애니메이션**(`holo-idle`: 은은한 부유 + 3D 회전)을 추가 → 가만히 있어도, 모바일에서도 3D가 드러남. 카드별 딜레이로 스태거.
- 포인터가 올라오면 아이들을 끄고 그 방향으로 기울임(기존 인터랙션 유지). 프리미엄 등급 포일 rest 가시성 상향. `prefers-reduced-motion` 시 정적.

## 검증
- `npx tsc --noEmit` 통과 · `npm run build` 통과(`/game`·`/balance*` 컴파일)
- 게임 3D: 스탠드얼론 데모 스크린샷으로 정지 상태에서 카드가 서로 다른 각도로 기울어지는 3D 확인

> 참고: 현황 "현재 매매 대상"이 실제 체결과 일치하려면 워커 그룹 기준 활성화(idiotquant-worker #73)가 머지·배포돼야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_