### PR TITLE
feat(game): 몬스터 종 다양화 + D&D 주사위 전투/캐릭터 레벨 시스템

### DIFF
--- a/cf-idiotquant/app/(game)/game/characterEngine.ts
+++ b/cf-idiotquant/app/(game)/game/characterEngine.ts
@@ -1,0 +1,67 @@
+// 가치투자 덱빌더 — 캐릭터(계정 영구) 레벨/경험치 순수 로직. React/localStorage 비의존.
+
+import { computeValueScore } from "@/lib/utils/valueScore";
+import type { CharacterState, CharacterStats, CharClass } from "./gameTypes";
+
+export const CHAR_STAT_CAP = 99;
+export const MAX_LEVEL = 99;
+export const XP_PER_ATTACK = 1;
+export const LEVEL_XP_BASE = 100;
+export const LEVEL_XP_GROWTH = 1.1;
+
+export function xpToNextLevel(level: number): number {
+  return Math.round(LEVEL_XP_BASE * Math.pow(LEVEL_XP_GROWTH, level - 1));
+}
+
+// 몬스터 처치 시 등급별 지급 경험치 — 최하등급부터 10, 20, 40... 두 배씩.
+export const KILL_XP_BY_GRADE: Record<string, number> = {
+  H: 10, G: 20, F: 40, E: 80, D: 160, C: 320, B: 640, A: 1280, S: 2560, SS: 5120,
+};
+export function killXpFor(item: any): number {
+  return KILL_XP_BY_GRADE[computeValueScore(item).grade] ?? 0;
+}
+
+export interface ClassDef {
+  id: CharClass;
+  name: string;
+  baseStats: CharacterStats;
+  growthPerLevel: CharacterStats; // 레벨업마다 자동으로 오르는 스탯(직업색)
+  selectable: boolean;
+}
+// 전사 — 힘/체력 위주로 성장. 다른 직업 추가 시 이 표에 항목만 늘리면 됨.
+export const CLASS_DEFS: Record<CharClass, ClassDef> = {
+  warrior: {
+    id: "warrior", name: "전사",
+    baseStats: { str: 1, dex: 0, luk: 0, vit: 10 },
+    growthPerLevel: { str: 1, dex: 0, luk: 0, vit: 1 },
+    selectable: true,
+  },
+};
+
+export function newCharacter(classId: CharClass = "warrior"): CharacterState {
+  return { classId, level: 1, xp: 0, stats: { ...CLASS_DEFS[classId].baseStats } };
+}
+
+const clampStat = (n: number) => Math.min(CHAR_STAT_CAP, n);
+
+export function grantXp(character: CharacterState, amount: number): CharacterState {
+  if (amount <= 0 || character.level >= MAX_LEVEL) return character;
+  let level = character.level;
+  let xp = character.xp + amount;
+  let stats = { ...character.stats };
+  const growth = CLASS_DEFS[character.classId].growthPerLevel;
+  while (level < MAX_LEVEL) {
+    const need = xpToNextLevel(level);
+    if (xp < need) break;
+    xp -= need;
+    level += 1;
+    stats = {
+      str: clampStat(stats.str + growth.str),
+      dex: clampStat(stats.dex + growth.dex),
+      luk: clampStat(stats.luk + growth.luk),
+      vit: clampStat(stats.vit + growth.vit),
+    };
+  }
+  if (level >= MAX_LEVEL) xp = 0;
+  return { ...character, level, xp, stats };
+}

--- a/cf-idiotquant/app/(game)/game/combatEngine.ts
+++ b/cf-idiotquant/app/(game)/game/combatEngine.ts
@@ -4,16 +4,56 @@
 import { computeValueScore } from "@/lib/utils/valueScore";
 import type {
   CardStats, CombatCard, PassiveEffect, ActiveEffect, ItemDef, EnemyState, PlayerState,
+  CharacterStats, AttackRollOptions, AttackRollResult, EnemyEncounter,
 } from "./gameTypes";
 
 export const ENERGY_MAX = 4;
 export const HAND_SIZE = 5;
 export const BASE_HP = 30;
 export const MIN_DECK = 10;
+export const BATTLE_TURN_ENERGY_CAP = 10; // 코스트 성장 상한 — 전투 안에서 내 턴이 진행될수록 늘어남
+
+// 전투 안에서 내 턴이 몇 번째인지(1부터)로 기본 코스트를 계산 — 조우 진입 시 1로 리셋, 턴마다 +1.
+export function battleEnergyMax(battleTurn: number): number {
+  return Math.min(BATTLE_TURN_ENERGY_CAP, Math.max(1, battleTurn));
+}
 const ENEMY_BASE_HP = 12;
 const ENEMY_PER_FLOOR = 3;
-const BOSS_MULT = 2.2;
+const ENEMY_HP_PER_SHIELD = 2; // 뽑힌 카드 자체의 방어 스탯(등급과 상관관계가 있음)도 HP에 반영
+const BOSS_MULT = 3;   // "보스는 그 층 몬스터가 스탯 3배로 강화되어 등장"
 const ELITE_MULT = 1.5;
+
+// 주사위 — D&D 스타일 20면체. 카드 공격/적 공격 모두 이 함수 하나로 처리(몬스터는 str/dex/luk/
+// advantage를 안 넘기므로 자연 20 크리티컬만 적용됨).
+export const CRIT_ROLL_FACE = 20;        // 자연 20 = 크리티컬
+export const CRIT_MULTIPLIER = 2;        // 크리티컬 데미지 = base * 2(최대 데미지의 2배)
+export const DEX_ROLL_DIVISOR = 20;      // 민첩 20당 굴림 눈 +1
+export const STR_DAMAGE_DIVISOR = 10;    // 힘 10당 고정 데미지 +1
+export const VIT_HP_MULTIPLIER = 2;      // 체력 1당 최대 HP +2
+export const LUK_CRIT_PER_POINT = 0.003; // 행운 1당 추가 크리티컬 확률
+export const LUK_CRIT_CAP = 0.35;
+export const LUK_BOSS_EXTRA_PER_POINT = 0.005; // 행운 1당 보스 보상 4택 확률
+export const LUK_BOSS_EXTRA_CAP = 0.40;
+
+export function rollAttack(base: number, opts: AttackRollOptions = {}): AttackRollResult {
+  const roll1 = 1 + Math.floor(Math.random() * 20);
+  const roll2 = opts.advantage ? 1 + Math.floor(Math.random() * 20) : undefined;
+  const faces = roll2 !== undefined ? [roll1, roll2] : [roll1];
+  const rawFace = Math.max(...faces);
+  const isNatural20 = faces.includes(CRIT_ROLL_FACE);
+  const lukChance = opts.luk ? Math.min(LUK_CRIT_CAP, opts.luk * LUK_CRIT_PER_POINT) : 0;
+  const isCrit = isNatural20 || (lukChance > 0 && Math.random() < lukChance);
+  const dexBonus = opts.dex ? Math.floor(opts.dex / DEX_ROLL_DIVISOR) : 0;
+  const effectiveFace = Math.min(20, rawFace + dexBonus);
+  const diceDamage = isCrit ? base * CRIT_MULTIPLIER : Math.round(base * effectiveFace / 20);
+  const strBonus = opts.str ? Math.floor(opts.str / STR_DAMAGE_DIVISOR) : 0;
+  return { faces, rawFace, effectiveFace, isCrit, diceDamage, strBonus, totalDamage: diceDamage + strBonus };
+}
+
+// 행운 수치에 따라 보스 처치 보상을 3택 대신 4택으로 제공할 확률.
+export function bossExtraChoiceChance(luk: number): number {
+  return Math.min(LUK_BOSS_EXTRA_CAP, luk * LUK_BOSS_EXTRA_PER_POINT);
+}
 
 // 4개 재무 지표(sub, 0~1 clamp01된 정규화 점수 — computeValueScore가 이미 계산)를 4개 전투
 // 스탯(1~10 양의 정수)으로 매핑. 데이터 없는 지표는 sub=0(최저값)으로 처리돼 NaN이 안 생김.
@@ -30,6 +70,7 @@ export function cardStats(item: any): CardStats {
 
 const emptyPassive: Required<PassiveEffect> = {
   blockPerTurn: 0, drawBonus: 0, energyBonus: 0, maxHpBonus: 0, damageReduce: 0, freeCostThreshold: 0,
+  strBonus: 0, dexBonus: 0, lukBonus: 0, vitBonus: 0, extraDie: false,
 };
 
 // 보유 패시브 아이템 전체를 합산한 상시 보너스. 액티브 아이템은 포함하지 않음(발동 시점에만 효과).
@@ -44,6 +85,11 @@ export function aggregatePassive(ownedDefs: ItemDef[]): Required<PassiveEffect> 
     out.maxHpBonus += e.maxHpBonus ?? 0;
     out.damageReduce += e.damageReduce ?? 0;
     out.freeCostThreshold = Math.max(out.freeCostThreshold, e.freeCostThreshold ?? 0);
+    out.strBonus += e.strBonus ?? 0;
+    out.dexBonus += e.dexBonus ?? 0;
+    out.lukBonus += e.lukBonus ?? 0;
+    out.vitBonus += e.vitBonus ?? 0;
+    out.extraDie = out.extraDie || !!e.extraDie;
   }
   return out;
 }
@@ -87,26 +133,38 @@ export function drawHand(drawPile: CombatCard[], discardPile: CombatCard[], hand
   return { hand, drawPile: draw, discardPile: discard };
 }
 
-// 적 = 실제 종목 카드에서 뽑되, 보스/정예는 강한 등급 풀 우선. HP는 층수 비례 + 보스/정예 배율.
+// 적 = 실제 종목 카드에서 뽑되, 보스/정예는 강한 등급 풀 우선. HP는 층수 비례 + 카드 자체의 등급
+// 상관 스탯(shield) + 보스/정예 배율.
 export function enemyForFloor(pool: any[], floor: number, encounter: EnemyEncounter): EnemyState {
   const strong = pool.filter(it => ["gold", "diamond", "treasure", "legend"].includes(computeValueScore(it).tone));
   const source = (encounter === "boss" || encounter === "elite") && strong.length > 0 ? strong : pool;
   const item = source[Math.floor(Math.random() * source.length)];
   const stats = cardStats(item);
   const mult = encounter === "boss" ? BOSS_MULT : encounter === "elite" ? ELITE_MULT : 1;
-  const maxHp = Math.round((ENEMY_BASE_HP + floor * ENEMY_PER_FLOOR) * mult);
+  const baseHp = ENEMY_BASE_HP + floor * ENEMY_PER_FLOOR + stats.shield * ENEMY_HP_PER_SHIELD;
+  const maxHp = Math.round(baseHp * mult);
   const attack = stats.attack + Math.floor(floor / 3);
-  return { item, stats, hp: maxHp, maxHp, nextAttack: attack };
+  return { item, stats, hp: maxHp, maxHp, nextAttack: attack, encounter };
 }
-type EnemyEncounter = "battle" | "boss" | "elite";
 
 // 카드 한 장 발동 — 코스트를 낼 수 없으면 그대로 반환(호출부에서 사전에 막아야 함, 여기선 방어적으로만 처리).
-export function playCard(player: PlayerState, enemy: EnemyState, card: CombatCard, passive: Required<PassiveEffect>): { player: PlayerState; enemy: EnemyState } {
+// 공격력은 이제 고정 데미지가 아니라 rollAttack()으로 굴린 값 — charStats/passive의 힘/민첩/행운/
+// 어드밴티지가 그대로 반영된다.
+export function playCard(
+  player: PlayerState, enemy: EnemyState, card: CombatCard,
+  passive: Required<PassiveEffect>, charStats: CharacterStats,
+): { player: PlayerState; enemy: EnemyState; roll: AttackRollResult } {
   const cost = card.stats.cost <= passive.freeCostThreshold ? 0 : card.stats.cost;
-  if (player.energy < cost) return { player, enemy };
+  if (player.energy < cost) return { player, enemy, roll: rollAttack(0) };
+  const roll = rollAttack(card.stats.attack, {
+    advantage: passive.extraDie,
+    str: charStats.str + passive.strBonus,
+    dex: charStats.dex + passive.dexBonus,
+    luk: charStats.luk + passive.lukBonus,
+  });
   const nextPlayer: PlayerState = { ...player, energy: player.energy - cost, block: player.block + card.stats.shield };
-  const nextEnemy: EnemyState = { ...enemy, hp: Math.max(0, enemy.hp - card.stats.attack) };
-  return { player: nextPlayer, enemy: nextEnemy };
+  const nextEnemy: EnemyState = { ...enemy, hp: Math.max(0, enemy.hp - roll.totalDamage) };
+  return { player: nextPlayer, enemy: nextEnemy, roll };
 }
 
 // 예약된 환급 에너지(직전 턴에 낸 카드들의 refund 합)를 다음 턴 시작 에너지에 더해준다.
@@ -118,10 +176,14 @@ export function startTurn(player: PlayerState, passive: Required<PassiveEffect>,
   };
 }
 
-// 적 턴 — 공격력에서 블록·데미지감소를 뺀 뒤(최소 0) 플레이어 HP 차감, 블록은 소멸.
-export function resolveEnemyTurn(player: PlayerState, enemy: EnemyState, passive: Required<PassiveEffect>): PlayerState {
-  const dmg = Math.max(0, enemy.nextAttack - player.block - passive.damageReduce);
-  return { ...player, hp: Math.max(0, player.hp - dmg), block: 0 };
+// 적 턴 — 적도 동일한 주사위 규칙으로 굴리되(자연 20 크리티컬만 적용, 힘/민첩/행운/어드밴티지
+// 없음), 굴린 값에서 블록·데미지감소를 뺀 뒤(최소 0) 플레이어 HP 차감, 블록은 소멸.
+export function resolveEnemyTurn(
+  player: PlayerState, enemy: EnemyState, passive: Required<PassiveEffect>,
+): { player: PlayerState; roll: AttackRollResult } {
+  const roll = rollAttack(enemy.nextAttack);
+  const dmg = Math.max(0, roll.totalDamage - player.block - passive.damageReduce);
+  return { player: { ...player, hp: Math.max(0, player.hp - dmg), block: 0 }, roll };
 }
 
 // 액티브 아이템 즉시 발동(에너지 소모 없음, 1회 소모는 호출부의 보유 목록에서 제거)

--- a/cf-idiotquant/app/(game)/game/gameData.ts
+++ b/cf-idiotquant/app/(game)/game/gameData.ts
@@ -1,5 +1,5 @@
 // 가치투자 덱빌더 — 상수/데이터 테이블. 프로토타입 범위: 아이템은 소수만(패시브 4 + 액티브 4 +
-// 전설급 2), 콘텐츠 확장은 나중에.
+// 스탯 부스트 12 + 전설급 3), 콘텐츠 확장은 나중에.
 
 import { computeValueScore } from "@/lib/utils/valueScore";
 import type { ItemDef, CombatCard } from "./gameTypes";
@@ -29,16 +29,36 @@ export const ITEM_POOL: ItemDef[] = [
   { id: "buyMore", kind: "active", name: "추가 매수", desc: "카드 2장 즉시 드로우", icon: "🛒", effect: { kind: "draw", amount: 2 } },
 ];
 
+// 힘/민첩/행운/체력 스탯 부스트 — 각 3단계(lv2=lv1×2, lv3=lv1×4). 다른 패시브 아이템과 동일하게
+// 이번 런에서만 적용되고 던전을 나가면 사라짐(계정에 영구 저장되는 캐릭터 레벨과는 별개).
+export const STAT_ITEM_POOL: ItemDef[] = [
+  { id: "str_ring_1", kind: "passive", name: "힘의 반지 I", desc: "힘(STR) +1", icon: "💪", tier: 1, effect: { strBonus: 1 } },
+  { id: "str_ring_2", kind: "passive", name: "힘의 반지 II", desc: "힘(STR) +2", icon: "💪", tier: 2, effect: { strBonus: 2 } },
+  { id: "str_ring_3", kind: "passive", name: "힘의 반지 III", desc: "힘(STR) +4", icon: "💪", tier: 3, effect: { strBonus: 4 } },
+  { id: "dex_ring_1", kind: "passive", name: "민첩의 반지 I", desc: "민첩(DEX) +1", icon: "🐇", tier: 1, effect: { dexBonus: 1 } },
+  { id: "dex_ring_2", kind: "passive", name: "민첩의 반지 II", desc: "민첩(DEX) +2", icon: "🐇", tier: 2, effect: { dexBonus: 2 } },
+  { id: "dex_ring_3", kind: "passive", name: "민첩의 반지 III", desc: "민첩(DEX) +4", icon: "🐇", tier: 3, effect: { dexBonus: 4 } },
+  { id: "luk_ring_1", kind: "passive", name: "행운의 반지 I", desc: "행운(LUK) +1", icon: "🍀", tier: 1, effect: { lukBonus: 1 } },
+  { id: "luk_ring_2", kind: "passive", name: "행운의 반지 II", desc: "행운(LUK) +2", icon: "🍀", tier: 2, effect: { lukBonus: 2 } },
+  { id: "luk_ring_3", kind: "passive", name: "행운의 반지 III", desc: "행운(LUK) +4", icon: "🍀", tier: 3, effect: { lukBonus: 4 } },
+  { id: "vit_ring_1", kind: "passive", name: "체력의 반지 I", desc: "체력(VIT) +10", icon: "🫀", tier: 1, effect: { vitBonus: 10 } },
+  { id: "vit_ring_2", kind: "passive", name: "체력의 반지 II", desc: "체력(VIT) +20", icon: "🫀", tier: 2, effect: { vitBonus: 20 } },
+  { id: "vit_ring_3", kind: "passive", name: "체력의 반지 III", desc: "체력(VIT) +40", icon: "🫀", tier: 3, effect: { vitBonus: 40 } },
+];
+
 // 전설급 아이템 — 업적 해금 시에만 파밍 풀에 추가(기존 전설 장비 자리를 대체, 세트 개념 없음)
 export const LEGEND_ITEMS: ItemDef[] = [
   { id: "legend_buffett", kind: "passive", name: "워런 버핏의 서한", desc: "최대 HP +10", icon: "📜", isLegend: true, achievementId: "collector", effect: { maxHpBonus: 10 } },
   { id: "legend_blackswan", kind: "active", name: "블랙스완 헤지", desc: "즉시 적에게 15 데미지", icon: "🦢", isLegend: true, achievementId: "legend3", effect: { kind: "damage", amount: 15 } },
+  { id: "legend_advantage", kind: "passive", name: "야수의 감각", desc: "카드 공격 시 주사위를 2번 굴려 더 높은 눈 사용(어드밴티지)", icon: "🎲", isLegend: true, achievementId: "captain", effect: { extraDie: true } },
 ];
 
-export const ALL_ITEMS: ItemDef[] = [...ITEM_POOL, ...LEGEND_ITEMS];
+export const ALL_ITEMS: ItemDef[] = [...ITEM_POOL, ...STAT_ITEM_POOL, ...LEGEND_ITEMS];
 
 // 컬렉션이 MIN_DECK(combatEngine) 미만일 때 채우는 스타터 카드 — 계정 덱에는 저장되지 않는 합성
 // 카드. 실제 컬렉션보다 확실히 약하게 잡아 수집 동기를 유지한다.
+// 코스트가 전투 턴마다 성장(1부터 시작)하는 구조라, 스타터 카드가 전부 코스트 2 이상이면 첫
+// 턴엔 아무것도 못 내는 상황이 생김 — "안전 마진"은 코스트 1로 낮춰 첫 턴에도 낼 수 있게 함.
 export const STARTER_DECK: Omit<CombatCard, "instanceId">[] = [
   ...Array.from({ length: 6 }, (_, i) => ({
     ticker: `STARTER-A${i}`, name: "가치 원석", isStarter: true,
@@ -48,12 +68,13 @@ export const STARTER_DECK: Omit<CombatCard, "instanceId">[] = [
   ...Array.from({ length: 4 }, (_, i) => ({
     ticker: `STARTER-B${i}`, name: "안전 마진", isStarter: true,
     item: { ticker: `STARTER-B${i}`, name: "안전 마진" },
-    stats: { attack: 4, shield: 3, cost: 2, refund: 1 },
+    stats: { attack: 4, shield: 3, cost: 1, refund: 1 },
   })),
 ];
 
-// 아이템 선택지 3택1 — 슬롯 개념이 없어 이미 보유한 아이템도 후보에서 제외하지 않음(패시브는
-// 중복 보유 시 효과가 합산되고, 액티브는 충전 개념이 없어 여러 장 들고 있으면 그만큼 더 쓸 수 있음).
-export function pickItemChoices(pool: ItemDef[]): ItemDef[] {
-  return [...pool].sort(() => Math.random() - 0.5).slice(0, ITEM_OFFER_COUNT);
+// 아이템 선택지 3택1(보스는 행운 수치에 따라 4택) — 슬롯 개념이 없어 이미 보유한 아이템도 후보에서
+// 제외하지 않음(패시브는 중복 보유 시 효과가 합산되고, 액티브는 충전 개념이 없어 여러 장 들고 있으면
+// 그만큼 더 쓸 수 있음).
+export function pickItemChoices(pool: ItemDef[], count: number = ITEM_OFFER_COUNT): ItemDef[] {
+  return [...pool].sort(() => Math.random() - 0.5).slice(0, count);
 }

--- a/cf-idiotquant/app/(game)/game/gameTypes.ts
+++ b/cf-idiotquant/app/(game)/game/gameTypes.ts
@@ -2,6 +2,7 @@
 
 export type Phase = "loading" | "battling" | "resolved" | "over" | "event";
 export type EncounterType = "battle" | "boss" | "merchant" | "rest" | "elite";
+export type EnemyEncounter = "battle" | "boss" | "elite"; // 실제로 적이 등장하는 조우만(상인/휴식 제외)
 
 // 4개 재무 지표 → 4개 전투 스탯, 전부 1~10 양의 정수(combatEngine.cardStats 참고).
 export interface CardStats {
@@ -28,6 +29,11 @@ export type PassiveEffect = {
   maxHpBonus?: number;       // 최대 HP 증가
   damageReduce?: number;     // 적 공격 데미지 감소
   freeCostThreshold?: number; // 이 값 이하 코스트인 카드는 무료
+  strBonus?: number;         // 이번 런 한정 힘(STR) 보너스
+  dexBonus?: number;         // 이번 런 한정 민첩(DEX) 보너스
+  lukBonus?: number;         // 이번 런 한정 행운(LUK) 보너스
+  vitBonus?: number;         // 이번 런 한정 체력(VIT) 보너스
+  extraDie?: boolean;        // 카드 공격 주사위 굴림에 어드밴티지(2개 굴려 높은 값) 적용
 };
 
 export type ActiveEffect =
@@ -45,6 +51,7 @@ export interface ItemDef {
   icon: string;
   isLegend?: boolean;
   achievementId?: string; // 전설급 아이템 해금 조건(업적 id)
+  tier?: 1 | 2 | 3; // 스탯 부스트 아이템 등급(lv2=lv1×2, lv3=lv1×4) — 없으면 티어 배지 미표시
   effect: PassiveEffect | ActiveEffect;
 }
 
@@ -56,7 +63,8 @@ export interface EnemyState {
   stats: CardStats;
   hp: number;
   maxHp: number;
-  nextAttack: number; // 텔레그래프에 표시되는, 다음 적 턴에 실제로 들어올 공격력
+  nextAttack: number; // 주사위 굴림의 base — 실제 피해는 0~nextAttack 범위에서 결정됨
+  encounter: EnemyEncounter; // 정예/보스 상시 표시용
 }
 
 export interface PlayerState {
@@ -65,6 +73,31 @@ export interface PlayerState {
   block: number;
   energy: number;
   energyMax: number;
+}
+
+// 캐릭터(계정에 영구 저장) — 던전 런과 무관하게 유지되는 레벨/능력치.
+export interface CharacterStats { str: number; dex: number; luk: number; vit: number }
+export type CharClass = "warrior"; // 현재는 전사만 선택 가능 — 다른 직업 추가 시 유니온만 확장
+export interface CharacterState {
+  classId: CharClass;
+  level: number; // 1~99
+  xp: number;    // 다음 레벨까지 진행도(레벨업 시 초과분 이월, 누적 총량 아님)
+  stats: CharacterStats;
+}
+
+// 주사위 굴림 — 카드 공격/적 공격 판정 결과.
+export interface AttackRollOptions {
+  advantage?: boolean; // 어드밴티지 아이템 보유 시(플레이어 전용) 2개 굴려 높은 값 채택
+  str?: number; dex?: number; luk?: number; // 플레이어 전용 — 몬스터는 넘기지 않음
+}
+export interface AttackRollResult {
+  faces: number[];        // 실제로 굴린 주사위 눈(어드밴티지면 2개)
+  rawFace: number;        // 채택된 원본 눈(민첩 보정 전) — 크리티컬 판정 기준
+  effectiveFace: number;  // 민첩 보정 적용 후(최대 20)
+  isCrit: boolean;
+  diceDamage: number;     // 크리티컬 배율까지 반영된 주사위 데미지(힘 보너스 제외)
+  strBonus: number;
+  totalDamage: number;    // diceDamage + strBonus — 실제 적용되는 최종 피해
 }
 
 // 전투 로그 한 줄 — D&D 전투기록처럼 실제 수치를 담아 쌓아가는 메시지.

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 // =========================================================================
-// 가치투자 덱빌더 — 손패·에너지 기반 다중 턴 전투 던전 크롤 게임(프로토타입).
+// 가치투자 덱빌더 — 손패·코스트 기반 다중 턴 전투 던전 크롤 게임(프로토타입).
 // 4개 재무지표(ROE→공격력·NCAV→방어력·PBR→코스트·PER→환급) → 카드 전투 스탯(1~10).
+// 공격력은 20면체 주사위(D&D 스타일)로 굴려 0~N 범위에서 실제 피해가 정해짐(자연 20=크리티컬).
+// 캐릭터(전사, 계정 영구 저장)는 힘/민첩/행운/체력 4스탯 + 레벨을 갖고, 공격/처치마다 경험치 획득.
 // 보유 컬렉션(계정 덱) 전체가 곧 전투 덱 — 손패에서 카드를 전장(Phaser 캔버스)으로 드래그해
-// 발동, 에너지 소진 시 "턴 종료"로 적 턴 진행. 3층마다 패시브/액티브 아이템 획득, 10층마다 보스.
+// 발동, 코스트 소진 시 "턴 종료"로 적 턴 진행(코스트는 전투 턴마다 성장, 최대 10). 3층마다
+// 패시브/액티브 아이템 획득, 10층마다 보스(같은 몬스터가 스탯 3배로 강화되어 등장).
 // 이긴 층의 카드만 확률적으로 "내 덱"에 수집(계정별 D1 저장, 로그인 필요).
 // =========================================================================
 
@@ -28,8 +31,10 @@ import { cn } from "@/lib/utils";
 import { HOLO_THRESHOLD, PackReveal, AchievementBadges, ACHIEVEMENTS } from "./gameCollectibles";
 import { WalletChip, ConvertButton, ShopPanel, BOOST_ITEMS } from "./gameShop";
 import { useGameRun, deckTotal, type DeckItem } from "./useGameRun";
-import { HpBar, EnergyBar, ShieldBadge, ItemBar } from "@/components/game/CombatHud";
+import { HpBar, EnergyBar, ShieldBadge, EnemyIntentBadge, ItemBar } from "@/components/game/CombatHud";
 import CombatLog from "@/components/game/CombatLog";
+import CharacterCard from "@/components/game/CharacterCard";
+import DiceRollOverlay from "@/components/game/DiceRollOverlay";
 
 const PhaserCombatCanvas = dynamic(() => import("@/components/game/PhaserCombatCanvas"), { ssr: false });
 const HandView = dynamic(() => import("@/components/game/HandView"), { ssr: false });
@@ -606,6 +611,11 @@ function GameContent() {
                         <ShieldBadge block={run.player.block} />
                       </div>
                     )}
+                    {run.phase === "battling" && run.enemy && (
+                      <div className="px-2 py-1.5 rounded-2xl backdrop-blur-md bg-white/85 dark:bg-white/[0.06] border border-black/5 dark:border-white/10 shadow-[0_6px_18px_-8px_rgba(0,0,0,0.35)]">
+                        <EnemyIntentBadge base={run.enemy.nextAttack} />
+                      </div>
+                    )}
                   </button>
                   <div className="flex items-center justify-center gap-1.5 h-8 overflow-x-auto overflow-y-hidden flex-nowrap scrollbar-hide">
                     {run.gold > 0 && (
@@ -673,13 +683,14 @@ function GameContent() {
             </div>
             <div className="space-y-3">
               {[
-                { icon: "⚔️", text: <>내 덱(보유 카드)이 곧 전투 카드예요. 매 턴 <b className="text-neutral-800 dark:text-neutral-100">손패</b>에서 카드를 <b className="text-neutral-800 dark:text-neutral-100">전장으로 드래그</b>해 발동하세요 — 공격력만큼 적 HP를, 방어력만큼 내 블록을 올려요.</> },
-                { icon: "●", text: <>카드를 내려면 <b className="text-neutral-800 dark:text-neutral-100">코스트</b>가 필요해요 — 상단의 노란 동그라미 개수만큼 쓸 수 있고, 카드의 ●숫자만큼 소모돼요.</> },
+                { icon: "⚔️", text: <>내 덱(보유 카드)이 곧 전투 카드예요. 매 턴 <b className="text-neutral-800 dark:text-neutral-100">손패</b>에서 카드를 <b className="text-neutral-800 dark:text-neutral-100">전장으로 드래그</b>해 발동하세요 — 카드의 공격력은 <b className="text-neutral-800 dark:text-neutral-100">0~N 범위</b>로 20면체 주사위를 굴려 실제 피해가 정해지고, 방어력만큼 내 블록을 올려요.</> },
+                { icon: "🎲", text: <>주사위 눈이 <b className="text-amber-500 dark:text-amber-400">자연 20</b>이면 <b className="text-amber-500 dark:text-amber-400">크리티컬</b>(최대 피해의 2배)! 몬스터의 공격도 같은 방식으로 굴려요. 상태창에서 자동/수동 굴림을 고를 수 있어요.</> },
+                { icon: "●", text: <>카드를 내려면 <b className="text-neutral-800 dark:text-neutral-100">코스트</b>가 필요해요 — 전투 시작 시 1개로 시작해 <b className="text-neutral-800 dark:text-neutral-100">내 턴마다 +1</b>씩 늘어나 최대 10개까지 커져요.</> },
                 { icon: "🔋", text: <>카드의 🔋(환급) 숫자만큼 <b className="text-neutral-800 dark:text-neutral-100">다음 턴 코스트</b>가 미리 충전돼요 — 이번 턴엔 안 쓰이고 다음 턴 시작할 때 동그라미로 더해져요.</> },
-                { icon: "🛡️", text: <>쌓인 방어력은 상단 🛡️ 배지에 실시간으로 표시돼요. <b className="text-neutral-800 dark:text-neutral-100">적 턴 하나만</b> 막고 사라지니, 적의 "다음 턴 예정 공격력"을 미리 보고 방어할지 판단하세요.</> },
-                { icon: "🎒", text: <>3층마다 <b className="text-neutral-800 dark:text-neutral-100">패시브/액티브 아이템</b>을 하나 고를 수 있어요. 패시브는 자동 적용, 액티브는 원할 때 탭해서 1회 사용해요.</> },
+                { icon: "🛡️", text: <>쌓인 방어력은 상단 🛡️ 배지에 실시간으로 표시돼요. <b className="text-neutral-800 dark:text-neutral-100">적 턴 하나만</b> 막고 사라지니, 적의 "다음 턴 예정 공격력 범위"를 미리 보고 방어할지 판단하세요.</> },
+                { icon: "🎒", text: <>3층마다 <b className="text-neutral-800 dark:text-neutral-100">패시브/액티브 아이템</b>을 하나 고를 수 있어요. 힘·민첩·행운·체력을 올려주는 스탯 아이템도 있어요.</> },
                 { icon: "🃏", text: <>적을 처치(층 클리어)하면 확률에 따라 <b className="text-neutral-800 dark:text-neutral-100">내 덱</b>에 카드가 수집돼요. 좋은 카드일수록 전투 스탯도 강해요.</> },
-                { icon: "🎲", text: <>층이 깊어질수록 <b className="text-neutral-800 dark:text-neutral-100">상인</b>(골드로 HP 회복)·<b className="text-neutral-800 dark:text-neutral-100">휴식</b>(무료 회복)·<b className="text-orange-500 dark:text-orange-400">정예</b>(강한 몬스터) 조우가 섞여 나와요. 10층마다는 <b className="text-violet-600 dark:text-violet-400">보스</b>예요.</> },
+                { icon: "🧭", text: <>층이 깊어질수록 <b className="text-neutral-800 dark:text-neutral-100">상인</b>(골드로 HP 회복)·<b className="text-neutral-800 dark:text-neutral-100">휴식</b>(무료 회복)·<b className="text-orange-500 dark:text-orange-400">정예</b>(강한 몬스터) 조우가 섞여 나와요. <b className="text-violet-600 dark:text-violet-400">10층마다는 보스</b>(같은 몬스터가 스탯 3배로 강화돼 등장)예요.</> },
               ].map((row, i) => (
                 <div key={i} className="flex items-start gap-2.5">
                   <span aria-hidden className="shrink-0 text-lg leading-none">{row.icon}</span>
@@ -708,6 +719,22 @@ function GameContent() {
               <b className="text-neutral-800 dark:text-neutral-100">{rankOf(run.roundNum).title}</b>
               <span>· 지하 {run.roundNum + 1}층</span>
             </p>
+            <div className="mb-3">
+              <CharacterCard character={run.character} effectiveStats={run.effectiveStats} hp={run.player.hp} maxHp={run.player.maxHp} />
+            </div>
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-xs font-black text-neutral-700 dark:text-neutral-200">주사위 굴림</span>
+              <div className="inline-flex rounded-full bg-black/[0.04] dark:bg-white/[0.06] p-0.5">
+                <button type="button" onClick={() => run.setDiceAutoRoll(true)}
+                  className={cn("px-2.5 py-1 rounded-full text-[10px] font-black transition-colors", run.diceAutoRoll ? "bg-[#16a34a] text-white" : "text-neutral-500")}>
+                  자동
+                </button>
+                <button type="button" onClick={() => run.setDiceAutoRoll(false)}
+                  className={cn("px-2.5 py-1 rounded-full text-[10px] font-black transition-colors", !run.diceAutoRoll ? "bg-[#16a34a] text-white" : "text-neutral-500")}>
+                  수동
+                </button>
+              </div>
+            </div>
             <div className="grid grid-cols-3 gap-1.5 mb-3">
               <div className="rounded-lg bg-black/[0.03] dark:bg-white/[0.04] py-1.5 text-center">
                 <p className="flex items-center justify-center gap-0.5 text-sm font-black tabular-nums text-rose-500 leading-none"><UserRound size={11} strokeWidth={2.5} />{run.player.hp}/{run.player.maxHp}</p>
@@ -758,6 +785,7 @@ function GameContent() {
                         <span className="flex items-center gap-1 text-xs font-black text-neutral-800 dark:text-neutral-100">
                           {def.name}
                           {def.isLegend && <span className="px-1 py-0.5 rounded text-[8px] font-black bg-amber-500 text-white">전설</span>}
+                          {def.tier && <span className="px-1 py-0.5 rounded text-[8px] font-black bg-violet-500 text-white">Lv{def.tier}</span>}
                           <span className="text-[9px] font-bold text-neutral-400">{def.kind === "active" ? "액티브" : "패시브"}</span>
                         </span>
                         <span className="block text-[10px] text-neutral-500 dark:text-neutral-400">{def.desc}</span>
@@ -786,6 +814,7 @@ function GameContent() {
                     <span className="flex items-center gap-1 text-sm font-black text-neutral-800 dark:text-neutral-100">
                       {item.name}
                       {item.isLegend && <span className="px-1 py-0.5 rounded text-[8px] font-black bg-amber-500 text-white">전설</span>}
+                      {item.tier && <span className="px-1 py-0.5 rounded text-[8px] font-black bg-violet-500 text-white">Lv{item.tier}</span>}
                       <span className="text-[9px] font-bold text-neutral-400">{item.kind === "active" ? "액티브" : "패시브"}</span>
                     </span>
                     <span className="block text-xs text-neutral-500 dark:text-neutral-400">{item.desc}</span>
@@ -799,6 +828,8 @@ function GameContent() {
           </div>
         </div>
       )}
+
+      <DiceRollOverlay roll={run.lastRoll} auto={run.diceAutoRoll} onDismiss={run.dismissRoll} />
     </div>
   );
 }

--- a/cf-idiotquant/app/(game)/game/useCharacter.ts
+++ b/cf-idiotquant/app/(game)/game/useCharacter.ts
@@ -1,0 +1,32 @@
+"use client";
+
+// 가치투자 덱빌더 — 캐릭터(레벨/경험치/힘·민첩·행운·체력) localStorage 연동 훅. 던전 런과 무관하게
+// 계정에 영구 저장(이번 런에서 주운 스탯 아이템은 별개로 useGameRun의 패시브 합산에서만 적용됨).
+
+import { useCallback, useEffect, useState } from "react";
+import { newCharacter, grantXp } from "./characterEngine";
+import type { CharacterState } from "./gameTypes";
+
+const CHAR_KEY = "iq:game:character:v1";
+
+export function useCharacter() {
+  const [character, setCharacter] = useState<CharacterState>(() => newCharacter());
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(CHAR_KEY);
+      if (raw) setCharacter(c => ({ ...c, ...JSON.parse(raw) }));
+    } catch { /* 저장값이 손상됐으면 기본값 그대로 사용 */ }
+    setLoaded(true);
+  }, []);
+
+  useEffect(() => {
+    if (!loaded) return; // 마운트 시 기본값으로 실제 저장값을 덮어쓰지 않기 위한 가드
+    try { localStorage.setItem(CHAR_KEY, JSON.stringify(character)); } catch { /* 저장 실패는 무시 */ }
+  }, [character, loaded]);
+
+  const gainXp = useCallback((amount: number) => setCharacter(c => grantXp(c, amount)), []);
+
+  return { character, characterLoaded: loaded, gainXp };
+}

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -9,12 +9,16 @@ import { addDeckCard, getWallet, syncBestStreak, type DeckCardSnapshot } from "@
 import {
   buildRunDeck, drawHand, enemyForFloor, playCard as engPlayCard,
   startTurn, resolveEnemyTurn, useActiveItem as engUseActiveItem, checkOutcome, aggregatePassive,
-  ENERGY_MAX, HAND_SIZE, BASE_HP,
+  battleEnergyMax, bossExtraChoiceChance,
+  ENERGY_MAX, HAND_SIZE, BASE_HP, VIT_HP_MULTIPLIER,
 } from "./combatEngine";
-import { ALL_ITEMS, STARTER_DECK, pickItemChoices, acquireChance } from "./gameData";
+import { ALL_ITEMS, STARTER_DECK, ITEM_OFFER_COUNT, pickItemChoices, acquireChance } from "./gameData";
 import { ACHIEVEMENTS } from "./gameCollectibles";
+import { useCharacter } from "./useCharacter";
+import { killXpFor, XP_PER_ATTACK } from "./characterEngine";
 import type {
   Phase, EncounterType, CombatCard, ItemDef, OwnedItem, EnemyState, PlayerState, ActiveEffect, LogEntry, LogKind,
+  CharacterStats, AttackRollResult,
 } from "./gameTypes";
 
 const safeNum = (v: any): number => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
@@ -77,6 +81,20 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   const [pile, setPile] = useState<Pile>({ draw: [], hand: [], discard: [] });
   const reservedRefundRef = useRef(0); // 이번 턴에 낸 카드들의 refund 합 — 다음 턴 시작 시 에너지로 편입
   const [turnBonusCost, setTurnBonusCost] = useState(0); // 직전 턴 카드들의 refund로 "이번 턴" 코스트에 얹힌 보너스분(기본 코스트와 구분 표시용)
+  const [battleTurn, setBattleTurn] = useState(1); // 이번 전투에서 몇 번째 내 턴인지(1부터) — 코스트 성장의 기준
+
+  const { character, characterLoaded, gainXp } = useCharacter();
+  const [lastRoll, setLastRoll] = useState<{ source: "player" | "enemy"; roll: AttackRollResult } | null>(null);
+  const diceAutoRollKey = "iq:game:diceAutoRoll";
+  const [diceAutoRoll, setDiceAutoRollState] = useState(true);
+  useEffect(() => {
+    try { const raw = localStorage.getItem(diceAutoRollKey); if (raw != null) setDiceAutoRollState(raw === "1"); } catch { /* 기본값(자동) 유지 */ }
+  }, []);
+  const setDiceAutoRoll = useCallback((v: boolean) => {
+    setDiceAutoRollState(v);
+    try { localStorage.setItem(diceAutoRollKey, v ? "1" : "0"); } catch { /* 저장 실패는 무시 */ }
+  }, []);
+  const dismissRoll = useCallback(() => setLastRoll(null), []);
 
   const [log, setLog] = useState<LogEntry[]>([]);
   const pushLog = useCallback((kind: LogKind, text: string) => {
@@ -108,7 +126,14 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
 
   const ownedDefs = useMemo(() => ownedItems.map(o => ALL_ITEMS.find(d => d.id === o.defId)!).filter(Boolean), [ownedItems]);
   const passive = useMemo(() => aggregatePassive(ownedDefs), [ownedDefs]);
-  const maxHp = BASE_HP + passive.maxHpBonus;
+  // 캐릭터(영구) 스탯 + 이번 런에서 주운 아이템 보너스 = 실제 전투 계산에 쓰이는 유효 스탯.
+  const effectiveStats = useMemo<CharacterStats>(() => ({
+    str: character.stats.str + passive.strBonus,
+    dex: character.stats.dex + passive.dexBonus,
+    luk: character.stats.luk + passive.lukBonus,
+    vit: character.stats.vit + passive.vitBonus,
+  }), [character.stats, passive]);
+  const maxHp = BASE_HP + effectiveStats.vit * VIT_HP_MULTIPLIER + passive.maxHpBonus;
 
   // 아이템 보너스로 maxHp가 늘면 그만큼 현재 HP도 즉시 채워줌(줄어드는 경우는 없음)
   const prevMaxHpRef = useRef(maxHp);
@@ -122,6 +147,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   const handleWin = useCallback((beatenEnemy: EnemyState, enc: EncounterType, floor: number) => {
     const nt = floor + 1; // 클리어한 층수(0-indexed floor → 1부터)
     pushLog("system", `🏆 ${beatenEnemy.item?.name ?? "적"}을(를) 처치했습니다!`);
+    gainXp(killXpFor(beatenEnemy.item));
     if (nt > best) {
       setBest(nt); setNewBest(true);
       try { localStorage.setItem(bestKey, String(nt)); } catch { }
@@ -136,7 +162,9 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     const isItemRound = floor > 0 && floor % 3 === 0 && enc === "battle";
     if (isItemRound || isBossRound) {
       const offerPool = isBossRound && unlockedLegendItems.length > 0 ? unlockedLegendItems : availableItemPool;
-      setItemChoices(pickItemChoices(offerPool));
+      // 보스는 행운 수치에 따라 낮은 확률로 3택 대신 4택을 제공
+      const offerCount = isBossRound && Math.random() < bossExtraChoiceChance(effectiveStats.luk) ? ITEM_OFFER_COUNT + 1 : ITEM_OFFER_COUNT;
+      setItemChoices(pickItemChoices(offerPool, offerCount));
     }
 
     // 상점에서 산 확률 부스트는 세션 로컬로만 추적 — 층 클리어마다 1씩 소진
@@ -164,26 +192,29 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
         setSaveFail(deckFailReason(res));
       }
     }).catch(() => setSaveFail("네트워크 오류"));
-  }, [best, isLoggedIn, availableItemPool, unlockedLegendItems, setDeck, activeBoost, pushLog]);
+  }, [best, isLoggedIn, availableItemPool, unlockedLegendItems, setDeck, activeBoost, pushLog, gainXp, effectiveStats.luk]);
 
-  // 손패 카드 발동 — dnd-kit 드롭 이벤트에서 호출
+  // 손패 카드 발동 — dnd-kit 드롭 이벤트에서 호출. 공격력은 이제 주사위로 굴려서 정해짐.
   const playHandCard = useCallback((instanceId: string) => {
     if (phase !== "battling" || !enemy) return;
     const card = pile.hand.find(c => c.instanceId === instanceId);
     if (!card) return;
     const cost = card.stats.cost <= passive.freeCostThreshold ? 0 : card.stats.cost;
     if (player.energy < cost) return;
-    const result = engPlayCard(player, enemy, card, passive);
+    const result = engPlayCard(player, enemy, card, passive, effectiveStats);
     setPlayer(result.player);
     setEnemy(result.enemy);
     setPile(p => ({ ...p, hand: p.hand.filter(c => c.instanceId !== instanceId), discard: [...p.discard, card] }));
     reservedRefundRef.current += card.stats.refund;
-    const parts = [`⚔${card.stats.attack} 피해`];
+    gainXp(XP_PER_ATTACK);
+    setLastRoll({ source: "player", roll: result.roll });
+    const critTxt = result.roll.isCrit ? " 💥크리티컬!" : "";
+    const parts = [`🎲${result.roll.faces.join("/")}${critTxt} → ⚔${result.roll.totalDamage} 피해`];
     if (card.stats.shield > 0) parts.push(`🛡${card.stats.shield} 방어`);
     if (card.stats.refund > 0) parts.push(`🔋다음 턴 코스트 +${card.stats.refund}`);
     pushLog("player", `${card.name} 발동 — ${parts.join(", ")} (코스트 -${cost})`);
     if (checkOutcome(result.player, result.enemy) === "win") handleWin(result.enemy, encounter, roundNum);
-  }, [phase, enemy, pile.hand, passive, player, encounter, roundNum, handleWin, pushLog]);
+  }, [phase, enemy, pile.hand, passive, player, effectiveStats, encounter, roundNum, handleWin, pushLog, gainXp]);
 
   // 액티브 아이템 즉시 발동(1회 소모)
   const useOwnedActiveItem = useCallback((instanceId: string) => {
@@ -199,24 +230,28 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     if (checkOutcome(r.player, r.enemy) === "win") handleWin(r.enemy, encounter, roundNum);
   }, [phase, enemy, ownedItems, player, pile, encounter, roundNum, handleWin, pushLog]);
 
-  // 턴 종료 — 적 턴 해석 → (생존 시) 다음 턴 시작(에너지 리필+예약환급, 손패 재드로우)
+  // 턴 종료 — 적 턴 해석(적도 주사위 굴림) → (생존 시) 다음 턴 시작(코스트 성장+환급, 손패 재드로우)
   const endTurn = useCallback(() => {
     if (phase !== "battling" || !enemy) return;
-    const blocked = Math.min(enemy.nextAttack, player.block + passive.damageReduce);
-    const dmg = enemy.nextAttack - blocked;
-    pushLog("enemy", `${enemy.item?.name ?? "적"}의 공격! ⚔${enemy.nextAttack} 중 🛡${blocked} 경감 → ${dmg} 피해`);
-    const afterEnemy = resolveEnemyTurn(player, enemy, passive);
+    const { player: afterEnemy, roll } = resolveEnemyTurn(player, enemy, passive);
+    setLastRoll({ source: "enemy", roll });
+    const blocked = Math.min(roll.totalDamage, player.block + passive.damageReduce);
+    const dmg = Math.max(0, roll.totalDamage - blocked);
+    const critTxt = roll.isCrit ? " 💥크리티컬!" : "";
+    pushLog("enemy", `${enemy.item?.name ?? "적"}의 공격! 🎲${roll.faces.join("/")}${critTxt} → ⚔${roll.totalDamage} 중 🛡${blocked} 경감 → ${dmg} 피해`);
     setPlayer(afterEnemy);
     if (afterEnemy.hp <= 0) { setPhase("over"); setLastResult({ win: false }); pushLog("system", "💀 쓰러졌습니다..."); return; }
     const rr = reservedRefundRef.current; reservedRefundRef.current = 0;
     setTurnBonusCost(rr);
-    setPlayer(p => startTurn(p, passive, rr));
+    const nextTurn = battleTurn + 1;
+    setBattleTurn(nextTurn);
+    setPlayer(p => startTurn({ ...p, energyMax: battleEnergyMax(nextTurn) }, passive, rr));
     setPile(prev => {
       const carryDiscard = [...prev.discard, ...prev.hand];
       const r = drawHand(prev.draw, carryDiscard, HAND_SIZE + passive.drawBonus);
       return { draw: r.drawPile, hand: r.hand, discard: r.discardPile };
     });
-  }, [phase, enemy, player, passive, pushLog]);
+  }, [phase, enemy, player, passive, pushLog, battleTurn]);
 
   // 다음 라운드 진입 — 조우 판정 후 배틀(적 생성+손패 재드로우) 또는 이벤트(상인/휴식)
   const advanceToRound = useCallback((nextRoundNum: number) => {
@@ -246,7 +281,8 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     });
     const rr = reservedRefundRef.current; reservedRefundRef.current = 0;
     setTurnBonusCost(rr);
-    setPlayer(p => startTurn(p, passive, rr));
+    setBattleTurn(1); // 새 전투 진입 — 코스트 성장 카운터 리셋
+    setPlayer(p => startTurn({ ...p, energyMax: battleEnergyMax(1) }, passive, rr));
     setPhase("battling");
   }, [pool, passive, pushLog]);
 
@@ -284,23 +320,25 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setLastResult(null); setDropped(false); setDropPrompt(false); setSaveFail(null); setPackOpening(false); setAcquired([]);
     reservedRefundRef.current = 0;
     setTurnBonusCost(0);
-    const hp = BASE_HP;
-    setPlayer({ hp, maxHp: hp, block: 0, energy: ENERGY_MAX, energyMax: ENERGY_MAX });
-    prevMaxHpRef.current = hp;
+    setBattleTurn(1);
+    const initialEnergyMax = battleEnergyMax(1);
+    setPlayer({ hp: maxHp, maxHp, block: 0, energy: initialEnergyMax, energyMax: initialEnergyMax });
+    prevMaxHpRef.current = maxHp;
     setLog([{ id: "l0", kind: "system", text: `🐉 ${newEnemy.item?.name ?? "적"} 등장! (HP ${newEnemy.maxHp})` }]);
     setPhase("battling");
-  }, [pool, deck]);
+  }, [pool, deck, maxHp]);
 
   const started = useRef(false);
-  useEffect(() => { if (!started.current && pool.length >= 2) { started.current = true; start(); } }, [pool, start]);
+  useEffect(() => { if (!started.current && pool.length >= 2 && characterLoaded) { started.current = true; start(); } }, [pool, characterLoaded, start]);
 
   const acquirePct = enemy ? Math.round(Math.min(0.95, acquireChance(enemy.item, roundNum + 1) * (activeBoost?.mult ?? 1)) * 100) : 0;
 
   return {
     phase, roundNum, encounter, restHealed, gold, best, newBest,
     ownedItems, ownedDefs, itemChoices, passive, maxHp, unlockedLegendItems, activeBoost,
-    player, enemy, hand: pile.hand, drawCount: pile.draw.length, log, turnBonusCost,
+    player, enemy, hand: pile.hand, drawCount: pile.draw.length, log, turnBonusCost, battleTurn,
     lastResult, dropped, dropPrompt, saveFail, packOpening, acquired, acquirePct,
+    character, effectiveStats, lastRoll, diceAutoRoll, setDiceAutoRoll, dismissRoll,
     start, playHandCard, useOwnedActiveItem, endTurn, nextRound, proceedFromEvent, cashOut, buyMerchantHeal, buyBoost, pickItem, skipItem,
   };
 }

--- a/cf-idiotquant/components/game/CharacterCard.tsx
+++ b/cf-idiotquant/components/game/CharacterCard.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+// 플레이어 캐릭터 카드 — 기존 주식 카드(TcgCard)의 둥근 프레임 + 아이콘 + 2x2 스탯 그리드
+// 시각 언어를 재사용하되, 등급 글로우 대신 직업 고정 톤(전사=주황 계열)을 쓴다. 이번 스코프는
+// 픽셀아트 대신 이모지 placeholder — 몬스터도 처음엔 placeholder였다가 여러 피드백을 거쳐
+// 지금 모습이 된 전례를 따라 우선 저비용으로 시작한다.
+
+import { CLASS_DEFS, xpToNextLevel } from "@/app/(game)/game/characterEngine";
+import type { CharacterState, CharacterStats } from "@/app/(game)/game/gameTypes";
+
+const STAT_ICON: Record<keyof CharacterStats, string> = { str: "💪", dex: "🐇", luk: "🍀", vit: "🫀" };
+const STAT_LABEL: Record<keyof CharacterStats, string> = { str: "힘", dex: "민첩", luk: "행운", vit: "체력" };
+const STAT_KEYS = Object.keys(STAT_ICON) as (keyof CharacterStats)[];
+
+export default function CharacterCard({ character, effectiveStats, hp, maxHp }: {
+  character: CharacterState; effectiveStats: CharacterStats; hp: number; maxHp: number;
+}) {
+  const cls = CLASS_DEFS[character.classId];
+  const need = xpToNextLevel(character.level);
+  const xpPct = Math.max(0, Math.min(100, (character.xp / need) * 100));
+  const hpPct = maxHp > 0 ? Math.max(0, Math.min(100, (hp / maxHp) * 100)) : 0;
+
+  return (
+    <div className="rounded-2xl border-2 border-orange-500/40 bg-gradient-to-b from-orange-500/10 to-transparent p-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-black text-orange-700 dark:text-orange-300">{cls.name}</span>
+        <span className="px-2 py-0.5 rounded-full bg-orange-500 text-white text-[10px] font-black">Lv.{character.level}</span>
+      </div>
+
+      <div className="flex justify-center py-2 text-4xl" aria-hidden>⚔️🛡️</div>
+
+      <div className="grid grid-cols-2 gap-1.5 mb-2">
+        {STAT_KEYS.map(key => {
+          const base = character.stats[key];
+          const bonus = effectiveStats[key] - base;
+          return (
+            <div key={key} className="rounded-lg bg-black/[0.03] dark:bg-white/[0.04] py-1 text-center">
+              <p className="text-xs font-black tabular-nums text-neutral-800 dark:text-neutral-100">
+                {STAT_ICON[key]} {base}{bonus > 0 && <span className="text-emerald-500"> (+{bonus})</span>}
+              </p>
+              <p className="text-[8px] font-bold text-neutral-400">{STAT_LABEL[key]}</p>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mb-1.5">
+        <div className="flex items-center justify-between text-[9px] font-bold text-neutral-400 mb-0.5">
+          <span>XP</span><span className="tabular-nums">{character.xp}/{need}</span>
+        </div>
+        <div className="h-1.5 rounded-full bg-black/10 dark:bg-white/10 overflow-hidden">
+          <div className="h-full bg-violet-500" style={{ width: `${xpPct}%` }} />
+        </div>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between text-[9px] font-bold text-neutral-400 mb-0.5">
+          <span>HP</span><span className="tabular-nums">{hp}/{maxHp}</span>
+        </div>
+        <div className="h-1.5 rounded-full bg-black/10 dark:bg-white/10 overflow-hidden">
+          <div className="h-full bg-rose-500" style={{ width: `${hpPct}%` }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/cf-idiotquant/components/game/CombatHud.tsx
+++ b/cf-idiotquant/components/game/CombatHud.tsx
@@ -67,6 +67,17 @@ export function ShieldBadge({ block }: { block: number }) {
   );
 }
 
+// 적의 다음 공격이 얼마나 아플지 미리 보여주는 텔레그래프 — 공격력이 이제 고정 데미지가 아니라
+// 0~N 범위 주사위 굴림이라 정확한 수치 대신 범위로 표시한다.
+export function EnemyIntentBadge({ base }: { base: number }) {
+  return (
+    <div className="flex items-center gap-1 shrink-0">
+      <span aria-hidden className="text-rose-500">⚔️</span>
+      <span className="text-[10px] font-black tabular-nums text-rose-600 dark:text-rose-400">0~{base} 예정</span>
+    </div>
+  );
+}
+
 export function ItemBar({ ownedDefs, ownedItems, onUseActive, canUseActive }: {
   ownedDefs: ItemDef[]; ownedItems: OwnedItem[];
   onUseActive: (instanceId: string) => void; canUseActive: boolean;

--- a/cf-idiotquant/components/game/CombatScene.ts
+++ b/cf-idiotquant/components/game/CombatScene.ts
@@ -280,8 +280,11 @@ export default class CombatScene extends Phaser.Scene {
     }
   }
 
-  setEnemy(name: string, hp: number, maxHp: number) {
-    this.enemyLabel.setText(name);
+  // 정예/보스는 상시 배지를 라벨에 붙여 등장 인트로가 사라진 뒤에도 계속 구분되게 함.
+  setEnemy(name: string, hp: number, maxHp: number, encounter: "battle" | "boss" | "elite" = "battle") {
+    const prefix = encounter === "boss" ? "👑 보스 · " : encounter === "elite" ? "🗡️ 정예 · " : "";
+    const color = encounter === "boss" ? "#facc15" : encounter === "elite" ? "#c084fc" : "#ffffff";
+    this.enemyLabel.setText(prefix + name).setColor(color);
     this.spec = randomMonster();
     this.blinking = false;
     this.squished = false;

--- a/cf-idiotquant/components/game/CombatScene.ts
+++ b/cf-idiotquant/components/game/CombatScene.ts
@@ -2,70 +2,158 @@ import Phaser from "phaser";
 
 // 가치투자 덱빌더 — 전투 씬(프로토타입 비주얼). 몬스터는 진짜 픽셀 격자(Graphics로 정사각형을
 // 하나하나 찍는 방식)로 그린 귀여운 블롭 캐릭터. 유니코드 글자 기반 ASCII 아트는 폰트마다
-// 모양이 달라지고 못생겨 보인다는 피드백을 받아 폐기하고, 격자 좌표만으로 매번 매끈한 타원
-// 실루엣을 계산해 그리는 방식으로 바꿨다 — 조합이 아무리 랜덤해도 항상 매끈한 블롭이 보장됨.
+// 모양이 달라지고 못생겨 보인다는 피드백을 받아 폐기하고, 격자 좌표만으로 매번 매끈한 실루엣을
+// 계산해 그리는 방식으로 바꿨다 — 조합이 아무리 랜덤해도 항상 매끈한 실루엣이 보장됨.
 // 판정 로직은 전혀 없음 — combatEngine이 계산한 결과를 받아 재생만 한다.
-
-// 슬라임 실루엣 — 위쪽은 돔(타원 상반부) + 정수리 뾰족점(고전 물방울형 슬라임 실루엣 관례
-// 참고, 특정 캐릭터 디자인을 그대로 베끼지 않고 형태 관례만 차용), 적도(CY)부터 아래는
-// 바닥으로 갈수록 폭이 점점 넓어지는 플레어(치마처럼 퍼짐)를 줘서 "바닥에 퍼져 앉은" 느낌을
-// 낸다. 맨 아랫줄만 살짝 좁혀 모서리를 둥글게.
 const GRID = 18;
 const CX = GRID / 2;
-const RX = 5;
-const CY = 7; // 돔의 적도(가장 넓은 지점) — 여기부터 아래는 바닥까지 폭이 늘어남
+const CY = 7; // 그래픽스 좌표계 원점 기준 행(캔버스 세로 중앙에 맞추는 용도, 특정 종과 무관)
 
-// 대기 애니메이션용 두 프레임 — 위치를 옮기는 트윈 대신, 돔 높이/바닥 폭 몇 줄만 바꿔서
-// "숨쉬듯" 눌렸다 펴지는 느낌을 픽셀 단위로 표현한다(값이 낮을수록 납작하게 눌린 프레임).
-type ShapeParams = { ry: number; bodyBottom: number; flare: number };
-const SHAPE_NORMAL: ShapeParams = { ry: 5.5, bodyBottom: 13, flare: 2.6 };
-const SHAPE_SQUISH: ShapeParams = { ry: 4.6, bodyBottom: 12, flare: 3.6 };
-
-const SPIKE_ROW_OFFSET = 1.5; // 정수리 뾰족점이 돔 타원보다 몇 줄 위까지 튀어나오는지
-const SPIKE_HALF_WIDTH = 0.6; // 뾰족점의 중심 기준 반폭(칸)
-
-function inBody(col: number, row: number, shape: ShapeParams): boolean {
-  if (row > shape.bodyBottom) return false;
+// 슬라임 — 돔(타원 상반부) + 정수리 뾰족점(고전 물방울형 슬라임 실루엣 관례 참고, 특정
+// 캐릭터 디자인을 그대로 베끼지 않고 형태 관례만 차용), 적도부터 아래는 바닥으로 갈수록
+// 폭이 점점 넓어지는 플레어(치마처럼 퍼짐)를 줘서 "바닥에 퍼져 앉은" 느낌을 낸다.
+const SLIME_RX = 5, SLIME_RY = 5.5, SLIME_EQ = 7, SLIME_BOTTOM = 13, SLIME_FLARE = 2.6;
+const SLIME_SPIKE_ROW_OFFSET = 1.5, SLIME_SPIKE_HALF_WIDTH = 0.6;
+function slimeBody(col: number, row: number): boolean {
+  if (row > SLIME_BOTTOM) return false;
   const dx = col + 0.5 - CX;
-  if (row <= CY) {
-    const ny = (row + 0.5 - CY) / shape.ry;
-    const nx = dx / RX;
+  if (row <= SLIME_EQ) {
+    const ny = (row + 0.5 - SLIME_EQ) / SLIME_RY;
+    const nx = dx / SLIME_RX;
     if (nx * nx + ny * ny <= 1) return true;
     // 정수리 뾰족점 — 돔 타원 바로 위 한 줄만, 중앙 두 칸 폭으로 살짝 튀어나오게
-    const nyBelow = (row + SPIKE_ROW_OFFSET - CY) / shape.ry;
-    return nyBelow * nyBelow <= 1 && Math.abs(dx) <= SPIKE_HALF_WIDTH;
+    const nyBelow = (row + SLIME_SPIKE_ROW_OFFSET - SLIME_EQ) / SLIME_RY;
+    return nyBelow * nyBelow <= 1 && Math.abs(dx) <= SLIME_SPIKE_HALF_WIDTH;
   }
-  const t = (row - CY) / (shape.bodyBottom - CY); // 0(적도) → 1(바닥)
-  const flared = RX + t * shape.flare;
-  const maxRx = row >= shape.bodyBottom ? flared - 1 : flared; // 맨 아랫줄만 살짝 좁혀 모서리를 둥글게
+  const t = (row - SLIME_EQ) / (SLIME_BOTTOM - SLIME_EQ); // 0(적도) → 1(바닥)
+  const flared = SLIME_RX + t * SLIME_FLARE;
+  const maxRx = row >= SLIME_BOTTOM ? flared - 1 : flared; // 맨 아랫줄만 살짝 좁혀 모서리를 둥글게
   return Math.abs(dx) <= maxRx;
 }
 
-// 초록 계열 팔레트로만 구성(슬라임다움을 위해 색상군을 고정, 색조는 다양화)
+// 유령 — 둥근 정수리 돔 + 곧은 몸통 옆선 + 바닥의 물결치는 다리 3갈래(고전 유령 실루엣 관례).
+const GHOST_TOP = 2, GHOST_EQ = 6, GHOST_RX = 4.5, GHOST_RY = 4, GHOST_LEGTOP = 13, GHOST_BOTTOM = 16;
+const GHOST_LEG_OFFSETS = [-3, 0, 3];
+function ghostBody(col: number, row: number): boolean {
+  if (row < GHOST_TOP || row > GHOST_BOTTOM) return false;
+  const dx = col + 0.5 - CX;
+  if (row <= GHOST_EQ) {
+    const nx = dx / GHOST_RX, ny = (row - GHOST_EQ) / GHOST_RY;
+    return nx * nx + ny * ny <= 1;
+  }
+  if (row <= GHOST_LEGTOP) return Math.abs(dx) <= GHOST_RX;
+  const t = (row - GHOST_LEGTOP) / (GHOST_BOTTOM - GHOST_LEGTOP); // 0(다리 시작) → 1(다리 끝)
+  const legHalf = 1.4 - t * 1.1; // 갈래마다 아래로 갈수록 뾰족하게 좁아짐
+  return GHOST_LEG_OFFSETS.some(off => Math.abs(dx - off) <= legHalf);
+}
+
+// 박쥐 — 작은 타원 머리 + 삼각형 귀 한 쌍 + 몸통 옆으로 퍼지는 삼각형 날개 한 쌍.
+const BAT_HEAD_RX = 3, BAT_HEAD_RY = 3.2, BAT_HEAD_ROW = 8;
+const BAT_EAR_TOP = 2, BAT_EAR_BOTTOM = 5;
+const BAT_WING_TOP = 6, BAT_WING_MID = 9, BAT_WING_BOTTOM = 12, BAT_WING_REACH = 5, BAT_WING_ATTACH = 3;
+function batBody(col: number, row: number): boolean {
+  const dx = col + 0.5 - CX;
+  const nx = dx / BAT_HEAD_RX, ny = (row - BAT_HEAD_ROW) / BAT_HEAD_RY;
+  if (row >= BAT_EAR_TOP && nx * nx + ny * ny <= 1) return true;
+  if (row >= BAT_EAR_TOP && row <= BAT_EAR_BOTTOM) {
+    const t = (row - BAT_EAR_TOP) / (BAT_EAR_BOTTOM - BAT_EAR_TOP); // 0(귀 끝) → 1(머리와 만나는 지점)
+    for (const earDx of [-1.6, 1.6]) {
+      if (Math.abs(dx - earDx) <= 0.3 + t * 0.9) return true;
+    }
+  }
+  if (row >= BAT_WING_TOP && row <= BAT_WING_BOTTOM) {
+    const t = 1 - Math.abs(row - BAT_WING_MID) / (BAT_WING_MID - BAT_WING_TOP); // 중간 행에서 가장 넓게 퍼짐
+    const reach = Math.max(0, t) * BAT_WING_REACH;
+    if (dx <= -BAT_WING_ATTACH && dx >= -BAT_WING_ATTACH - reach) return true;
+    if (dx >= BAT_WING_ATTACH && dx <= BAT_WING_ATTACH + reach) return true;
+  }
+  return false;
+}
+
+// 버섯 — 넓적한 갓(타원) + 그 아래로 뻗은 얇은 기둥.
+const CAP_RX = 6.5, CAP_RY = 4, CAP_ROW = 6, CAP_TOP = 1, CAP_BOTTOM = 9;
+const STEM_HALF = 1.5, STEM_TOP = 9, STEM_BOTTOM = 15;
+function mushroomBody(col: number, row: number): boolean {
+  const dx = col + 0.5 - CX;
+  if (row >= CAP_TOP && row <= CAP_BOTTOM) {
+    const nx = dx / CAP_RX, ny = (row - CAP_ROW) / CAP_RY;
+    if (nx * nx + ny * ny <= 1) return true;
+  }
+  if (row > STEM_TOP && row <= STEM_BOTTOM) return Math.abs(dx) <= STEM_HALF;
+  return false;
+}
+
+// 대기 애니메이션(숨쉬듯 눌렸다 펴지는 효과)용 공용 변형 — 아래 칸에서 당겨와 위쪽이 눌린
+// 것처럼 보이게 하고(수직 압축), 좌우 이웃 칸과 합쳐서 눌린 만큼 옆으로 퍼지게(수평 팽창)
+// 만든다. 종마다 따로 눌린 모양을 튜닝하지 않아도 어떤 실루엣이든 동일하게 적용됨.
+function squish(col: number, row: number, base: (c: number, r: number) => boolean): boolean {
+  const r = row + 1;
+  return base(col, r) || base(col - 1, r) || base(col + 1, r);
+}
+
 type Palette = { body: number; outline: number; shine: number };
 function lighten(hex: number, amt: number): number {
   const r = (hex >> 16) & 0xff, g = (hex >> 8) & 0xff, b = hex & 0xff;
   const mix = (c: number) => Math.min(255, Math.round(c + (255 - c) * amt));
   return (mix(r) << 16) | (mix(g) << 8) | mix(b);
 }
-const PALETTE_BASE = [
-  { body: 0x4ade80, outline: 0x15803d }, // 에메랄드
-  { body: 0x34d399, outline: 0x047857 }, // 민트
-  { body: 0xa3e635, outline: 0x4d7c0f }, // 라임
-  { body: 0x22c55e, outline: 0x14532d }, // 포레스트
-  { body: 0x6ee7b7, outline: 0x0f766e }, // 시폼
-  { body: 0x84cc16, outline: 0x3f6212 }, // 올리브
+function makePalette(body: number, outline: number): Palette {
+  return { body, outline, shine: lighten(body, 0.6) };
+}
+const BLUSH_COLOR = 0xfda4af; // 볼터치는 종과 무관하게 고정 분홍(몸 색과는 항상 대비됨)
+
+// 종마다 색상군을 고정해서(슬라임=초록, 유령=창백한 한색, 박쥐=어두운 보라, 버섯=따뜻한
+// 원색) 같은 종끼리는 늘 닮아 보이면서도 색조는 다양하게 섞이도록 함.
+const SLIME_PALETTES: Palette[] = [
+  makePalette(0x4ade80, 0x15803d), // 에메랄드
+  makePalette(0x34d399, 0x047857), // 민트
+  makePalette(0xa3e635, 0x4d7c0f), // 라임
+  makePalette(0x22c55e, 0x14532d), // 포레스트
+  makePalette(0x6ee7b7, 0x0f766e), // 시폼
+  makePalette(0x84cc16, 0x3f6212), // 올리브
 ];
-const PALETTES: Palette[] = PALETTE_BASE.map(p => ({ ...p, shine: lighten(p.body, 0.6) }));
-const BLUSH_COLOR = 0xfda4af; // 초록 몸과 대비되도록 볼터치는 고정 분홍
+const GHOST_PALETTES: Palette[] = [
+  makePalette(0xf1f5f9, 0x94a3b8), // 슬레이트 화이트
+  makePalette(0xe0e7ff, 0x818cf8), // 라벤더
+  makePalette(0xdbeafe, 0x60a5fa), // 스카이 화이트
+  makePalette(0xfae8ff, 0xd8b4fe), // 연보라
+];
+const BAT_PALETTES: Palette[] = [
+  makePalette(0x6d28d9, 0x3b0764), // 퍼플
+  makePalette(0x4c1d95, 0x2e1065), // 인디고
+  makePalette(0x581c87, 0x3b0764), // 플럼
+  makePalette(0x312e81, 0x1e1b4b), // 미드나잇
+];
+const MUSHROOM_PALETTES: Palette[] = [
+  makePalette(0xef4444, 0x991b1b), // 레드캡
+  makePalette(0xf97316, 0xc2410c), // 오렌지캡
+  makePalette(0xa16207, 0x713f12), // 브라운캡
+  makePalette(0xeab308, 0x854d0e), // 옐로캡
+];
+
+type SpeciesDef = {
+  inBody: (col: number, row: number) => boolean;
+  eyeRow: number; // 눈 중심 행(종마다 실루엣이 달라 얼굴 위치도 따로 지정)
+  mouthRow: number;
+  eyeGapOptions: number[]; // 종 너비에 맞는 눈 사이 간격 후보
+  palettes: Palette[];
+};
+const SPECIES: SpeciesDef[] = [
+  { inBody: slimeBody, eyeRow: SLIME_EQ - 0.5, mouthRow: SLIME_EQ + 2, eyeGapOptions: [2, 3], palettes: SLIME_PALETTES },
+  { inBody: ghostBody, eyeRow: 8, mouthRow: 10, eyeGapOptions: [2], palettes: GHOST_PALETTES },
+  { inBody: batBody, eyeRow: 7, mouthRow: 9, eyeGapOptions: [1], palettes: BAT_PALETTES },
+  { inBody: mushroomBody, eyeRow: 8, mouthRow: 9, eyeGapOptions: [2, 3], palettes: MUSHROOM_PALETTES },
+];
 
 type MouthKind = "smile" | "o" | "none";
-type MonsterSpec = { palette: Palette; eyeGap: number; mouth: MouthKind; hasBlush: boolean };
+type MonsterSpec = { species: SpeciesDef; palette: Palette; eyeGap: number; mouth: MouthKind; hasBlush: boolean };
 const pick = <T,>(arr: T[]) => arr[Math.floor(Math.random() * arr.length)];
 function randomMonster(): MonsterSpec {
+  const species = pick(SPECIES);
   return {
-    palette: pick(PALETTES),
-    eyeGap: pick([2, 3]),
+    species,
+    palette: pick(species.palettes),
+    eyeGap: pick(species.eyeGapOptions),
     mouth: pick(["smile", "smile", "o", "none"]),
     hasBlush: Math.random() < 0.5,
   };
@@ -124,7 +212,9 @@ export default class CombatScene extends Phaser.Scene {
   private drawMonster() {
     const g = this.enemyGfx;
     const s = this.spec;
-    const shape = this.squished ? SHAPE_SQUISH : SHAPE_NORMAL;
+    const species = s.species;
+    const basePred = species.inBody;
+    const pred = this.squished ? (c: number, r: number) => squish(c, r, basePred) : basePred;
     g.clear();
 
     // 몸통 판정을 칸마다 한 번만 계산해 캐시해두고(테두리 판정에서 이웃 4칸 재조회 시 재사용),
@@ -132,11 +222,11 @@ export default class CombatScene extends Phaser.Scene {
     const body: boolean[][] = [];
     for (let row = 0; row < GRID; row++) {
       body[row] = [];
-      for (let col = 0; col < GRID; col++) body[row][col] = inBody(col, row, shape);
+      for (let col = 0; col < GRID; col++) body[row][col] = pred(col, row);
     }
     const isBody = (col: number, row: number) => body[row]?.[col] ?? false;
 
-    // 몸통 — 칸마다 타원 안쪽인지 검사해 채우고, 바로 바깥 칸이 하나라도 비어 있으면 외곽선색으로.
+    // 몸통 — 칸마다 실루엣 안쪽인지 검사해 채우고, 바로 바깥 칸이 하나라도 비어 있으면 외곽선색으로.
     for (let row = 0; row < GRID; row++) {
       for (let col = 0; col < GRID; col++) {
         if (!isBody(col, row)) continue;
@@ -147,9 +237,9 @@ export default class CombatScene extends Phaser.Scene {
       }
     }
 
-    // 광택 — 슬라임 특유의 물방울/젤리 느낌을 주는 밝은 하이라이트(왼쪽 위, 반투명)
+    // 광택 — 젤리/매끈한 표면 느낌을 주는 밝은 하이라이트(눈 위쪽, 반투명)
     {
-      const p = this.cellPx(CX - RX * 0.45, CY - shape.ry * 0.55);
+      const p = this.cellPx(CX - 3, species.eyeRow - 2);
       g.fillStyle(s.palette.shine, 0.7);
       g.fillEllipse(p.x, p.y, this.cell * 2.2, this.cell * 1.4);
     }
@@ -158,7 +248,7 @@ export default class CombatScene extends Phaser.Scene {
     if (s.hasBlush) {
       g.fillStyle(BLUSH_COLOR, 0.85);
       for (const dir of [-1, 1]) {
-        const p = this.cellPx(CX + dir * (s.eyeGap + 1.8), CY + 1);
+        const p = this.cellPx(CX + dir * (s.eyeGap + 1.8), species.eyeRow + 1.5);
         g.fillCircle(p.x + this.cell / 2, p.y + this.cell / 2, this.cell * 0.75);
       }
     }
@@ -168,7 +258,7 @@ export default class CombatScene extends Phaser.Scene {
     // 반복하지 않기 위함. 깜빡일 땐 얇은 곡선으로.
     for (const dir of [-1, 1]) {
       const ex = CX + dir * s.eyeGap;
-      const p = this.cellPx(ex, CY - 0.5);
+      const p = this.cellPx(ex, species.eyeRow);
       const cxPx = p.x + this.cell / 2, cyPx = p.y + this.cell / 2;
       if (this.blinking) {
         g.fillStyle(s.palette.outline, 1);
@@ -183,7 +273,7 @@ export default class CombatScene extends Phaser.Scene {
 
     // 입
     if (s.mouth !== "none") {
-      const p = this.cellPx(CX, CY + 2);
+      const p = this.cellPx(CX, species.mouthRow);
       g.fillStyle(s.palette.outline, 1);
       if (s.mouth === "smile") g.fillRoundedRect(p.x - this.cell, p.y, this.cell * 2, this.cell * 0.4, this.cell * 0.2);
       else g.fillCircle(p.x + this.cell / 2, p.y, this.cell * 0.4);
@@ -203,9 +293,9 @@ export default class CombatScene extends Phaser.Scene {
     this.enemyHpText.setText(asciiBar(hp, maxHp));
   }
 
-  // 살아있는 느낌을 주는 대기 애니메이션 — 위치를 옮기는 트윈 대신 몇 개 픽셀(돔 높이·바닥
-  // 폭 몇 줄)만 주기적으로 바꿔서 숨쉬듯 눌렸다 펴지는 느낌을 낸다 + 몇 초마다 눈을 잠깐
-  // 감는 깜빡임. 둘 다 판정과 무관한 순수 장식 타이머.
+  // 살아있는 느낌을 주는 대기 애니메이션 — 위치를 옮기는 트윈 대신 몇 개 픽셀만 주기적으로
+  // 바꿔서 숨쉬듯 눌렸다 펴지는 느낌을 낸다 + 몇 초마다 눈을 잠깐 감는 깜빡임. 둘 다 판정과
+  // 무관한 순수 장식 타이머.
   private startIdleAnim() {
     this.time.addEvent({
       delay: 550, loop: true,

--- a/cf-idiotquant/components/game/DiceRollOverlay.tsx
+++ b/cf-idiotquant/components/game/DiceRollOverlay.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+// 주사위 굴림 결과 연출 — 굴림 자체는 combatEngine의 rollAttack()이 이미 동기로 판정을 끝내고
+// HP/블록 등 상태가 즉시 반영된 뒤, 이 오버레이는 그 결과를 잠깐 보여주는 순수 연출 레이어.
+// 판정 로직은 전혀 없음(재생만) — Phaser 캔버스의 popText와 같은 역할을 DOM에서 담당.
+
+import { useEffect } from "react";
+import { cn } from "@/lib/utils";
+import type { AttackRollResult } from "@/app/(game)/game/gameTypes";
+
+const AUTO_DISMISS_MS = 500;
+
+export default function DiceRollOverlay({ roll, auto, onDismiss }: {
+  roll: { source: "player" | "enemy"; roll: AttackRollResult } | null;
+  auto: boolean;
+  onDismiss: () => void;
+}) {
+  useEffect(() => {
+    if (!roll || !auto) return;
+    const t = setTimeout(onDismiss, AUTO_DISMISS_MS);
+    return () => clearTimeout(t);
+  }, [roll, auto, onDismiss]);
+
+  if (!roll) return null;
+  const { source, roll: r } = roll;
+  const isPlayer = source === "player";
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 backdrop-blur-[2px] p-3"
+      onClick={auto ? undefined : onDismiss}>
+      <div onClick={e => e.stopPropagation()}
+        className="rounded-2xl px-6 py-5 text-center shadow-xl bg-white dark:bg-[#242320] border border-neutral-200 dark:border-[#35332e] animate-in zoom-in-95 fade-in duration-150">
+        <p className="text-[10px] font-bold text-neutral-400 mb-1.5">{isPlayer ? "내 공격" : "적의 공격"}</p>
+        <div className="flex items-center justify-center gap-2 mb-2">
+          {r.faces.map((f, i) => (
+            <span key={i} className={cn("inline-flex items-center justify-center w-10 h-10 rounded-lg text-lg font-black tabular-nums border-2",
+              f === 20 ? "bg-amber-400 border-amber-500 text-white" : "bg-black/[0.04] dark:bg-white/[0.06] border-black/10 dark:border-white/10 text-neutral-800 dark:text-neutral-100")}>
+              {f}
+            </span>
+          ))}
+        </div>
+        {r.isCrit && <p className="text-sm font-black text-amber-500 mb-1">💥 크리티컬!</p>}
+        <p className={cn("text-2xl font-black tabular-nums", isPlayer ? "text-[#16a34a]" : "text-rose-500")}>⚔{r.totalDamage}</p>
+        {!auto && (
+          <button type="button" onClick={onDismiss}
+            className="mt-3 px-4 py-1.5 rounded-full bg-[#16a34a] text-white text-xs font-bold active:scale-95 transition-transform">
+            확인
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/cf-idiotquant/components/game/HandView.tsx
+++ b/cf-idiotquant/components/game/HandView.tsx
@@ -14,7 +14,7 @@ function CardFace({ card, free }: { card: CombatCard; free: boolean }) {
     <>
       <p className="text-[8px] font-bold text-neutral-500 dark:text-neutral-400 truncate w-full text-center">{card.name}</p>
       <div className="grid grid-cols-2 gap-x-1 gap-y-0.5 text-[9px] font-black tabular-nums w-full">
-        <span className="text-rose-500 text-center">⚔{card.stats.attack}</span>
+        <span className="text-rose-500 text-center text-[8px]">⚔0~{card.stats.attack}</span>
         <span className="text-sky-500 text-center">🛡{card.stats.shield}</span>
         <span className={cn("text-center", free ? "text-amber-400 line-through" : "text-amber-600 dark:text-amber-400")}>●{card.stats.cost}</span>
         <span className="text-emerald-500 text-center">🔋{card.stats.refund}</span>

--- a/cf-idiotquant/components/game/PhaserCombatCanvas.tsx
+++ b/cf-idiotquant/components/game/PhaserCombatCanvas.tsx
@@ -45,7 +45,7 @@ export default function PhaserCombatCanvas({ enemy, player, introLabel }: {
         // 씬이 준비되기 전에 이미 적이 정해져 있었을 수 있음(마운트 시점 경쟁) — 놓치지 않게 즉시 반영.
         const e = latestEnemyRef.current;
         if (e) {
-          scene.setEnemy?.(String(e.item?.name ?? "몬스터"), e.hp, e.maxHp);
+          scene.setEnemy?.(String(e.item?.name ?? "몬스터"), e.hp, e.maxHp, e.encounter);
           prevEnemyTicker.current = e.item?.ticker ?? null;
           prevEnemyHp.current = e.hp;
         }
@@ -72,7 +72,7 @@ export default function PhaserCombatCanvas({ enemy, player, introLabel }: {
     if (!scene || !enemy) return;
     const id = requestAnimationFrame(() => {
       if (enemy.item?.ticker !== prevEnemyTicker.current) {
-        scene.setEnemy?.(String(enemy.item?.name ?? "몬스터"), enemy.hp, enemy.maxHp);
+        scene.setEnemy?.(String(enemy.item?.name ?? "몬스터"), enemy.hp, enemy.maxHp, enemy.encounter);
         if (introLabel) scene.showIntro?.(introLabel);
         prevEnemyTicker.current = enemy.item?.ticker ?? null;
         prevEnemyHp.current = enemy.hp;


### PR DESCRIPTION
## 작업 내용

### 1. 몬스터 종류를 슬라임 외 유령·박쥐·버섯으로 다양화

"적 캐릭터를 슬라임 이외의 다양한 몬스터를 추가하고 싶어요. 픽셀 아트로요" 요청 반영.

- 종마다 절차적 실루엣 함수(`inBody`)와 고유 색상군, 얼굴 위치를 갖는 `SpeciesDef` 구조로 일반화했습니다.
- 대기 애니메이션(숨쉬듯 눌림)도 슬라임 전용 두 형태(`SHAPE_NORMAL`/`SHAPE_SQUISH`) 대신, 아래 칸에서 당겨와 위를 압축하고 좌우로 살짝 팽창시키는 범용 `squish()` 변형으로 바꿔서 종이 늘어나도 각자 형태를 따로 튜닝할 필요가 없게 했습니다.
- 신규 종 4가지: 슬라임(초록, 기존 유지) / 유령(창백한 한색 계열) / 박쥐(어두운 보라 계열) / 버섯(따뜻한 원색 계열)

### 2. D&D 20면체 주사위 전투 + 캐릭터 레벨/능력치 + 등급 기반 몬스터 재설계

"카드 게임 레벨 및 카드 단계 및 코스트 디자인을 다시 해보면 좋겠습니다" 요청 반영 — 결정론적 고정 데미지 전투에 운적 요소를 넣고, 계정에 영구 저장되는 캐릭터 성장 시스템을 재도입했습니다.

**주사위 전투**
- 카드 공격력을 고정 데미지 대신 "0~N 범위"로 바꾸고, `rollAttack()`이 d20 굴림(+어드밴티지 아이템 보유 시 2회 굴림 중 높은 눈 채택)으로 실제 데미지를 결정합니다.
- 자연 20은 크리티컬(최대 데미지의 2배). DEX는 굴림 눈 보정(20당 +1), STR은 고정 데미지 보너스(10당 +1), LUK은 크리티컬 확률 가산 — 플레이어/몬스터 공격 모두 동일 함수로 처리(몬스터는 자연 20 크리티컬만 적용).

**캐릭터 레벨/경험치** (`characterEngine.ts`/`useCharacter.ts`, 신규)
- 전사(warrior) 직업만 우선 지원(직업 확장 가능한 데이터 구조), 시작 스탯 레벨1/힘1/민첩0/행운0/체력10.
- 공격 시마다 XP+1, 몬스터 처치 시 등급별 XP(H=10 ~ SS=5120, 기존 `computeValueScore` 등급 재사용). 레벨업 필요 경험치는 레벨마다 10%씩 증가, 레벨업 시 힘+1·체력+1 자동 성장. 최대 레벨 99, 스탯 상한 99.
- localStorage에 영구 저장 — 던전 런이 끝나도 유지(단, 이번 런에서 주운 스탯 아이템은 기존 패시브 아이템들과 동일하게 런 종료 시 소멸하는 로그라이크 규칙).

**몬스터 강함 = 등급 기반**
- 몬스터 HP 공식에 카드 자체의 방어(shield) 스탯(이미 등급과 상관관계가 있는 값)을 반영해 층수뿐 아니라 뽑힌 카드의 등급도 난이도에 체감되게 했습니다.
- 보스 배율을 2.2배 → 3배로 상향(별도 보스 디자인 대신 "같은 몬스터 풀에서 스탯 3배로 강화"). 정예/보스는 전투 화면에 상시 배지("🗡️ 정예"/"👑 보스")로 표시(기존엔 등장 인트로 후 사라져 구분이 안 됐음). 보스 처치 보상은 기본 3택, 행운 수치에 따라 낮은 확률로 4택.

**아이템 확장**
- 힘/민첩/행운/체력 반지 아이템 각 3단계(Lv1/2/3, 수치 1배/2배/4배 스케일) 총 12종 추가.
- 어드밴티지(주사위 2개 굴림) 전설 아이템 1종 추가 — 기존 최고난도 업적(captain, 연승 15+)으로 게이팅.

**코스트 재설계**
- 기존 고정 에너지(4) 대신, 전투(조우) 안에서 내 턴이 진행될 때마다 코스트가 1씩 늘어 최대 10에서 멈추는 구조로 변경. 초반엔 저비용 카드만, 전투가 길어질수록 고비용 카드도 낼 수 있는 텐션 곡선을 의도했습니다.
- 스타터 카드가 전부 코스트 2 이상이라 첫 턴엔 아무것도 못 내던 회귀를 발견해, "안전 마진" 카드 코스트를 2→1로 조정해 해결했습니다.

**UI**
- 카드 공격력 범위 표시(`⚔0~N`), 적 공격 의도 배지(`EnemyIntentBadge`), 주사위 결과 오버레이(`DiceRollOverlay`, 자동/수동 모드 지원), 플레이어 캐릭터 카드(`CharacterCard`, 상태창에 배치).

## 체크리스트

- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 통과
- [x] Playwright(CDP 실제 터치, iPhone SE)로 몬스터 종 다양화 스크린샷 확인(species_1~4.png)
- [x] 주사위 전투 순수 함수 단위 테스트 30/30 통과(주사위 평균/크리티컬 확률, 어드밴티지 크리티컬 확률, 능력치 경계값, XP/레벨 곡선, 보스 3배 HP 비율 등)
- [x] Playwright로 드래그 회귀 확인(손패 5→4 정상 전환)
- [x] Playwright(smart bot — 매 턴 낼 수 있는 카드를 모두 시도)로 다층 진행 확인: 12층 클리어, 페이지 에러 0건(보스층 포함)
- [x] Playwright로 캐릭터 레벨 localStorage 영속성 확인(새로고침 후에도 레벨/스탯 유지)
- [x] Playwright로 주사위 오버레이·전투 로그(주사위 눈+크리티컬 여부+데미지) 표시 확인

## 참고 사항

- 백엔드 변경 없음.
- 보스 배지("👑 보스")는 Phaser 캔버스에 렌더링되어 Playwright DOM 텍스트 로케이터로는 직접 검증이 안 됨 — 대신 보스 HP 3배 비율의 단위 테스트와, 보스층을 통과하는 12층 연속 플레이(0 에러)로 간접 검증했습니다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_