### PR TITLE
fix(search): 연속 종목 검색 시 name 상태 레이스 컨디션 수정

### DIFF
--- a/cf-idiotquant/app/(search)/search/hooks/useStockSearch.ts
+++ b/cf-idiotquant/app/(search)/search/hooks/useStockSearch.ts
@@ -108,11 +108,15 @@ export function useStockSearch() {
     const onSearch = useCallback(async (stockName: string) => {
         if (!stockName) return;
 
+        // 연속 검색 시 이전 호출의 await가 나중에 끝나 name이 뒤집히는 것을 막기 위해
+        // await 이전에 동기적으로 호출 순서대로 세팅한다.
+        dispatch(addKrMarketHistory(stockName));
+        setName(stockName);
+        setWaitResponse(true);
+
         const upper = stockName.toUpperCase();
         const usOverrides = await loadUsOverrides();
         const isUs = us_tickers.includes(upper) || usOverrides.has(upper);
-        dispatch(addKrMarketHistory(stockName));
-        setName(stockName);
 
         if (!isUs) {
             setKrOrUs("KR");
@@ -135,7 +139,6 @@ export function useStockSearch() {
                 }));
                 dispatch(reqGetBalanceSheet({ PDNO: code }));
                 dispatch(reqGetIncomeStatement({ PDNO: code }));
-                setWaitResponse(true);
             } else {
                 // 유효한 6자리 KR 코드가 없으면 US 티커로 폴백 (오버라이드 country 미설정 등)
                 setKrOrUs("US");


### PR DESCRIPTION
## 문제
`/analyze` 페이지에서 연속으로 종목을 검색하면 로딩이 멈춘 것처럼 보이는 문제.

원인: `useStockSearch.ts`의 `onSearch`에서 `setName(stockName)`이 `await loadUsOverrides()` 이후에 호출됐음. 빠르게 연속 검색하면 먼저 시작한 검색의 `await`가 나중에 끝나면서 `name` 상태가 최신 검색과 어긋나게 세팅될 수 있었고, `analyze/page.tsx`의 `isLoaded`/`isPriceLoaded`가 `tickerFromUrl === name` 조건에 의존하기 때문에 이 불일치가 생기면 로딩 스켈레톤이 안 사라짐.

## 변경 (`app/(search)/search/hooks/useStockSearch.ts`)
- `setName`/`setWaitResponse(true)`/`addKrMarketHistory` 디스패치를 `await` 이전, 함수 최상단으로 이동 — 연속 호출이 호출 순서대로 동기 반영되도록 함.
- 기존에 KR 코드 매칭 분기에만 있던 `setWaitResponse(true)`를 모든 경로(KR/US)에서 일관되게 적용.

## 검증
- `npx tsc --noEmit` 통과
- `npm run build` 통과 (`/analyze` 컴파일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_