### PR TITLE
feat(game·profile): 게임 카드 패럴랙스 깊이 + 관심 종목 3D 레고 포트폴리오

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -208,14 +208,15 @@ function Card({ item, stat, value, idleDelay = 0 }: { item: any; stat: Stat; val
   const tone = computeValueScore(item).tone;
   return (
     <HoloCard tone={tone} radius="rounded-3xl" idleDelay={idleDelay} className="w-full h-full">
-      <div className="w-full h-full rounded-3xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] shadow-sm p-5 sm:p-6 flex flex-col items-center text-center">
-        <StockLogo item={item} size={52} />
-        <div className="mt-2"><Medal item={item} lg /></div>
-        <p className="mt-2 font-black text-lg sm:text-xl text-neutral-900 dark:text-white leading-tight break-keep">{item.name}</p>
-        <p className="text-[11px] text-neutral-400 font-mono tracking-wider">{item.ticker}</p>
+      {/* 카드 면 위로 요소들이 떠올라(translateZ) 기울일 때 시차 깊이가 생김 (preserve-3d) */}
+      <div className="w-full h-full rounded-3xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] shadow-sm p-5 sm:p-6 flex flex-col items-center text-center [transform-style:preserve-3d]">
+        <div style={{ transform: "translateZ(42px)" }}><StockLogo item={item} size={52} /></div>
+        <div className="mt-2" style={{ transform: "translateZ(32px)" }}><Medal item={item} lg /></div>
+        <p className="mt-2 font-black text-lg sm:text-xl text-neutral-900 dark:text-white leading-tight break-keep" style={{ transform: "translateZ(26px)" }}>{item.name}</p>
+        <p className="text-[11px] text-neutral-400 font-mono tracking-wider" style={{ transform: "translateZ(18px)" }}>{item.ticker}</p>
         <div className="my-4 h-px w-16 bg-neutral-100 dark:bg-[#35332e]" />
-        <p className="text-[10px] font-bold text-neutral-400 uppercase tracking-widest">{stat.label}</p>
-        <div className="mt-1 text-2xl sm:text-3xl font-black tabular-nums text-[#16a34a] dark:text-[#16a34a] min-h-[2.5rem] flex items-center">
+        <p className="text-[10px] font-bold text-neutral-400 uppercase tracking-widest" style={{ transform: "translateZ(12px)" }}>{stat.label}</p>
+        <div className="mt-1 text-2xl sm:text-3xl font-black tabular-nums text-[#16a34a] dark:text-[#16a34a] min-h-[2.5rem] flex items-center" style={{ transform: "translateZ(24px)" }}>
           {value}
         </div>
       </div>
@@ -683,17 +684,18 @@ function DeckView({ deck, isLoggedIn, onLogin, onClose }: { deck: DeckItem[]; is
               <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
                 {cards.map(({ item: c }, ci) => (
                   <HoloCard key={c.ticker} tone={tone} radius="rounded-2xl" idleDelay={ci * 0.6}>
-                    <div className={cn("relative rounded-2xl border p-4 text-center flex flex-col items-center", TIER_CARD_BG[tone])}>
+                    <div className={cn("relative rounded-2xl border p-4 text-center flex flex-col items-center [transform-style:preserve-3d]", TIER_CARD_BG[tone])}>
                       <span className={cn("absolute top-1.5 right-1.5 px-1.5 py-0.5 rounded-full text-[10px] font-black tabular-nums leading-none",
                         (c.count ?? 1) > 1
                           ? "bg-[#16a34a] text-white"
-                          : "bg-neutral-200/70 text-neutral-500 dark:bg-[#35332e] dark:text-neutral-400")}>
+                          : "bg-neutral-200/70 text-neutral-500 dark:bg-[#35332e] dark:text-neutral-400")}
+                        style={{ transform: "translateZ(30px)" }}>
                         ×{c.count ?? 1}
                       </span>
-                      <StockLogo item={c} size={40} />
-                      <div className="mt-1.5"><Medal item={c} /></div>
-                      <p className="mt-1.5 font-bold text-sm text-neutral-900 dark:text-white truncate max-w-full">{c.name}</p>
-                      <p className="text-[10px] text-neutral-400 font-mono">{c.ticker}</p>
+                      <div style={{ transform: "translateZ(28px)" }}><StockLogo item={c} size={40} /></div>
+                      <div className="mt-1.5" style={{ transform: "translateZ(20px)" }}><Medal item={c} /></div>
+                      <p className="mt-1.5 font-bold text-sm text-neutral-900 dark:text-white truncate max-w-full" style={{ transform: "translateZ(14px)" }}>{c.name}</p>
+                      <p className="text-[10px] text-neutral-400 font-mono" style={{ transform: "translateZ(8px)" }}>{c.ticker}</p>
                     </div>
                   </HoloCard>
                 ))}

--- a/cf-idiotquant/app/(profile)/profile/page.tsx
+++ b/cf-idiotquant/app/(profile)/profile/page.tsx
@@ -4,7 +4,7 @@ import { useSession, signOut } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { LogOut, Eye, DollarSign, ChevronRight, ShieldCheck, Heart, Trash2 } from "lucide-react";
+import { LogOut, Eye, DollarSign, ChevronRight, ShieldCheck, Heart, Trash2, Blocks } from "lucide-react";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import {
     selectLikedList, selectLikesState,
@@ -12,6 +12,8 @@ import {
 } from "@/lib/features/stockLikes/stockLikesSlice";
 import { cn } from "@/lib/utils";
 import { CopyStockButtons, type CopyStock } from "@/components/copyStockButtons";
+import { computeValueScore, type ValueTone } from "@/lib/utils/valueScore";
+import PortfolioLegoTower from "@/components/profile/portfolioLegoTower";
 
 const STRATEGY_BADGE: Record<string, string> = {
     ncav:           "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-400",
@@ -30,6 +32,25 @@ const STRATEGY_LABEL: Record<string, string> = {
     near_ncav: "NCAV근접", balanced_value: "균형가치",
 };
 
+// 등급(tone) 표시 — 게임/valueScore 와 통일 (강한 순서)
+const TONE_ORDER: ValueTone[] = ["legend", "treasure", "diamond", "gold", "silver", "bronze", "raw", "explore"];
+const TONE_LABEL: Record<ValueTone, string> = {
+    legend: "전설", treasure: "보물", diamond: "다이아", gold: "금", silver: "은", bronze: "동", raw: "원석", explore: "탐색",
+};
+const TONE_MEDAL: Record<ValueTone, string> = {
+    legend: "👑", treasure: "🏆", diamond: "💎", gold: "🥇", silver: "🥈", bronze: "🥉", raw: "🪨", explore: "🧭",
+};
+const TONE_CSS: Record<ValueTone, string> = {
+    legend: "bg-violet-100 text-violet-700 dark:bg-violet-950/40 dark:text-violet-300",
+    treasure: "bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-300",
+    diamond: "bg-sky-100 text-sky-700 dark:bg-sky-950/40 dark:text-sky-300",
+    gold: "bg-yellow-100 text-yellow-700 dark:bg-yellow-950/40 dark:text-yellow-300",
+    silver: "bg-neutral-100 text-neutral-600 dark:bg-[#35332e] dark:text-neutral-300",
+    bronze: "bg-orange-100 text-orange-700 dark:bg-orange-950/40 dark:text-orange-300",
+    raw: "bg-stone-100 text-stone-600 dark:bg-stone-900/40 dark:text-stone-400",
+    explore: "bg-neutral-100 text-neutral-500 dark:bg-[#2c2b27] dark:text-neutral-500",
+};
+
 export default function ProfilePage() {
     const { data: session, status } = useSession();
     const router = useRouter();
@@ -46,6 +67,12 @@ export default function ProfilePage() {
         per: item.per,
         roe: Number(item.bps) > 0 ? (Number(item.eps) / Number(item.bps)) * 100 : null,
     }));
+
+    // 포트폴리오 탄탄함 — 관심 종목의 저평가 점수 평균 + 등급 분포
+    const scored = likedList.map(item => computeValueScore(item));
+    const solidity = scored.length ? Math.round(scored.reduce((a, v) => a + v.score, 0) / scored.length) : 0;
+    const solidityLabel = solidity >= 70 ? "매우 탄탄" : solidity >= 50 ? "탄탄" : solidity >= 35 ? "보통" : "보강 필요";
+    const toneCounts = scored.reduce((acc, v) => { acc[v.tone] = (acc[v.tone] ?? 0) + 1; return acc; }, {} as Record<string, number>);
 
     const isMasterUser = session?.user?.name === process.env.NEXT_PUBLIC_MASTER;
     const isAdmin = (session?.user as any)?.role === "admin";
@@ -193,6 +220,56 @@ export default function ProfilePage() {
                                 </span>
                                 <ChevronRight size={14} className="text-neutral-300 dark:text-neutral-600 group-hover:text-neutral-500 dark:group-hover:text-neutral-400 transition-colors" />
                             </Link>
+                        </div>
+                    </div>
+                )}
+
+                {/* 포트폴리오 탄탄함 (관심 종목 기반 3D 레고 타워) */}
+                {likedList.length > 0 && (
+                    <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200/70 dark:border-[#35332e] shadow-sm overflow-hidden">
+                        <div className="px-5 pt-4 pb-2 flex items-center justify-between">
+                            <div className="flex items-center gap-1.5">
+                                <Blocks size={12} className="text-[#16a34a]" />
+                                <span className="text-[10px] font-bold text-neutral-400 dark:text-neutral-500 uppercase tracking-widest">
+                                    포트폴리오 탄탄함
+                                </span>
+                            </div>
+                            <span className="text-[10px] text-neutral-400">관심 {likedList.length}종목 기반</span>
+                        </div>
+
+                        {/* 3D 레고 타워 */}
+                        <div className="h-60 sm:h-72 bg-gradient-to-b from-[#f4faf6] to-white dark:from-[#12241c] dark:to-[#242320]">
+                            <PortfolioLegoTower items={likedList} />
+                        </div>
+
+                        {/* 탄탄함 지수 */}
+                        <div className="px-5 py-4 flex items-end gap-4 border-t border-neutral-100 dark:border-[#35332e]">
+                            <div className="shrink-0">
+                                <p className="text-[10px] font-bold text-neutral-400 uppercase tracking-wider">탄탄함 지수</p>
+                                <p className="text-3xl font-black text-[#16a34a] tabular-nums leading-none mt-1">
+                                    {solidity}<span className="text-base text-neutral-400 font-bold">/100</span>
+                                </p>
+                            </div>
+                            <div className="flex-1 min-w-0 pb-0.5">
+                                <div className="flex items-center justify-between mb-1.5">
+                                    <span className="text-xs font-black text-neutral-700 dark:text-neutral-200">{solidityLabel}</span>
+                                    <span className="text-[10px] text-neutral-400">
+                                        블록 {Math.min(likedList.length, 18)}{likedList.length > 18 ? ` / ${likedList.length}` : ""}
+                                    </span>
+                                </div>
+                                <div className="h-2 rounded-full bg-neutral-100 dark:bg-[#35332e] overflow-hidden">
+                                    <div className="h-full rounded-full bg-gradient-to-r from-[#16a34a] to-emerald-400 transition-all" style={{ width: `${solidity}%` }} />
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* 등급 분포 */}
+                        <div className="px-5 pb-4 flex flex-wrap gap-1.5">
+                            {TONE_ORDER.filter(t => toneCounts[t]).map(t => (
+                                <span key={t} className={cn("inline-flex items-center gap-1 text-[10px] font-bold px-2 py-0.5 rounded-full", TONE_CSS[t])}>
+                                    <span aria-hidden>{TONE_MEDAL[t]}</span>{TONE_LABEL[t]} {toneCounts[t]}
+                                </span>
+                            ))}
                         </div>
                     </div>
                 )}

--- a/cf-idiotquant/components/profile/portfolioLegoTower.tsx
+++ b/cf-idiotquant/components/profile/portfolioLegoTower.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+// 좋아요(관심) 종목 기반 "포트폴리오 탄탄함" 3D 레고 타워.
+// 종목별 저평가 점수(computeValueScore)로 블록을 만들어, 강한 종목일수록 넓은 블록을 아래(기반)에 쌓는다.
+// 색은 게임 등급(메달)과 통일. three.js(WebGL) — 홈 HeroArt 와 동일 패턴.
+
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
+import { computeValueScore, type ValueTone } from "@/lib/utils/valueScore";
+import type { LikedStockItem } from "@/lib/features/stockLikes/stockLikesSlice";
+
+const TIER_HEX: Record<ValueTone, number> = {
+  legend: 0x8b5cf6, treasure: 0xf59e0b, diamond: 0x38bdf8, gold: 0xeab308,
+  silver: 0xa3a3a3, bronze: 0xf97316, raw: 0xa8a29e, explore: 0xd4d4d4,
+};
+
+// 점수 → 블록 폭(스터드 개수). 강할수록 넓은 기반.
+const studsFor = (score: number) => (score >= 70 ? 4 : score >= 45 ? 3 : 2);
+
+const MAX_BRICKS = 18; // 타워 높이 상한 (상위 점수 종목 우선)
+
+export default function PortfolioLegoTower({ items }: { items: LikedStockItem[] }) {
+  const mountRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const mount = mountRef.current;
+    if (!mount) return;
+    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+    // 점수 내림차순 → 강한 종목이 아래(기반)
+    const bricks = items
+      .map(it => ({ tone: computeValueScore(it).tone, score: computeValueScore(it).score }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_BRICKS);
+    if (bricks.length === 0) return;
+
+    const U = 1;          // 스터드 피치
+    const H = 1.15;       // 블록 높이
+    const GAP = 0.06;
+    const studR = 0.3, studH = 0.24, DEPTH = 2;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(38, 1, 0.1, 100);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.toneMappingExposure = 1.05;
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    const canvas = renderer.domElement;
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+    canvas.style.display = "block";
+    mount.appendChild(canvas);
+
+    const disposables: { dispose: () => void }[] = [];
+    const pmrem = new THREE.PMREMGenerator(renderer);
+    const envRT = pmrem.fromScene(new RoomEnvironment(), 0.04);
+    scene.environment = envRT.texture;
+    pmrem.dispose();
+    disposables.push(envRT.texture);
+
+    scene.add(new THREE.HemisphereLight(0xffffff, 0x9a9a88, 0.55));
+    const key = new THREE.DirectionalLight(0xfff4e0, 2.4);
+    key.position.set(5, 9, 6);
+    scene.add(key);
+    const rim = new THREE.DirectionalLight(0xbfe3ff, 0.9);
+    rim.position.set(-6, 4, -5);
+    scene.add(rim);
+
+    const tower = new THREE.Group();
+    scene.add(tower);
+
+    const studGeo = new THREE.CylinderGeometry(studR, studR, studH, 16);
+    disposables.push(studGeo);
+    let maxW = 2;
+
+    bricks.forEach((b, i) => {
+      const nx = studsFor(b.score);
+      maxW = Math.max(maxW, nx);
+      const w = nx * U, d = DEPTH * U;
+      const color = TIER_HEX[b.tone];
+      const mat = new THREE.MeshPhysicalMaterial({ color, roughness: 0.34, clearcoat: 0.7, clearcoatRoughness: 0.28 });
+      disposables.push(mat);
+
+      const boxGeo = new THREE.BoxGeometry(w - GAP, H - GAP, d - GAP);
+      disposables.push(boxGeo);
+      const y = i * H + H / 2;
+      const brick = new THREE.Mesh(boxGeo, mat);
+      brick.position.set(0, y, 0);
+      tower.add(brick);
+
+      // 스터드 (nx × 2 격자)
+      for (let sx = 0; sx < nx; sx++) {
+        for (let sz = 0; sz < DEPTH; sz++) {
+          const stud = new THREE.Mesh(studGeo, mat);
+          stud.position.set((sx - (nx - 1) / 2) * U, i * H + H + studH / 2 - GAP / 2, (sz - (DEPTH - 1) / 2) * U);
+          tower.add(stud);
+        }
+      }
+    });
+
+    const towerH = bricks.length * H;
+    tower.position.y = -towerH / 2; // 중앙 정렬
+
+    // 바닥 소프트 섀도
+    const shadowCanvas = document.createElement("canvas");
+    shadowCanvas.width = shadowCanvas.height = 128;
+    const sctx = shadowCanvas.getContext("2d")!;
+    const grad = sctx.createRadialGradient(64, 64, 4, 64, 64, 62);
+    grad.addColorStop(0, "rgba(20,40,25,0.5)");
+    grad.addColorStop(1, "rgba(0,0,0,0)");
+    sctx.fillStyle = grad; sctx.fillRect(0, 0, 128, 128);
+    const shadowTex = new THREE.CanvasTexture(shadowCanvas);
+    shadowTex.colorSpace = THREE.SRGBColorSpace;
+    const shadowMat = new THREE.MeshBasicMaterial({ map: shadowTex, transparent: true, depthWrite: false, opacity: 0.5 });
+    const shadowGeo = new THREE.PlaneGeometry(1, 1);
+    disposables.push(shadowTex, shadowMat, shadowGeo);
+    const shadow = new THREE.Mesh(shadowGeo, shadowMat);
+    shadow.rotation.x = -Math.PI / 2;
+    shadow.position.y = -towerH / 2 - 0.02;
+    shadow.scale.set(maxW * 2.6, DEPTH * 3, 1);
+    tower.add(shadow);
+
+    // 카메라 프레이밍 — 타워 높이·폭에 맞춤
+    const fit = Math.max(towerH * 0.62, maxW * 1.4);
+    const dist = fit / Math.tan((camera.fov * Math.PI) / 180 / 2) + 3.5;
+    camera.position.set(dist * 0.05, towerH * 0.08, dist);
+    camera.lookAt(0, 0, 0);
+
+    const resize = () => {
+      const w = mount.clientWidth || 1, h = mount.clientHeight || 1;
+      renderer.setSize(w, h, false);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(mount);
+
+    const clock = new THREE.Clock();
+    let raf = 0;
+    const render = () => {
+      const t = clock.getElapsedTime();
+      tower.rotation.y = t * 0.4;
+      tower.position.y = -towerH / 2 + Math.sin(t * 0.8) * 0.12;
+      renderer.render(scene, camera);
+      raf = requestAnimationFrame(render);
+    };
+    if (reduce) {
+      tower.rotation.y = -0.5;
+      renderer.render(scene, camera);
+    } else {
+      raf = requestAnimationFrame(render);
+    }
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      disposables.forEach(d => d.dispose());
+      renderer.dispose();
+      if (canvas.parentNode) canvas.parentNode.removeChild(canvas);
+    };
+  }, [items]);
+
+  return <div ref={mountRef} className="w-full h-full" aria-hidden="true" />;
+}


### PR DESCRIPTION
두 개의 독립 변경.

## 1. 게임 카드 3D 패럴랙스 깊이 (`app/(game)/game/page.tsx`)
기존엔 카드가 통째로 기울기만 했는데, 카드 면 **위로 요소들이 떠오르도록**(`translateZ` + `preserve-3d`) 개선 → 기울일 때 레이어별 시차로 진짜 입체감.
- 비교 카드: 로고(42px)→메달(32px)→이름(26px)→가격(24px) 깊이 차등(깊게)
- 덱 수집 카드: 로고·메달·×N 배지 가볍게 띄움
- 기존 아이들 애니메이션·포인터 틸트·홀로그램 포일과 결합

## 2. 관심 종목 기반 3D 레고 포트폴리오 탄탄함 (`components/profile/portfolioLegoTower.tsx`, `app/(profile)/profile/page.tsx`)
좋아요(관심) 종목을 저평가 점수(`computeValueScore`)로 **레고 블록**화해 3D로 쌓아 포트폴리오가 얼마나 탄탄한지 시각화.
- **강한 종목일수록 넓은 블록(4칸) → 아래 기반**, 약할수록 좁은 블록(2칸) → 위로 ("탄탄한 기반" 은유)
- 블록 색 = 게임 등급(메달)과 통일, 스터드 얹힌 3D 플라스틱 재질 + 회전·부유. three.js(홈 HeroArt 패턴), `prefers-reduced-motion` 시 정적, 상위 18블록 캡
- 유저 정보 페이지에 **탄탄함 지수**(관심 종목 평균 점수)·등급 라벨·진행 막대·등급 분포 칩과 함께 표시(관심 종목 있을 때만)

## 검증
- `npx tsc --noEmit` 통과 · `npm run build` 통과(`/game`·`/profile` 컴파일)
- 게임 패럴랙스·레고 타워 모두 스탠드얼론 렌더 스크린샷으로 시각 확인(레고는 실제 three.js를 importmap으로 렌더)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_