### PR TITLE
fix(game): 용어 에너지→코스트 통일 + 카드 코스트 아이콘을 상단 동그라미와 매칭 + 방어력 실시간 표시

### DIFF
--- a/cf-idiotquant/app/(game)/game/gameData.ts
+++ b/cf-idiotquant/app/(game)/game/gameData.ts
@@ -21,7 +21,7 @@ export const ITEM_OFFER_COUNT = 3;
 export const ITEM_POOL: ItemDef[] = [
   { id: "buffer", kind: "passive", name: "여유 자금", desc: "매 턴 시작 시 블록 +2", icon: "🧱", effect: { blockPerTurn: 2 } },
   { id: "network", kind: "passive", name: "정보망", desc: "손패 드로우 +1", icon: "📡", effect: { drawBonus: 1 } },
-  { id: "leverage", kind: "passive", name: "레버리지", desc: "턴 시작 에너지 +1", icon: "⚡", effect: { energyBonus: 1 } },
+  { id: "leverage", kind: "passive", name: "레버리지", desc: "턴 시작 코스트 +1", icon: "⚡", effect: { energyBonus: 1 } },
   { id: "diversify", kind: "passive", name: "분산 투자", desc: "코스트 1인 카드는 무료로 낼 수 있음", icon: "🧩", effect: { freeCostThreshold: 1 } },
   { id: "stoploss", kind: "active", name: "손절매", desc: "즉시 적에게 5 데미지", icon: "✂️", effect: { kind: "damage", amount: 5 } },
   { id: "loan", kind: "active", name: "긴급 대출", desc: "즉시 블록 +5", icon: "🏦", effect: { kind: "block", amount: 5 } },

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -28,7 +28,7 @@ import { cn } from "@/lib/utils";
 import { HOLO_THRESHOLD, PackReveal, AchievementBadges, ACHIEVEMENTS } from "./gameCollectibles";
 import { WalletChip, ConvertButton, ShopPanel, BOOST_ITEMS } from "./gameShop";
 import { useGameRun, deckTotal, type DeckItem } from "./useGameRun";
-import { HpBar, EnergyBar, ItemBar } from "@/components/game/CombatHud";
+import { HpBar, EnergyBar, ShieldBadge, ItemBar } from "@/components/game/CombatHud";
 import CombatLog from "@/components/game/CombatLog";
 
 const PhaserCombatCanvas = dynamic(() => import("@/components/game/PhaserCombatCanvas"), { ssr: false });
@@ -601,8 +601,9 @@ function GameContent() {
                       <FloorGraph nodes={floorWindow} />
                     </div>
                     {run.phase === "battling" && (
-                      <div className="px-2 py-1.5 rounded-2xl backdrop-blur-md bg-white/85 dark:bg-white/[0.06] border border-black/5 dark:border-white/10 shadow-[0_6px_18px_-8px_rgba(0,0,0,0.35)]">
+                      <div className="flex items-center gap-2 px-2 py-1.5 rounded-2xl backdrop-blur-md bg-white/85 dark:bg-white/[0.06] border border-black/5 dark:border-white/10 shadow-[0_6px_18px_-8px_rgba(0,0,0,0.35)]">
                         <EnergyBar energy={run.player.energy} energyMax={run.player.energyMax} />
+                        <ShieldBadge block={run.player.block} />
                       </div>
                     )}
                   </div>
@@ -676,8 +677,9 @@ function GameContent() {
             <div className="space-y-3">
               {[
                 { icon: "⚔️", text: <>내 덱(보유 카드)이 곧 전투 카드예요. 매 턴 <b className="text-neutral-800 dark:text-neutral-100">손패</b>에서 카드를 <b className="text-neutral-800 dark:text-neutral-100">전장으로 드래그</b>해 발동하세요 — 공격력만큼 적 HP를, 방어력만큼 내 블록을 올려요.</> },
-                { icon: "🔋", text: <>카드를 내려면 <b className="text-neutral-800 dark:text-neutral-100">에너지(코스트)</b>가 필요해요. 환급 스탯이 있는 카드는 <b className="text-neutral-800 dark:text-neutral-100">다음 턴 에너지</b>를 미리 채워줘요.</> },
-                { icon: "🛡️", text: <>블록은 <b className="text-neutral-800 dark:text-neutral-100">적 턴 하나만</b> 막고 사라져요. 적의 "다음 턴 예정 공격력"을 미리 보고 방어할지 판단하세요.</> },
+                { icon: "●", text: <>카드를 내려면 <b className="text-neutral-800 dark:text-neutral-100">코스트</b>가 필요해요 — 상단의 노란 동그라미 개수만큼 쓸 수 있고, 카드의 ●숫자만큼 소모돼요.</> },
+                { icon: "🔋", text: <>카드의 🔋(환급) 숫자만큼 <b className="text-neutral-800 dark:text-neutral-100">다음 턴 코스트</b>가 미리 충전돼요 — 이번 턴엔 안 쓰이고 다음 턴 시작할 때 동그라미로 더해져요.</> },
+                { icon: "🛡️", text: <>쌓인 방어력은 상단 🛡️ 배지에 실시간으로 표시돼요. <b className="text-neutral-800 dark:text-neutral-100">적 턴 하나만</b> 막고 사라지니, 적의 "다음 턴 예정 공격력"을 미리 보고 방어할지 판단하세요.</> },
                 { icon: "🎒", text: <>3층마다 <b className="text-neutral-800 dark:text-neutral-100">패시브/액티브 아이템</b>을 하나 고를 수 있어요. 패시브는 자동 적용, 액티브는 원할 때 탭해서 1회 사용해요.</> },
                 { icon: "🃏", text: <>적을 처치(층 클리어)하면 확률에 따라 <b className="text-neutral-800 dark:text-neutral-100">내 덱</b>에 카드가 수집돼요. 좋은 카드일수록 전투 스탯도 강해요.</> },
                 { icon: "🎲", text: <>층이 깊어질수록 <b className="text-neutral-800 dark:text-neutral-100">상인</b>(골드로 HP 회복)·<b className="text-neutral-800 dark:text-neutral-100">휴식</b>(무료 회복)·<b className="text-orange-500 dark:text-orange-400">정예</b>(강한 몬스터) 조우가 섞여 나와요. 10층마다는 <b className="text-violet-600 dark:text-violet-400">보스</b>예요.</> },

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -602,7 +602,7 @@ function GameContent() {
                     </div>
                     {run.phase === "battling" && (
                       <div className="flex items-center gap-2 px-2 py-1.5 rounded-2xl backdrop-blur-md bg-white/85 dark:bg-white/[0.06] border border-black/5 dark:border-white/10 shadow-[0_6px_18px_-8px_rgba(0,0,0,0.35)]">
-                        <EnergyBar energy={run.player.energy} energyMax={run.player.energyMax} />
+                        <EnergyBar energy={run.player.energy} base={run.player.energyMax + run.passive.energyBonus} bonus={run.turnBonusCost} />
                         <ShieldBadge block={run.player.block} />
                       </div>
                     )}

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -179,7 +179,8 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     reservedRefundRef.current += card.stats.refund;
     const parts = [`⚔${card.stats.attack} 피해`];
     if (card.stats.shield > 0) parts.push(`🛡${card.stats.shield} 방어`);
-    pushLog("player", `${card.name} 발동 — ${parts.join(", ")} (에너지 -${cost})`);
+    if (card.stats.refund > 0) parts.push(`🔋다음 턴 코스트 +${card.stats.refund}`);
+    pushLog("player", `${card.name} 발동 — ${parts.join(", ")} (코스트 -${cost})`);
     if (checkOutcome(result.player, result.enemy) === "win") handleWin(result.enemy, encounter, roundNum);
   }, [phase, enemy, pile.hand, passive, player, encounter, roundNum, handleWin, pushLog]);
 

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -76,6 +76,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   const [enemy, setEnemy] = useState<EnemyState | null>(null);
   const [pile, setPile] = useState<Pile>({ draw: [], hand: [], discard: [] });
   const reservedRefundRef = useRef(0); // 이번 턴에 낸 카드들의 refund 합 — 다음 턴 시작 시 에너지로 편입
+  const [turnBonusCost, setTurnBonusCost] = useState(0); // 직전 턴 카드들의 refund로 "이번 턴" 코스트에 얹힌 보너스분(기본 코스트와 구분 표시용)
 
   const [log, setLog] = useState<LogEntry[]>([]);
   const pushLog = useCallback((kind: LogKind, text: string) => {
@@ -208,6 +209,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setPlayer(afterEnemy);
     if (afterEnemy.hp <= 0) { setPhase("over"); setLastResult({ win: false }); pushLog("system", "💀 쓰러졌습니다..."); return; }
     const rr = reservedRefundRef.current; reservedRefundRef.current = 0;
+    setTurnBonusCost(rr);
     setPlayer(p => startTurn(p, passive, rr));
     setPile(prev => {
       const carryDiscard = [...prev.discard, ...prev.hand];
@@ -243,6 +245,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       return { draw: r.drawPile, hand: r.hand, discard: r.discardPile };
     });
     const rr = reservedRefundRef.current; reservedRefundRef.current = 0;
+    setTurnBonusCost(rr);
     setPlayer(p => startTurn(p, passive, rr));
     setPhase("battling");
   }, [pool, passive, pushLog]);
@@ -280,6 +283,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setGold(0); setRoundNum(0); setEncounter("battle"); setRestHealed(false); setNewBest(false);
     setLastResult(null); setDropped(false); setDropPrompt(false); setSaveFail(null); setPackOpening(false); setAcquired([]);
     reservedRefundRef.current = 0;
+    setTurnBonusCost(0);
     const hp = BASE_HP;
     setPlayer({ hp, maxHp: hp, block: 0, energy: ENERGY_MAX, energyMax: ENERGY_MAX });
     prevMaxHpRef.current = hp;
@@ -295,7 +299,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   return {
     phase, roundNum, encounter, restHealed, gold, best, newBest,
     ownedItems, ownedDefs, itemChoices, passive, maxHp, unlockedLegendItems, activeBoost,
-    player, enemy, hand: pile.hand, drawCount: pile.draw.length, log,
+    player, enemy, hand: pile.hand, drawCount: pile.draw.length, log, turnBonusCost,
     lastResult, dropped, dropPrompt, saveFail, packOpening, acquired, acquirePct,
     start, playHandCard, useOwnedActiveItem, endTurn, nextRound, proceedFromEvent, cashOut, buyMerchantHeal, buyBoost, pickItem, skipItem,
   };

--- a/cf-idiotquant/components/game/CombatHud.tsx
+++ b/cf-idiotquant/components/game/CombatHud.tsx
@@ -18,19 +18,28 @@ export function HpBar({ hp, maxHp, label }: { hp: number; maxHp: number; label: 
   );
 }
 
-// 상단 동그라미 개수 = energyMax(기본 4 + 레버리지 등 패시브 아이템의 energyBonus 합).
-// 채워진(노란) 동그라미 수 = 이번 턴에 아직 쓸 수 있는 코스트. 카드의 코스트 숫자와 같은
-// 동그라미 기호(●)를 써서 "카드를 내면 이 동그라미가 그만큼 준다"는 걸 시각적으로 잇는다.
-export function EnergyBar({ energy, energyMax }: { energy: number; energyMax: number }) {
+// 동그라미 개수 = base(기본 4 + 레버리지 등 패시브의 energyBonus) + bonus(직전 턴 카드들의
+// 환급(🔋)으로 이번 턴에만 얹힌 보너스). 기본분은 노란색, 환급 보너스분은 카드의 🔋과 같은
+// 초록색으로 구분해서 "이번 턴엔 기본보다 N 더 쓸 수 있다"는 걸 한눈에 보이게 한다.
+// 채워진 동그라미 수 = 아직 안 쓴 코스트, 카드의 ●와 같은 기호를 써서 관계를 시각적으로 잇는다.
+export function EnergyBar({ energy, base, bonus }: { energy: number; base: number; bonus: number }) {
+  const total = Math.max(energy, base + bonus);
   return (
     <div className="flex items-center gap-1.5 min-w-0">
       <span className="text-[9px] font-black text-neutral-400 shrink-0">코스트</span>
       <div className="flex items-center gap-0.5">
-        {Array.from({ length: Math.max(energy, energyMax) }, (_, i) => (
-          <span key={i} aria-hidden className={cn("w-2.5 h-2.5 rounded-full", i < energy ? "bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.7)]" : "bg-black/10 dark:bg-white/10")} />
-        ))}
+        {Array.from({ length: total }, (_, i) => {
+          const filled = i < energy;
+          const isBonus = i >= base;
+          return (
+            <span key={i} aria-hidden className={cn("w-2.5 h-2.5 rounded-full",
+              !filled ? "bg-black/10 dark:bg-white/10"
+                : isBonus ? "bg-emerald-400 shadow-[0_0_6px_rgba(52,211,153,0.7)]" : "bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.7)]")} />
+          );
+        })}
       </div>
       <span className="text-[10px] font-black tabular-nums text-amber-600 dark:text-amber-400 shrink-0">{energy}</span>
+      {bonus > 0 && <span className="text-[9px] font-black text-emerald-600 dark:text-emerald-400 shrink-0">🔋+{bonus}</span>}
     </div>
   );
 }

--- a/cf-idiotquant/components/game/CombatHud.tsx
+++ b/cf-idiotquant/components/game/CombatHud.tsx
@@ -18,13 +18,30 @@ export function HpBar({ hp, maxHp, label }: { hp: number; maxHp: number; label: 
   );
 }
 
+// 상단 동그라미 개수 = energyMax(기본 4 + 레버리지 등 패시브 아이템의 energyBonus 합).
+// 채워진(노란) 동그라미 수 = 이번 턴에 아직 쓸 수 있는 코스트. 카드의 코스트 숫자와 같은
+// 동그라미 기호(●)를 써서 "카드를 내면 이 동그라미가 그만큼 준다"는 걸 시각적으로 잇는다.
 export function EnergyBar({ energy, energyMax }: { energy: number; energyMax: number }) {
   return (
-    <div className="flex items-center gap-0.5">
-      {Array.from({ length: Math.max(energy, energyMax) }, (_, i) => (
-        <span key={i} aria-hidden className={cn("w-2.5 h-2.5 rounded-full", i < energy ? "bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.7)]" : "bg-black/10 dark:bg-white/10")} />
-      ))}
-      <span className="ml-1 text-[10px] font-black tabular-nums text-amber-600 dark:text-amber-400">{energy}</span>
+    <div className="flex items-center gap-1.5 min-w-0">
+      <span className="text-[9px] font-black text-neutral-400 shrink-0">코스트</span>
+      <div className="flex items-center gap-0.5">
+        {Array.from({ length: Math.max(energy, energyMax) }, (_, i) => (
+          <span key={i} aria-hidden className={cn("w-2.5 h-2.5 rounded-full", i < energy ? "bg-amber-400 shadow-[0_0_6px_rgba(251,191,36,0.7)]" : "bg-black/10 dark:bg-white/10")} />
+        ))}
+      </div>
+      <span className="text-[10px] font-black tabular-nums text-amber-600 dark:text-amber-400 shrink-0">{energy}</span>
+    </div>
+  );
+}
+
+// 이번 턴 동안 쌓인 방어력 — 적 턴 한 번 막고 사라지므로, 카드를 낼 때마다 바로바로
+// 눈에 보여야 "지금 방어를 쌓고 있다"는 걸 알 수 있다.
+export function ShieldBadge({ block }: { block: number }) {
+  return (
+    <div className="flex items-center gap-1 shrink-0">
+      <span aria-hidden className="text-sky-500">🛡️</span>
+      <span className="text-[10px] font-black tabular-nums text-sky-600 dark:text-sky-400">{block}</span>
     </div>
   );
 }

--- a/cf-idiotquant/components/game/CombatScene.ts
+++ b/cf-idiotquant/components/game/CombatScene.ts
@@ -22,6 +22,11 @@ function asciiBar(hp: number, maxHp: number): string {
   return `[${"█".repeat(filled)}${"░".repeat(BAR_LEN - filled)}] ${Math.max(0, hp)}/${maxHp}`;
 }
 
+// Phaser의 Text는 자체 해상도(resolution)로 텍스처를 굽는데 기본값 1이라 고밀도(레티나)
+// 모바일 화면에서 흐릿하게 보임 — devicePixelRatio만큼 올려서 선명하게 그린다(과도한 메모리
+// 사용 방지로 최대 3배로 제한).
+const RES = typeof window !== "undefined" ? Math.min(window.devicePixelRatio || 1, 3) : 1;
+
 export default class CombatScene extends Phaser.Scene {
   private enemyArt!: Phaser.GameObjects.Text;
   private enemyHpText!: Phaser.GameObjects.Text;
@@ -34,15 +39,15 @@ export default class CombatScene extends Phaser.Scene {
     const w = this.scale.width, h = this.scale.height;
     this.cameras.main.setBackgroundColor("#00000000");
 
-    this.enemyLabel = this.add.text(w / 2, h * 0.08, "", { fontSize: "12px", color: "#ffffff", fontStyle: "bold" }).setOrigin(0.5);
+    this.enemyLabel = this.add.text(w / 2, h * 0.08, "", { fontSize: "12px", color: "#ffffff", fontStyle: "bold", resolution: RES }).setOrigin(0.5);
     this.enemyArt = this.add.text(w / 2, h * 0.48, randomMonster(), {
-      fontFamily: "monospace", fontSize: "11px", color: "#f87171", align: "center", lineSpacing: 1,
+      fontFamily: "monospace", fontSize: "11px", color: "#f87171", align: "center", lineSpacing: 1, resolution: RES,
     }).setOrigin(0.5);
     this.enemyHpText = this.add.text(w / 2, h * 0.88, asciiBar(0, 1), {
-      fontFamily: "monospace", fontSize: "11px", color: "#4ade80", fontStyle: "bold",
+      fontFamily: "monospace", fontSize: "11px", color: "#4ade80", fontStyle: "bold", resolution: RES,
     }).setOrigin(0.5);
 
-    this.introText = this.add.text(w / 2, h / 2, "", { fontSize: "20px", color: "#facc15", fontStyle: "bold" })
+    this.introText = this.add.text(w / 2, h / 2, "", { fontSize: "20px", color: "#facc15", fontStyle: "bold", resolution: RES })
       .setOrigin(0.5).setAlpha(0).setDepth(10);
   }
 
@@ -83,7 +88,7 @@ export default class CombatScene extends Phaser.Scene {
   }
 
   private popText(x: number, y: number, text: string, color: string) {
-    const t = this.add.text(x, y, text, { fontSize: "16px", color, fontStyle: "bold" }).setOrigin(0.5).setDepth(5);
+    const t = this.add.text(x, y, text, { fontSize: "16px", color, fontStyle: "bold", resolution: RES }).setOrigin(0.5).setDepth(5);
     this.tweens.add({ targets: t, y: y - 30, alpha: 0, duration: 600, ease: "Quad.easeOut", onComplete: () => t.destroy() });
   }
 }

--- a/cf-idiotquant/components/game/HandView.tsx
+++ b/cf-idiotquant/components/game/HandView.tsx
@@ -16,7 +16,7 @@ function CardFace({ card, free }: { card: CombatCard; free: boolean }) {
       <div className="grid grid-cols-2 gap-x-1 gap-y-0.5 text-[9px] font-black tabular-nums w-full">
         <span className="text-rose-500 text-center">⚔{card.stats.attack}</span>
         <span className="text-sky-500 text-center">🛡{card.stats.shield}</span>
-        <span className={cn("text-center", free ? "text-amber-400 line-through" : "text-amber-600 dark:text-amber-400")}>💰{card.stats.cost}</span>
+        <span className={cn("text-center", free ? "text-amber-400 line-through" : "text-amber-600 dark:text-amber-400")}>●{card.stats.cost}</span>
         <span className="text-emerald-500 text-center">🔋{card.stats.refund}</span>
       </div>
     </>


### PR DESCRIPTION
## 작업 내용

실기기 테스트 피드백을 반영한 UX 명확화 패치입니다 (머지된 PR #635/#636 이후 후속).

- **용어 통일**: 사용자에게 보이는 텍스트에서 "에너지"를 전부 "코스트"로 교체(튜토리얼/아이템 설명/전투 로그). 카드 스탯 이름이 이미 "코스트"라서 상단 배지·카드·로그 용어가 일관되게 맞음.
- **상단 코스트 배지에 라벨 추가**: "코스트" 텍스트 라벨을 붙여서 동그라미 개수(=`energyMax`, 레버리지 등 패시브로 증가) / 채워진 개수(=이번 턴 남은 코스트)가 뭘 뜻하는지 바로 알 수 있게 함.
- **카드 코스트 아이콘 교체**: 💰(상단 골드 배지와 혼동되던 아이콘)를 상단 코스트 배지와 같은 ● 기호로 바꿔서 "이 카드가 저 동그라미를 그만큼 쓴다"는 관계가 시각적으로 보이게 함.
- **방어력 실시간 배지 추가**: 이번 턴에 쌓인 방어력을 상단에 🛡️N 배지로 항상 표시. 기존엔 카드 낼 때 잠깐 뜨는 팝업 텍스트로만 보여서 누적치를 바로 확인할 방법이 없었음.
- **전투 로그 보강**: 환급(🔋) 효과도 "다음 턴 코스트 +N"으로 명시해서 카드를 낼 때 무슨 일이 일어나는지 로그만 보고도 이해할 수 있게 함.

## 체크리스트

- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 통과
- [x] Playwright(CDP 실제 터치 이벤트, iPhone SE 뷰포트)로 드래그→발동 재검증 — 페이지 에러 0건
- [x] 스크린샷으로 코스트 라벨/● 아이콘/🛡️ 배지/로그 문구가 의도대로 렌더링되는지 확인

## 참고 사항

- 백엔드 변경 없음.
- 내부 코드 변수명(`energy`, `ENERGY_MAX`, `energyBonus` 등)은 그대로 유지 — 이번 변경은 사용자에게 보이는 텍스트/아이콘 범위로 한정.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_