### PR TITLE
fix(game): 드래그 카드 사라짐/레이아웃 겹침 버그 수정 + 적 ASCII 아트·전투 로그 추가

### DIFF
--- a/cf-idiotquant/app/(game)/game/gameTypes.ts
+++ b/cf-idiotquant/app/(game)/game/gameTypes.ts
@@ -66,3 +66,7 @@ export interface PlayerState {
   energy: number;
   energyMax: number;
 }
+
+// 전투 로그 한 줄 — D&D 전투기록처럼 실제 수치를 담아 쌓아가는 메시지.
+export type LogKind = "player" | "enemy" | "item" | "system";
+export interface LogEntry { id: string; kind: LogKind; text: string }

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -29,6 +29,7 @@ import { HOLO_THRESHOLD, PackReveal, AchievementBadges, ACHIEVEMENTS } from "./g
 import { WalletChip, ConvertButton, ShopPanel, BOOST_ITEMS } from "./gameShop";
 import { useGameRun, deckTotal, type DeckItem } from "./useGameRun";
 import { HpBar, EnergyBar, ItemBar } from "@/components/game/CombatHud";
+import CombatLog from "@/components/game/CombatLog";
 
 const PhaserCombatCanvas = dynamic(() => import("@/components/game/PhaserCombatCanvas"), { ssr: false });
 const HandView = dynamic(() => import("@/components/game/HandView"), { ssr: false });
@@ -643,10 +644,13 @@ function GameContent() {
                 <ResolvedScreen run={run} />
               ) : run.enemy ? (
                 <div className="flex-1 min-h-0 flex flex-col">
-                  <div className="flex-1 min-h-0 rounded-2xl overflow-hidden backdrop-blur-md bg-white/60 dark:bg-white/[0.03] border border-black/5 dark:border-white/10">
+                  <div className="flex-1 min-h-0 flex flex-col rounded-2xl overflow-hidden backdrop-blur-md bg-white/60 dark:bg-white/[0.03] border border-black/5 dark:border-white/10">
                     <HandView cards={run.hand} energy={run.player.energy} freeCostThreshold={run.passive.freeCostThreshold} onPlayCard={run.playHandCard}>
                       <PhaserCombatCanvas enemy={run.enemy} player={run.player} introLabel={introLabel} />
                     </HandView>
+                  </div>
+                  <div className="shrink-0 pt-1.5">
+                    <CombatLog entries={run.log} />
                   </div>
                   <div className="shrink-0 pt-1.5 flex justify-center">
                     <button type="button" onClick={run.endTurn}

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -14,7 +14,7 @@ import {
 import { ALL_ITEMS, STARTER_DECK, pickItemChoices, acquireChance } from "./gameData";
 import { ACHIEVEMENTS } from "./gameCollectibles";
 import type {
-  Phase, EncounterType, CombatCard, ItemDef, OwnedItem, EnemyState, PlayerState, ActiveEffect,
+  Phase, EncounterType, CombatCard, ItemDef, OwnedItem, EnemyState, PlayerState, ActiveEffect, LogEntry, LogKind,
 } from "./gameTypes";
 
 const safeNum = (v: any): number => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
@@ -77,6 +77,11 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   const [pile, setPile] = useState<Pile>({ draw: [], hand: [], discard: [] });
   const reservedRefundRef = useRef(0); // 이번 턴에 낸 카드들의 refund 합 — 다음 턴 시작 시 에너지로 편입
 
+  const [log, setLog] = useState<LogEntry[]>([]);
+  const pushLog = useCallback((kind: LogKind, text: string) => {
+    setLog(prev => [...prev.slice(-49), { id: `l${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`, kind, text }]);
+  }, []);
+
   const [lastResult, setLastResult] = useState<{ win: boolean; goldGain?: number } | null>(null);
   const [dropped, setDropped] = useState(false);
   const [dropPrompt, setDropPrompt] = useState(false);
@@ -115,6 +120,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   // 승리(층 클리어) 공통 처리 — 최고기록·골드·아이템 제공·카드 수집 판정
   const handleWin = useCallback((beatenEnemy: EnemyState, enc: EncounterType, floor: number) => {
     const nt = floor + 1; // 클리어한 층수(0-indexed floor → 1부터)
+    pushLog("system", `🏆 ${beatenEnemy.item?.name ?? "적"}을(를) 처치했습니다!`);
     if (nt > best) {
       setBest(nt); setNewBest(true);
       try { localStorage.setItem(bestKey, String(nt)); } catch { }
@@ -146,6 +152,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     addDeckCard(snap).then(res => {
       if (res?.added) {
         setDropped(true);
+        pushLog("system", `✨ ${snap.name} 카드를 획득했습니다!`);
         setAcquired(prev => [snap, ...prev]);
         setDeck(prev => {
           const i = prev.findIndex(c => c.ticker === snap.ticker);
@@ -156,7 +163,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
         setSaveFail(deckFailReason(res));
       }
     }).catch(() => setSaveFail("네트워크 오류"));
-  }, [best, isLoggedIn, availableItemPool, unlockedLegendItems, setDeck, activeBoost]);
+  }, [best, isLoggedIn, availableItemPool, unlockedLegendItems, setDeck, activeBoost, pushLog]);
 
   // 손패 카드 발동 — dnd-kit 드롭 이벤트에서 호출
   const playHandCard = useCallback((instanceId: string) => {
@@ -170,8 +177,11 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setEnemy(result.enemy);
     setPile(p => ({ ...p, hand: p.hand.filter(c => c.instanceId !== instanceId), discard: [...p.discard, card] }));
     reservedRefundRef.current += card.stats.refund;
+    const parts = [`⚔${card.stats.attack} 피해`];
+    if (card.stats.shield > 0) parts.push(`🛡${card.stats.shield} 방어`);
+    pushLog("player", `${card.name} 발동 — ${parts.join(", ")} (에너지 -${cost})`);
     if (checkOutcome(result.player, result.enemy) === "win") handleWin(result.enemy, encounter, roundNum);
-  }, [phase, enemy, pile.hand, passive, player, encounter, roundNum, handleWin]);
+  }, [phase, enemy, pile.hand, passive, player, encounter, roundNum, handleWin, pushLog]);
 
   // 액티브 아이템 즉시 발동(1회 소모)
   const useOwnedActiveItem = useCallback((instanceId: string) => {
@@ -183,15 +193,19 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setPlayer(r.player); setEnemy(r.enemy);
     setPile({ hand: r.hand, draw: r.drawPile, discard: r.discardPile });
     setOwnedItems(prev => prev.filter(o => o.instanceId !== instanceId));
+    pushLog("item", `🎒 ${def.name} 사용 — ${def.desc}`);
     if (checkOutcome(r.player, r.enemy) === "win") handleWin(r.enemy, encounter, roundNum);
-  }, [phase, enemy, ownedItems, player, pile, encounter, roundNum, handleWin]);
+  }, [phase, enemy, ownedItems, player, pile, encounter, roundNum, handleWin, pushLog]);
 
   // 턴 종료 — 적 턴 해석 → (생존 시) 다음 턴 시작(에너지 리필+예약환급, 손패 재드로우)
   const endTurn = useCallback(() => {
     if (phase !== "battling" || !enemy) return;
+    const blocked = Math.min(enemy.nextAttack, player.block + passive.damageReduce);
+    const dmg = enemy.nextAttack - blocked;
+    pushLog("enemy", `${enemy.item?.name ?? "적"}의 공격! ⚔${enemy.nextAttack} 중 🛡${blocked} 경감 → ${dmg} 피해`);
     const afterEnemy = resolveEnemyTurn(player, enemy, passive);
     setPlayer(afterEnemy);
-    if (afterEnemy.hp <= 0) { setPhase("over"); setLastResult({ win: false }); return; }
+    if (afterEnemy.hp <= 0) { setPhase("over"); setLastResult({ win: false }); pushLog("system", "💀 쓰러졌습니다..."); return; }
     const rr = reservedRefundRef.current; reservedRefundRef.current = 0;
     setPlayer(p => startTurn(p, passive, rr));
     setPile(prev => {
@@ -199,7 +213,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       const r = drawHand(prev.draw, carryDiscard, HAND_SIZE + passive.drawBonus);
       return { draw: r.drawPile, hand: r.hand, discard: r.discardPile };
     });
-  }, [phase, enemy, player, passive]);
+  }, [phase, enemy, player, passive, pushLog]);
 
   // 다음 라운드 진입 — 조우 판정 후 배틀(적 생성+손패 재드로우) 또는 이벤트(상인/휴식)
   const advanceToRound = useCallback((nextRoundNum: number) => {
@@ -208,8 +222,9 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setEncounter(enc);
     setLastResult(null); setDropped(false); setDropPrompt(false); setSaveFail(null); setPackOpening(false);
 
-    if (enc === "merchant") { setEnemy(null); setPhase("event"); return; }
+    if (enc === "merchant") { pushLog("system", "🛒 떠돌이 상인을 만났습니다."); setEnemy(null); setPhase("event"); return; }
     if (enc === "rest") {
+      pushLog("system", "🏕️ 잠깐의 휴식.");
       setPlayer(p => {
         const healed = p.hp < p.maxHp;
         setRestHealed(healed);
@@ -220,6 +235,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
 
     const newEnemy = enemyForFloor(pool, nextRoundNum, enc as "battle" | "boss" | "elite");
     setEnemy(newEnemy);
+    pushLog("system", `${enc === "boss" ? "👑" : enc === "elite" ? "🗡️" : "🐉"} ${newEnemy.item?.name ?? "적"} 등장! (HP ${newEnemy.maxHp})`);
     setPile(prev => {
       const carryDiscard = [...prev.discard, ...prev.hand];
       const r = drawHand(prev.draw, carryDiscard, HAND_SIZE + passive.drawBonus);
@@ -228,7 +244,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     const rr = reservedRefundRef.current; reservedRefundRef.current = 0;
     setPlayer(p => startTurn(p, passive, rr));
     setPhase("battling");
-  }, [pool, passive]);
+  }, [pool, passive, pushLog]);
 
   const nextRound = useCallback(() => { if (phase === "resolved") advanceToRound(roundNum + 1); }, [phase, roundNum, advanceToRound]);
   const proceedFromEvent = useCallback(() => { if (phase === "event") advanceToRound(roundNum + 1); }, [phase, roundNum, advanceToRound]);
@@ -266,6 +282,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     const hp = BASE_HP;
     setPlayer({ hp, maxHp: hp, block: 0, energy: ENERGY_MAX, energyMax: ENERGY_MAX });
     prevMaxHpRef.current = hp;
+    setLog([{ id: "l0", kind: "system", text: `🐉 ${newEnemy.item?.name ?? "적"} 등장! (HP ${newEnemy.maxHp})` }]);
     setPhase("battling");
   }, [pool, deck]);
 
@@ -277,7 +294,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   return {
     phase, roundNum, encounter, restHealed, gold, best, newBest,
     ownedItems, ownedDefs, itemChoices, passive, maxHp, unlockedLegendItems, activeBoost,
-    player, enemy, hand: pile.hand, drawCount: pile.draw.length,
+    player, enemy, hand: pile.hand, drawCount: pile.draw.length, log,
     lastResult, dropped, dropPrompt, saveFail, packOpening, acquired, acquirePct,
     start, playHandCard, useOwnedActiveItem, endTurn, nextRound, proceedFromEvent, cashOut, buyMerchantHeal, buyBoost, pickItem, skipItem,
   };

--- a/cf-idiotquant/components/game/CombatLog.tsx
+++ b/cf-idiotquant/components/game/CombatLog.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+// 전투 기록 — D&D 전투기록처럼 카드 발동/적 공격/아이템 사용 결과를 실제 수치와 함께 쌓아 보여줌.
+// 순수 표시용(useGameRun의 log 배열을 그대로 렌더링), 새 항목이 추가되면 자동으로 맨 아래로 스크롤.
+
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import type { LogEntry } from "@/app/(game)/game/gameTypes";
+
+const KIND_COLOR: Record<string, string> = {
+  player: "text-emerald-400",
+  enemy: "text-rose-400",
+  item: "text-amber-400",
+  system: "text-neutral-400",
+};
+
+export default function CombatLog({ entries }: { entries: LogEntry[] }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => { ref.current?.scrollTo({ top: ref.current.scrollHeight }); }, [entries]);
+
+  return (
+    <div ref={ref} className="shrink-0 h-14 sm:h-16 overflow-y-auto rounded-lg bg-black/85 border border-white/10 px-2 py-1 font-mono">
+      {entries.map(e => (
+        <p key={e.id} className={cn("text-[10px] leading-relaxed break-keep", KIND_COLOR[e.kind] ?? "text-neutral-400")}>
+          <span aria-hidden className="opacity-50">&gt; </span>{e.text}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/cf-idiotquant/components/game/CombatScene.ts
+++ b/cf-idiotquant/components/game/CombatScene.ts
@@ -1,11 +1,26 @@
 import Phaser from "phaser";
 
-// 가치투자 덱빌더 — 전투 씬(프로토타입 비주얼). 사각형/텍스트 placeholder + 단순 트윈만 사용.
+// 가치투자 덱빌더 — 전투 씬(프로토타입 비주얼). 몬스터는 모노스페이스 ASCII 아트로 그린다.
 // 판정 로직은 전혀 없음 — combatEngine이 계산한 결과를 받아 재생만 한다.
+const ASCII_MONSTER = [
+  "   ▄▄▄▄▄▄▄   ",
+  " ▄█▀▀   ▀▀█▄ ",
+  "█  ●     ●  █",
+  "█     ▼     █",
+  " █▄       ▄█ ",
+  "   ▀▀▀▀▀▀▀   ",
+].join("\n");
+
+const BAR_LEN = 14;
+function asciiBar(hp: number, maxHp: number): string {
+  const pct = maxHp > 0 ? Math.max(0, Math.min(1, hp / maxHp)) : 0;
+  const filled = Math.round(pct * BAR_LEN);
+  return `[${"█".repeat(filled)}${"░".repeat(BAR_LEN - filled)}] ${Math.max(0, hp)}/${maxHp}`;
+}
+
 export default class CombatScene extends Phaser.Scene {
-  private enemyBox!: Phaser.GameObjects.Rectangle;
-  private enemyHpBar!: Phaser.GameObjects.Rectangle;
-  private enemyHpBarBg!: Phaser.GameObjects.Rectangle;
+  private enemyArt!: Phaser.GameObjects.Text;
+  private enemyHpText!: Phaser.GameObjects.Text;
   private enemyLabel!: Phaser.GameObjects.Text;
   private introText!: Phaser.GameObjects.Text;
 
@@ -15,11 +30,13 @@ export default class CombatScene extends Phaser.Scene {
     const w = this.scale.width, h = this.scale.height;
     this.cameras.main.setBackgroundColor("#00000000");
 
-    this.enemyBox = this.add.rectangle(w / 2, h * 0.42, w * 0.4, h * 0.42, 0xdc2626, 0.85).setStrokeStyle(2, 0xffffff, 0.3);
-    this.enemyLabel = this.add.text(w / 2, h * 0.42, "", { fontSize: "14px", color: "#ffffff", fontStyle: "bold" }).setOrigin(0.5);
-
-    this.enemyHpBarBg = this.add.rectangle(w / 2, h * 0.7, w * 0.5, 10, 0x000000, 0.4);
-    this.enemyHpBar = this.add.rectangle(w / 2 - (w * 0.5) / 2, h * 0.7, w * 0.5, 10, 0x22c55e).setOrigin(0, 0.5);
+    this.enemyLabel = this.add.text(w / 2, h * 0.08, "", { fontSize: "12px", color: "#ffffff", fontStyle: "bold" }).setOrigin(0.5);
+    this.enemyArt = this.add.text(w / 2, h * 0.48, ASCII_MONSTER, {
+      fontFamily: "monospace", fontSize: "11px", color: "#f87171", align: "center", lineSpacing: 1,
+    }).setOrigin(0.5);
+    this.enemyHpText = this.add.text(w / 2, h * 0.88, asciiBar(0, 1), {
+      fontFamily: "monospace", fontSize: "11px", color: "#4ade80", fontStyle: "bold",
+    }).setOrigin(0.5);
 
     this.introText = this.add.text(w / 2, h / 2, "", { fontSize: "20px", color: "#facc15", fontStyle: "bold" })
       .setOrigin(0.5).setAlpha(0).setDepth(10);
@@ -31,15 +48,12 @@ export default class CombatScene extends Phaser.Scene {
   }
 
   setEnemyHp(hp: number, maxHp: number) {
-    const w = this.scale.width;
-    const pct = maxHp > 0 ? Math.max(0, hp / maxHp) : 0;
-    this.tweens.add({ targets: this.enemyHpBar, scaleX: pct, duration: 250, ease: "Quad.easeOut" });
-    this.enemyHpBar.width = w * 0.5; // scaleX 기준(원 width 고정)
+    this.enemyHpText.setText(asciiBar(hp, maxHp));
   }
 
   flashEnemyHit(damage: number) {
     this.cameras.main.flash(120, 255, 60, 60);
-    this.tweens.add({ targets: this.enemyBox, scaleX: 0.92, scaleY: 0.92, duration: 80, yoyo: true });
+    this.tweens.add({ targets: this.enemyArt, scaleX: 0.92, scaleY: 0.92, duration: 80, yoyo: true });
     this.popText(this.scale.width / 2, this.scale.height * 0.3, `-${damage}`, "#f87171");
   }
 

--- a/cf-idiotquant/components/game/CombatScene.ts
+++ b/cf-idiotquant/components/game/CombatScene.ts
@@ -2,14 +2,18 @@ import Phaser from "phaser";
 
 // 가치투자 덱빌더 — 전투 씬(프로토타입 비주얼). 몬스터는 모노스페이스 ASCII 아트로 그린다.
 // 판정 로직은 전혀 없음 — combatEngine이 계산한 결과를 받아 재생만 한다.
-const ASCII_MONSTER = [
-  "   ▄▄▄▄▄▄▄   ",
-  " ▄█▀▀   ▀▀█▄ ",
-  "█  ●     ●  █",
-  "█     ▼     █",
-  " █▄       ▄█ ",
-  "   ▀▀▀▀▀▀▀   ",
-].join("\n");
+
+// 몬스터 아트는 부위별(머리/눈/입/몸통) 조각을 랜덤 조합해 매 조우마다 다른 생김새를 만든다.
+// Phaser Text의 align:"center"는 줄마다 독립적으로 가운데 정렬하므로 줄 길이가 달라도 괜찮다.
+const HEAD_ROWS = ["   ▄▄▄▄▄▄▄   ", "  ▄███████▄  ", " ▄▄▀▀▀▀▀▀▀▄▄ ", "   ◢▄▄▄▄▄◣   "];
+const EYES_ROWS = ["█  ●     ●  █", "█  ◉     ◉  █", "█  ✕     ✕  █", "█  ▲     ▲  █", "█ ◕     ◕ █"];
+const MOUTH_ROWS = ["█     ▼     █", "█    ▽▽▽    █", "█   ▔▔▔▔▔   █", "█  ▁▁▁▁▁▁▁  █", "█    ◇◇◇    █"];
+const BODY_ROWS = [" █▄       ▄█ ", " ██▄     ▄██ ", "  █▄▄   ▄▄█  ", " ▐█       █▌ "];
+const FOOT_ROWS = ["   ▀▀▀▀▀▀▀   ", "  ▀▀▀▀▀▀▀▀▀  ", " ▀▀▀   ▀▀▀   ", "  ▘▘▘▘▘▘▘▘▘  "];
+const pick = <T,>(arr: T[]) => arr[Math.floor(Math.random() * arr.length)];
+function randomMonster(): string {
+  return [pick(HEAD_ROWS), pick(EYES_ROWS), pick(MOUTH_ROWS), pick(BODY_ROWS), pick(FOOT_ROWS)].join("\n");
+}
 
 const BAR_LEN = 14;
 function asciiBar(hp: number, maxHp: number): string {
@@ -31,7 +35,7 @@ export default class CombatScene extends Phaser.Scene {
     this.cameras.main.setBackgroundColor("#00000000");
 
     this.enemyLabel = this.add.text(w / 2, h * 0.08, "", { fontSize: "12px", color: "#ffffff", fontStyle: "bold" }).setOrigin(0.5);
-    this.enemyArt = this.add.text(w / 2, h * 0.48, ASCII_MONSTER, {
+    this.enemyArt = this.add.text(w / 2, h * 0.48, randomMonster(), {
       fontFamily: "monospace", fontSize: "11px", color: "#f87171", align: "center", lineSpacing: 1,
     }).setOrigin(0.5);
     this.enemyHpText = this.add.text(w / 2, h * 0.88, asciiBar(0, 1), {
@@ -44,6 +48,7 @@ export default class CombatScene extends Phaser.Scene {
 
   setEnemy(name: string, hp: number, maxHp: number) {
     this.enemyLabel.setText(name);
+    this.enemyArt.setText(randomMonster());
     this.setEnemyHp(hp, maxHp);
   }
 

--- a/cf-idiotquant/components/game/HandView.tsx
+++ b/cf-idiotquant/components/game/HandView.tsx
@@ -3,20 +3,15 @@
 // 손패(dnd-kit 드래그) — 미니카드를 전장(children, 드롭존)으로 드래그해서 놓으면 발동.
 // 에너지가 부족한 카드는 드래그 자체를 비활성화. 발동 로직은 onPlayCard(부모의 run.playHandCard)에 위임.
 
-import { DndContext, useDraggable, useDroppable, type DragEndEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { DndContext, DragOverlay, useDraggable, useDroppable, type DragEndEvent, PointerSensor, useSensor, useSensors } from "@dnd-kit/core";
+import { useState } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 import type { CombatCard } from "@/app/(game)/game/gameTypes";
 
-function MiniCard({ card, affordable, free }: { card: CombatCard; affordable: boolean; free: boolean }) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: card.instanceId, disabled: !affordable });
+function CardFace({ card, free }: { card: CombatCard; free: boolean }) {
   return (
-    <div ref={setNodeRef} {...listeners} {...attributes}
-      style={transform ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` } : undefined}
-      className={cn("relative shrink-0 w-14 h-20 rounded-lg border p-1 flex flex-col items-center justify-between select-none touch-none",
-        isDragging ? "z-50 shadow-xl scale-105" : "z-0",
-        affordable
-          ? "bg-white/90 dark:bg-white/[0.08] border-black/10 dark:border-white/15 cursor-grab active:cursor-grabbing"
-          : "bg-black/[0.03] dark:bg-white/[0.02] border-black/5 dark:border-white/5 opacity-40 cursor-not-allowed")}>
+    <>
       <p className="text-[8px] font-bold text-neutral-500 dark:text-neutral-400 truncate w-full text-center">{card.name}</p>
       <div className="grid grid-cols-2 gap-x-1 gap-y-0.5 text-[9px] font-black tabular-nums w-full">
         <span className="text-rose-500 text-center">⚔{card.stats.attack}</span>
@@ -24,6 +19,30 @@ function MiniCard({ card, affordable, free }: { card: CombatCard; affordable: bo
         <span className={cn("text-center", free ? "text-amber-400 line-through" : "text-amber-600 dark:text-amber-400")}>💰{card.stats.cost}</span>
         <span className="text-emerald-500 text-center">🔋{card.stats.refund}</span>
       </div>
+    </>
+  );
+}
+
+// 드래그 중엔 원래 자리의 카드는 옅게 남겨두고(원위치 표시), 실제 시각적 카드는 DragOverlay가
+// 별도 플로팅 레이어로 그려줌 — 부모(overflow-x-auto)의 클리핑 경계에 안 잘리게 하기 위함.
+function MiniCard({ card, affordable, free }: { card: CombatCard; affordable: boolean; free: boolean }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({ id: card.instanceId, disabled: !affordable });
+  return (
+    <div ref={setNodeRef} {...listeners} {...attributes}
+      className={cn("relative shrink-0 w-14 h-20 rounded-lg border p-1 flex flex-col items-center justify-between select-none touch-none",
+        isDragging && "opacity-30",
+        affordable
+          ? "bg-white/90 dark:bg-white/[0.08] border-black/10 dark:border-white/15 cursor-grab active:cursor-grabbing"
+          : "bg-black/[0.03] dark:bg-white/[0.02] border-black/5 dark:border-white/5 opacity-40 cursor-not-allowed")}>
+      <CardFace card={card} free={free} />
+    </div>
+  );
+}
+
+function DragPreview({ card, free }: { card: CombatCard; free: boolean }) {
+  return (
+    <div className="w-14 h-20 rounded-lg border-2 border-[#16a34a] p-1 flex flex-col items-center justify-between shadow-2xl scale-110 bg-white dark:bg-[#242320]">
+      <CardFace card={card} free={free} />
     </div>
   );
 }
@@ -42,12 +61,26 @@ export default function HandView({ cards, energy, freeCostThreshold, onPlayCard,
   onPlayCard: (instanceId: string) => void;
   children: React.ReactNode;
 }) {
+  const [activeId, setActiveId] = useState<string | null>(null);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 6 } }));
   const handleDragEnd = (e: DragEndEvent) => {
+    setActiveId(null);
     if (e.over?.id === "battlefield") onPlayCard(String(e.active.id));
   };
+  const activeCard = cards.find(c => c.instanceId === activeId) ?? null;
+  // DragOverlay는 position:fixed로 그려지는데, 손패를 감싼 조상(overflow-hidden +
+  // backdrop-blur)이 fixed 자손의 containing block을 가로채 화면 밖으로 잘려 보이던 문제가
+  // 있었다 — document.body로 직접 포탈해서 그 조상 체인을 완전히 벗어나게 함.
+  const overlay = (
+    <DragOverlay>
+      {activeCard ? <DragPreview card={activeCard} free={activeCard.stats.cost <= freeCostThreshold} /> : null}
+    </DragOverlay>
+  );
   return (
-    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+    <DndContext sensors={sensors}
+      onDragStart={e => setActiveId(String(e.active.id))}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveId(null)}>
       <div className="flex-1 min-h-0">
         <Battlefield>{children}</Battlefield>
       </div>
@@ -58,6 +91,7 @@ export default function HandView({ cards, energy, freeCostThreshold, onPlayCard,
           return <MiniCard key={card.instanceId} card={card} affordable={energy >= cost} free={free} />;
         })}
       </div>
+      {typeof document !== "undefined" ? createPortal(overlay, document.body) : overlay}
     </DndContext>
   );
 }

--- a/cf-idiotquant/components/game/PhaserCombatCanvas.tsx
+++ b/cf-idiotquant/components/game/PhaserCombatCanvas.tsx
@@ -19,6 +19,8 @@ export default function PhaserCombatCanvas({ enemy, player, introLabel }: {
   const prevEnemyHp = useRef<number>(0);
   const prevPlayerHp = useRef<number>(player.hp);
   const prevPlayerBlock = useRef<number>(player.block);
+  const latestEnemyRef = useRef(enemy);
+  latestEnemyRef.current = enemy;
 
   useEffect(() => {
     let disposed = false;
@@ -38,7 +40,15 @@ export default function PhaserCombatCanvas({ enemy, player, introLabel }: {
       });
       gameRef.current = game;
       game.events.once(Phaser.Core.Events.READY, () => {
-        sceneRef.current = game.scene.getScene("combat") as any;
+        const scene = game.scene.getScene("combat") as any;
+        sceneRef.current = scene;
+        // 씬이 준비되기 전에 이미 적이 정해져 있었을 수 있음(마운트 시점 경쟁) — 놓치지 않게 즉시 반영.
+        const e = latestEnemyRef.current;
+        if (e) {
+          scene.setEnemy?.(String(e.item?.name ?? "몬스터"), e.hp, e.maxHp);
+          prevEnemyTicker.current = e.item?.ticker ?? null;
+          prevEnemyHp.current = e.hp;
+        }
       });
       const ro = new ResizeObserver(() => {
         if (!containerRef.current) return;


### PR DESCRIPTION
## 작업 내용

머지된 PR #635(덱빌더 전투 재설계) 이후 실기기 테스트에서 나온 피드백을 반영한 후속 수정입니다.

### 버그 수정
- **드래그 중 카드가 화면 밖으로 사라지는 문제**: dnd-kit `DragOverlay`가 `position: fixed`로 그려지는데, 손패+캔버스를 감싼 부모 패널에 `backdrop-blur-md`가 걸려 있어 CSS 스펙상 그 부모가 `position: fixed` 자손의 containing block을 가로챕니다. 동시에 그 부모가 `overflow-hidden`이라, 어긋난 좌표의 드래그 카드가 경계 밖으로 밀려나 통째로 잘려 안 보이던 문제였습니다. `DragOverlay`를 `document.body`로 포탈해서 해결했습니다.
- **캔버스+손패 레이아웃 겹침**: 캔버스+손패를 감싼 래퍼 div에 `flex flex-col`이 빠져 있어서 내부 `flex-1`/`shrink-0` 클래스가 무효화되고, 콘텐츠가 실제 가용 공간과 무관하게 `overflow-hidden`에 잘려나가던 잠재 버그였습니다. 이번에 전투 로그 패널을 추가하면서 표면화되어(손패 카드와 로그 패널이 겹쳐 드롭이 씹히는 회귀) 같이 발견·수정했습니다.
- **적 이름/HP가 안 뜨는 문제**: Phaser 씬이 `READY` 되기 전에 이미 적 데이터가 정해져 있던 경쟁 상태로 최초 진입 시 표시가 비어 있던 문제 — 최신 `enemy` 값을 ref로 들고 있다가 씬이 준비되는 즉시 반영하도록 수정했습니다.

### 신규 기능
- **적 ASCII 아트**: 빨간 사각형 placeholder를 모노스페이스 ASCII 몬스터 아트 + 대괄호 스타일 HP 바(`[██████░░░░] 18/30`)로 교체했습니다.
- **전투 로그(D&D 전투기록 스타일)**: 카드 발동(공격/방어 수치), 적 공격(경감/실제 피해), 아이템 사용, 조우 진입, 승패, 카드 획득 등을 실제 수치와 함께 계속 쌓아서 보여주는 로그 패널을 추가했습니다. 별도의 "카드 사용법" 설명 없이도 플레이하면서 자연스럽게 인과관계를 파악할 수 있게 하려는 목적입니다.

## 체크리스트

- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 통과
- [x] Playwright(CDP 실제 터치 이벤트, iPhone SE 뷰포트)로 드래그→발동 재검증 — 손패 5장 → 4장 정상 전환, 페이지 에러 0건
- [x] Playwright로 8개 층 다회 루프 진행 확인 — 페이지 에러 0건
- [x] 레이아웃 겹침 수정 후 캔버스/손패/로그/버튼이 스크롤 없이 한 화면에 정상 배치되는지 스크린샷으로 확인

## 참고 사항

- 백엔드 변경 없음.
- 전투 밸런스(적 HP/공격력 수치)는 기존 PR #635에서 이미 명시한 대로 이번 스코프 밖입니다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_