### PR TITLE
feat(game): 코인 획득 방법을 게임 흐름·UI에서 자연스럽게 안내

### DIFF
--- a/cf-idiotquant/app/(game)/game/gameShop.tsx
+++ b/cf-idiotquant/app/(game)/game/gameShop.tsx
@@ -9,7 +9,11 @@ import { useState } from "react";
 import { Coins, Sparkles, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { convertDupes, spendCoins, type DeckCardSnapshot } from "@/lib/features/deck/deckAPI";
+import { computeValueScore } from "@/lib/utils/valueScore";
 import { type DeckItem } from "./page";
+
+// 워커 COIN_VALUE(d1Store.js)와 동일한 등급→코인 표 — 전환 팝오버에 예상 획득량을 보여주기 위한 표시용 사본.
+const COIN_VALUE: Record<string, number> = { explore: 1, raw: 2, bronze: 3, silver: 5, gold: 8, diamond: 12, treasure: 18, legend: 30 };
 
 export function WalletChip({ coins }: { coins: number }) {
   return (
@@ -28,6 +32,7 @@ export function ConvertButton({ item, count, onConverted }: {
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const max = count - 1; // 최소 1장은 남김
+  const perCard = COIN_VALUE[computeValueScore(item).tone] ?? COIN_VALUE.explore;
   if (max < 1) return null;
 
   const convert = async () => {
@@ -50,14 +55,17 @@ export function ConvertButton({ item, count, onConverted }: {
           <Coins size={9} /> 전환
         </button>
       ) : (
-        <span className="flex items-center gap-1 px-1.5 py-1 rounded-lg bg-black/85 text-white text-[9px]">
-          <input type="number" min={1} max={max} value={amount}
-            onChange={e => setAmount(Math.max(1, Math.min(max, Number(e.target.value) || 1)))}
-            className="w-8 bg-white/10 rounded px-1 py-0.5 text-center" />
-          <button type="button" disabled={pending} onClick={convert} className="font-black text-amber-300 disabled:opacity-50">
-            {pending ? "…" : "확인"}
-          </button>
-          <button type="button" onClick={() => setOpen(false)} className="text-neutral-400"><X size={10} /></button>
+        <span className="flex flex-col gap-1 px-1.5 py-1 rounded-lg bg-black/85 text-white text-[9px] w-max">
+          <span className="flex items-center gap-1">
+            <input type="number" min={1} max={max} value={amount}
+              onChange={e => setAmount(Math.max(1, Math.min(max, Number(e.target.value) || 1)))}
+              className="w-8 bg-white/10 rounded px-1 py-0.5 text-center" />
+            <button type="button" disabled={pending} onClick={convert} className="font-black text-amber-300 disabled:opacity-50">
+              {pending ? "…" : "확인"}
+            </button>
+            <button type="button" onClick={() => setOpen(false)} className="text-neutral-400"><X size={10} /></button>
+          </span>
+          <span className="text-neutral-400">1장당 🪙{perCard} · 예상 <b className="text-amber-300">🪙{perCard * amount}</b></span>
         </span>
       )}
       {error && <span className="block mt-0.5 px-1 py-0.5 rounded bg-rose-950/80 text-rose-300 text-[8px]">{error}</span>}
@@ -93,6 +101,9 @@ export function ShopPanel({ coins, onBuy, onClose }: {
         </p>
         <button onClick={onClose} className="text-xs font-bold text-neutral-500 hover:text-[#16a34a]">닫기 ▶</button>
       </div>
+      <p className="text-[11px] text-neutral-400 mb-3 break-keep">
+        🪙 코인은 <b className="text-neutral-600 dark:text-neutral-300">내 덱에서 중복 카드(×2 이상)를 전환</b>하면 모을 수 있어요. 등급이 높을수록 더 많이 받아요.
+      </p>
       <div className="space-y-2">
         {BOOST_ITEMS.map(item => (
           <div key={item.id} className="flex items-center justify-between gap-2 rounded-xl border border-neutral-100 dark:border-[#35332e] bg-[#faf9f7] dark:bg-[#1f1e1b] p-3">

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -534,6 +534,7 @@ export default function GamePage() {
   const [showShop, setShowShop] = useState(false);
   const [activeBoost, setActiveBoost] = useState<{ mult: number; roundsLeft: number } | null>(null); // 상점 부스트(세션 로컬)
   const [packOpening, setPackOpening] = useState(false); // 팩 오픈 리빌 연출 표시 중
+  const [firstDupHint, setFirstDupHint] = useState(false); // 첫 중복 카드 획득 시 지갑/전환 안내
 
   useEffect(() => { dispatch(reqGetNcavDailyList("latest")); }, [dispatch]);
 
@@ -600,7 +601,7 @@ export default function GamePage() {
     if (!a) return;
     setAnchor(a); setChallenger(draw(a.ticker));
     // 새 게임에서도 직전 항해 기록 카드 몇 장은 필름스트립 왼쪽에 남겨둠(연속성)
-    setStreak(0); setNewBest(false); setLastWin(null); setDropped(false); setDropPrompt(false); setSaveFail(null); setEscaped(null); setMissed(null); setAcquired([]); setHistory(h => h.slice(-3)); setPackOpening(false); setPhase("guessing");
+    setStreak(0); setNewBest(false); setLastWin(null); setDropped(false); setDropPrompt(false); setSaveFail(null); setEscaped(null); setMissed(null); setAcquired([]); setHistory(h => h.slice(-3)); setPackOpening(false); setFirstDupHint(false); setPhase("guessing");
   }, [draw]);
 
   const started = useRef(false);
@@ -613,7 +614,7 @@ export default function GamePage() {
     const av = STAT.get(anchor), cv = STAT.get(challenger);
     const win = dir === "higher" ? cv >= av : cv <= av;   // 동점은 승리 처리
     setLastWin(win);
-    setDropped(false); setDropPrompt(false); setSaveFail(null); setEscaped(null);
+    setDropped(false); setDropPrompt(false); setSaveFail(null); setEscaped(null); setFirstDupHint(false);
     setPhase("revealed");
 
     // 상점에서 산 확률 부스트는 세션 로컬로만 추적 — 라운드(승패 무관)마다 1씩 소진
@@ -644,6 +645,7 @@ export default function GamePage() {
           addDeckCard(snap).then(res => {
             if (res?.added) {
               setDropped(true);
+              if (res.count === 2) setFirstDupHint(true); // 처음으로 중복 카드가 생긴 순간 — 전환 기능 안내
               setAcquired(prev => [snap, ...prev]); // 이번 항해 획득 목록에 추가
               // 같은 종목이면 개수 누적, 없으면 새로 추가
               setDeck(prev => {
@@ -683,7 +685,7 @@ export default function GamePage() {
     setHistory(h => [...h, anchor]);   // 왼쪽 카드를 항해 기록에 쌓음(오른쪽 카드가 왼쪽 자리로)
     setAnchor(challenger);
     setChallenger(draw(challenger?.ticker));
-    setDropped(false); setDropPrompt(false); setSaveFail(null); setEscaped(null); setLastWin(null); setPackOpening(false); setPhase("guessing");
+    setDropped(false); setDropPrompt(false); setSaveFail(null); setEscaped(null); setLastWin(null); setPackOpening(false); setFirstDupHint(false); setPhase("guessing");
   }, [lastWin, anchor, challenger, draw]);
 
   // 카드가 늘거나 라운드가 바뀌면 필름스트립을 우측 끝(최신)으로 부드럽게 스크롤 → 카드가 왼쪽으로 흐르는 효과
@@ -851,8 +853,16 @@ export default function GamePage() {
                   ) : (
                     <>
                       {phase === "revealed" && dropped && (
-                        <span className="inline-flex items-center gap-1 text-xs font-bold text-amber-600 dark:text-amber-400 animate-in fade-in slide-in-from-bottom-1">
-                          <Sparkles size={12} /> 카드 획득! {challenger.name} 이(가) 덱에 추가됨
+                        <span className="flex flex-col items-center gap-1 animate-in fade-in slide-in-from-bottom-1">
+                          <span className="inline-flex items-center gap-1 text-xs font-bold text-amber-600 dark:text-amber-400">
+                            <Sparkles size={12} /> 카드 획득! {challenger.name} 이(가) 덱에 추가됨
+                          </span>
+                          {firstDupHint && (
+                            <button onClick={() => setShowDeck(true)}
+                              className="text-[10px] font-bold text-neutral-400 hover:text-[#16a34a] hover:underline">
+                              🪙 같은 카드가 2장이 됐어요 — 내 덱에서 코인으로 전환해보세요 →
+                            </button>
+                          )}
                         </span>
                       )}
                       {phase === "revealed" && dropPrompt && (


### PR DESCRIPTION
## 배경
지갑(코인) 기능이 추가됐지만 "코인을 어떻게 모으는지" 알기 어렵다는 피드백. 게임 진행 흐름 속에서 자연스럽게 알 수 있도록 + 관련 UI에 설명을 추가.

## 변경 (`app/(game)/game/page.tsx`, `gameShop.tsx`)

1. **게임 중 자연스러운 안내** — 같은 카드가 처음으로 2장이 되는 순간(`res.count === 2`), "카드 획득!" 메시지 아래 "🪙 같은 카드가 2장이 됐어요 — 내 덱에서 코인으로 전환해보세요 →" 안내가 뜨고, 클릭하면 바로 내 덱 화면이 열림. 라운드가 바뀌면(start/next/guess 리셋) 사라짐.
2. **상점 설명** — 상점 패널 상단에 "코인은 내 덱에서 중복 카드(×2 이상)를 전환하면 모을 수 있어요. 등급이 높을수록 더 많이 받아요" 설명 추가.
3. **전환 시 즉시 예상 코인 표시** — 덱의 "전환" 버튼을 누르면 개수 입력 옆에 "1장당 🪙N · 예상 🪙M"을 바로 보여줌. 워커 `COIN_VALUE` 표를 표시용으로 소량 미러링(점수 산정 알고리즘 자체는 복제하지 않음).

## 검증
- `npx tsc --noEmit`, `npm run build`(`/game` 컴파일) 통과
- Chromium 렌더로 세 가지 모두 확인: 게임 중 중복 획득 시 안내 문구·링크, 상점 설명 문구, 전환 팝오버의 등급별 코인 예상치(예: 은 등급 카드 → "1장당 🪙5 · 예상 🪙5")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_