### PR TITLE
feat(game): 전사 고정 기술 4종 + PP 20 + 행동 선택 메뉴로 전투 재설계

### DIFF
--- a/cf-idiotquant/app/(game)/game/combatEngine.ts
+++ b/cf-idiotquant/app/(game)/game/combatEngine.ts
@@ -3,13 +3,11 @@
 
 import { computeValueScore } from "@/lib/utils/valueScore";
 import type {
-  CardStats, CombatCard, PassiveEffect, ActiveEffect, ItemDef, EnemyState, PlayerState,
+  CardStats, PassiveEffect, ActiveEffect, ItemDef, EnemyState, PlayerState, SkillDef, SkillState,
   CharacterStats, AttackRollOptions, AttackRollResult, EnemyEncounter,
 } from "./gameTypes";
 
-export const HAND_SIZE = 5; // 전투 시작 시 뽑는 고정 기술셋 매수(포켓몬처럼 전투 내내 고정)
 export const BASE_HP = 30;
-export const MIN_DECK = 10;
 const ENEMY_BASE_HP = 12;
 const ENEMY_PER_FLOOR = 3;
 const ENEMY_HP_PER_SHIELD = 2; // 뽑힌 카드 자체의 방어 스탯(등급과 상관관계가 있음)도 HP에 반영
@@ -48,21 +46,20 @@ export function bossExtraChoiceChance(luk: number): number {
   return Math.min(LUK_BOSS_EXTRA_CAP, luk * LUK_BOSS_EXTRA_PER_POINT);
 }
 
-// 3개 재무 지표(sub, 0~1 clamp01된 정규화 점수 — computeValueScore가 이미 계산)를 3개 전투
+// 2개 재무 지표(sub, 0~1 clamp01된 정규화 점수 — computeValueScore가 이미 계산)를 적의 전투
 // 스탯(1~10 양의 정수)으로 매핑. 데이터 없는 지표는 sub=0(최저값)으로 처리돼 NaN이 안 생김.
-// PER(역방향)은 "환급" 계산식을 그대로 재사용해 포켓몬식 PP(maxUses)로 재해석한 것.
+// 플레이어 기술은 더 이상 이 함수를 쓰지 않음(직업별 고정 SkillDef 세트를 씀).
 export function cardStats(item: any): CardStats {
   const parts = computeValueScore(item).parts;
   const sub = (key: string) => parts.find(p => p.key === key)?.sub ?? 0;
   return {
     attack: 1 + Math.round(sub("roe") * 9),
     shield: 1 + Math.round(sub("ncav") * 9),
-    maxUses: 1 + Math.round(sub("per") * 9),
   };
 }
 
 const emptyPassive: Required<PassiveEffect> = {
-  blockPerTurn: 0, drawBonus: 0, maxHpBonus: 0, damageReduce: 0,
+  blockPerTurn: 0, maxHpBonus: 0, damageReduce: 0,
   strBonus: 0, dexBonus: 0, lukBonus: 0, vitBonus: 0, extraDie: false,
 };
 
@@ -73,7 +70,6 @@ export function aggregatePassive(ownedDefs: ItemDef[]): Required<PassiveEffect> 
     if (def.kind !== "passive") continue;
     const e = def.effect as PassiveEffect;
     out.blockPerTurn += e.blockPerTurn ?? 0;
-    out.drawBonus += e.drawBonus ?? 0;
     out.maxHpBonus += e.maxHpBonus ?? 0;
     out.damageReduce += e.damageReduce ?? 0;
     out.strBonus += e.strBonus ?? 0;
@@ -83,49 +79,6 @@ export function aggregatePassive(ownedDefs: ItemDef[]): Required<PassiveEffect> 
     out.extraDie = out.extraDie || !!e.extraDie;
   }
   return out;
-}
-
-let seq = 0;
-const nextId = () => `c${Date.now().toString(36)}${(seq++).toString(36)}`;
-
-// 보유 컬렉션(계정 덱) 전체를 전투 카드로 변환 + 셔플. MIN_DECK 미만이면 스타터 카드로 패딩.
-export function buildRunDeck(deck: { ticker: string; name: string; count?: number;[k: string]: any }[], starterPool: Omit<CombatCard, "instanceId" | "usesLeft">[]): CombatCard[] {
-  const cards: CombatCard[] = [];
-  for (const d of deck) {
-    const n = Math.max(1, d.count ?? 1);
-    for (let i = 0; i < n; i++) {
-      const stats = cardStats(d);
-      cards.push({ instanceId: nextId(), ticker: d.ticker, name: d.name, item: d, stats, usesLeft: stats.maxUses, isStarter: false });
-    }
-  }
-  while (cards.length < MIN_DECK) {
-    const s = starterPool[cards.length % starterPool.length];
-    cards.push({ ...s, instanceId: nextId(), usesLeft: s.stats.maxUses });
-  }
-  for (let i = cards.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [cards[i], cards[j]] = [cards[j], cards[i]];
-  }
-  return cards;
-}
-
-// 전투 시작 시 1회 호출 — 덱에서 고정 기술셋을 뽑음(드로우 파일이 부족하면 버림 더미를 섞어
-// 합침, 슬레이더스파이어 표준 리셔플 규칙). 뽑힌 기술은 이전 전투에서 소진됐을 수 있으므로
-// usesLeft를 전부 maxUses로 새로 채워 반환한다.
-export function drawHand(drawPile: CombatCard[], discardPile: CombatCard[], handSize: number): { hand: CombatCard[]; drawPile: CombatCard[]; discardPile: CombatCard[] } {
-  let draw = [...drawPile], discard = [...discardPile];
-  const hand: CombatCard[] = [];
-  for (let i = 0; i < handSize; i++) {
-    if (draw.length === 0) {
-      if (discard.length === 0) break; // 덱 전체가 손패에 나가 있으면 그냥 적은 수로 진행
-      draw = discard;
-      for (let k = draw.length - 1; k > 0; k--) { const j = Math.floor(Math.random() * (k + 1));[draw[k], draw[j]] = [draw[j], draw[k]]; }
-      discard = [];
-    }
-    const card = draw.pop()!;
-    hand.push({ ...card, usesLeft: card.stats.maxUses });
-  }
-  return { hand, drawPile: draw, discardPile: discard };
 }
 
 // 적 = 실제 종목 카드에서 뽑되, 보스/정예는 강한 등급 풀 우선. HP는 층수 비례 + 카드 자체의 등급
@@ -142,23 +95,27 @@ export function enemyForFloor(pool: any[], floor: number, encounter: EnemyEncoun
   return { item, stats, hp: maxHp, maxHp, nextAttack: attack, encounter };
 }
 
-// 기술(카드) 한 장 발동 — PP(usesLeft)가 없으면 그대로 반환(호출부에서 사전에 막아야 함, 여기선
-// 방어적으로만 처리). 공격력은 고정 데미지가 아니라 rollAttack()으로 굴린 값 — charStats/passive의
-// 힘/민첩/행운/어드밴티지가 그대로 반영된다. 1기술=1턴이라 사용 즉시 곧바로 적 턴으로 이어진다.
-export function playCard(
-  player: PlayerState, enemy: EnemyState, card: CombatCard,
+// 기술 한 장 발동(PP 체크는 호출부 책임 — 이 함수는 PP 상태를 모름, useGameRun의 SkillState가
+// 별도로 관리). 효과별로 분기: attack=rollAttack()으로 굴린 데미지(charStats/passive의 힘/민첩/
+// 행운/어드밴티지 반영), shield=고정 블록 추가, heal=고정 HP 회복. 1기술=1턴이라 사용 즉시
+// 곧바로 적 턴으로 이어진다(roll은 attack일 때만 존재 — 나머지는 주사위를 안 굴리므로 null).
+export function useSkillEffect(
+  player: PlayerState, enemy: EnemyState, def: SkillDef,
   passive: Required<PassiveEffect>, charStats: CharacterStats,
-): { player: PlayerState; enemy: EnemyState; roll: AttackRollResult } {
-  if (card.usesLeft <= 0) return { player, enemy, roll: rollAttack(0) };
-  const roll = rollAttack(card.stats.attack, {
-    advantage: passive.extraDie,
-    str: charStats.str + passive.strBonus,
-    dex: charStats.dex + passive.dexBonus,
-    luk: charStats.luk + passive.lukBonus,
-  });
-  const nextPlayer: PlayerState = { ...player, block: player.block + card.stats.shield };
-  const nextEnemy: EnemyState = { ...enemy, hp: Math.max(0, enemy.hp - roll.totalDamage) };
-  return { player: nextPlayer, enemy: nextEnemy, roll };
+): { player: PlayerState; enemy: EnemyState; roll: AttackRollResult | null } {
+  if (def.effect === "attack") {
+    const roll = rollAttack(def.power, {
+      advantage: passive.extraDie,
+      str: charStats.str + passive.strBonus,
+      dex: charStats.dex + passive.dexBonus,
+      luk: charStats.luk + passive.lukBonus,
+    });
+    return { player, enemy: { ...enemy, hp: Math.max(0, enemy.hp - roll.totalDamage) }, roll };
+  }
+  if (def.effect === "shield") {
+    return { player: { ...player, block: player.block + def.power }, enemy, roll: null };
+  }
+  return { player: { ...player, hp: Math.min(player.maxHp, player.hp + def.power) }, enemy, roll: null };
 }
 
 // 적 턴 — 적도 동일한 주사위 규칙으로 굴리되(자연 20 크리티컬만 적용, 힘/민첩/행운/어드밴티지
@@ -174,14 +131,20 @@ export function resolveEnemyTurn(
 }
 
 // 액티브 아이템 즉시 발동 — 기술과 동일하게 발동 즉시 턴을 소모(호출부에서 이어서 적 턴 진행).
-export function useActiveItem(player: PlayerState, enemy: EnemyState, hand: CombatCard[], effect: ActiveEffect) {
+// restorePP는 보유 기술 전부를 각자의 maxPP로 되돌림(skillDefs로 PP 상한을 조회).
+export function useActiveItem(
+  player: PlayerState, enemy: EnemyState, skills: SkillState[], skillDefs: SkillDef[], effect: ActiveEffect,
+) {
   let nextPlayer = { ...player }, nextEnemy = { ...enemy };
-  let nextHand = hand;
+  let nextSkills = skills;
   if (effect.kind === "damage") nextEnemy.hp = Math.max(0, nextEnemy.hp - effect.amount);
   else if (effect.kind === "heal") nextPlayer.hp = Math.min(nextPlayer.maxHp, nextPlayer.hp + effect.amount);
   else if (effect.kind === "block") nextPlayer.block += effect.amount;
-  else if (effect.kind === "restorePP") nextHand = hand.map(c => ({ ...c, usesLeft: c.stats.maxUses }));
-  return { player: nextPlayer, enemy: nextEnemy, hand: nextHand };
+  else if (effect.kind === "restorePP") nextSkills = skills.map(s => {
+    const def = skillDefs.find(d => d.id === s.skillId);
+    return def ? { ...s, pp: def.maxPP } : s;
+  });
+  return { player: nextPlayer, enemy: nextEnemy, skills: nextSkills };
 }
 
 export function checkOutcome(player: PlayerState, enemy: EnemyState): "win" | "lose" | null {

--- a/cf-idiotquant/app/(game)/game/gameData.ts
+++ b/cf-idiotquant/app/(game)/game/gameData.ts
@@ -2,7 +2,19 @@
 // 스탯 부스트 12 + 전설급 3), 콘텐츠 확장은 나중에.
 
 import { computeValueScore } from "@/lib/utils/valueScore";
-import type { ItemDef, CombatCard } from "./gameTypes";
+import type { ItemDef, SkillDef, CharClass } from "./gameTypes";
+
+// 직업별 고정 기술 — 종목 카드가 아니라 미리 정의된 세트. 전사는 근접 공격 2종(주먹 휘두르기/
+// 강타)·방어·기력회복 4개, PP는 전부 20으로 통일(사용마다 1씩 차감, 던전 진행 내내 유지).
+export const WARRIOR_SKILLS: SkillDef[] = [
+  { id: "punch", name: "주먹 휘두르기", effect: "attack", power: 4, maxPP: 20 },
+  { id: "smash", name: "강타", effect: "attack", power: 8, maxPP: 20 },
+  { id: "defend", name: "방어", effect: "shield", power: 6, maxPP: 20 },
+  { id: "recover", name: "기력회복", effect: "heal", power: 8, maxPP: 20 },
+];
+export const SKILLS_BY_CLASS: Record<CharClass, SkillDef[]> = {
+  warrior: WARRIOR_SKILLS,
+};
 
 // 카드 수집: 승리(층 클리어)마다 판정. 등급별 기본 확률 + 클리어한 층수 보너스(옛 "연승" 보너스를
 // 대체 — 다중 턴 전투 구조에선 "판마다 승패"가 사라지고 "층 클리어"만 있어 streak==totalWins).
@@ -23,7 +35,6 @@ export const PP_POTION_COST = 10; // 매 층 상점에서 판매하는 PP 회복
 
 export const ITEM_POOL: ItemDef[] = [
   { id: "buffer", kind: "passive", name: "여유 자금", desc: "매 턴 시작 시 블록 +2", icon: "🧱", effect: { blockPerTurn: 2 } },
-  { id: "network", kind: "passive", name: "정보망", desc: "전투 시작 시 뽑는 기술 +1", icon: "📡", effect: { drawBonus: 1 } },
   { id: "stoploss", kind: "active", name: "손절매", desc: "즉시 적에게 5 데미지", icon: "✂️", effect: { kind: "damage", amount: 5 } },
   { id: "loan", kind: "active", name: "긴급 대출", desc: "즉시 블록 +5", icon: "🏦", effect: { kind: "block", amount: 5 } },
   { id: "compound", kind: "active", name: "복리의 마법", desc: "즉시 HP +8 회복", icon: "🔄", effect: { kind: "heal", amount: 8 } },
@@ -55,21 +66,6 @@ export const LEGEND_ITEMS: ItemDef[] = [
 ];
 
 export const ALL_ITEMS: ItemDef[] = [...ITEM_POOL, ...STAT_ITEM_POOL, ...LEGEND_ITEMS];
-
-// 컬렉션이 MIN_DECK(combatEngine) 미만일 때 채우는 스타터 카드 — 계정 덱에는 저장되지 않는 합성
-// 카드. 실제 컬렉션보다 확실히 약하게 잡아 수집 동기를 유지한다(공격/방어는 낮게, PP도 낮게).
-export const STARTER_DECK: Omit<CombatCard, "instanceId" | "usesLeft">[] = [
-  ...Array.from({ length: 6 }, (_, i) => ({
-    ticker: `STARTER-A${i}`, name: "가치 원석", isStarter: true,
-    item: { ticker: `STARTER-A${i}`, name: "가치 원석" },
-    stats: { attack: 6, shield: 1, maxUses: 3 },
-  })),
-  ...Array.from({ length: 4 }, (_, i) => ({
-    ticker: `STARTER-B${i}`, name: "안전 마진", isStarter: true,
-    item: { ticker: `STARTER-B${i}`, name: "안전 마진" },
-    stats: { attack: 4, shield: 3, maxUses: 3 },
-  })),
-];
 
 // 아이템 선택지 3택1(보스는 행운 수치에 따라 4택) — 슬롯 개념이 없어 이미 보유한 아이템도 후보에서
 // 제외하지 않음(패시브는 중복 보유 시 효과가 합산되고, 액티브는 충전 개념이 없어 여러 장 들고 있으면

--- a/cf-idiotquant/app/(game)/game/gameTypes.ts
+++ b/cf-idiotquant/app/(game)/game/gameTypes.ts
@@ -4,34 +4,22 @@ export type Phase = "loading" | "battling" | "resolved" | "over" | "event" | "sh
 export type EncounterType = "battle" | "boss" | "rest" | "elite";
 export type EnemyEncounter = "battle" | "boss" | "elite"; // 실제로 적이 등장하는 조우만(휴식 제외)
 
-// 3개 재무 지표 → 3개 전투 스탯, 전부 1~10 양의 정수(combatEngine.cardStats 참고).
+// 적(실제 종목) 전투 스탯 — ROE→공격력, NCAV→방어력/HP(combatEngine.cardStats 참고). 플레이어
+// 기술은 더 이상 종목 카드에서 오지 않고 직업별 고정 세트(SkillDef, 아래)를 씀.
 export interface CardStats {
-  attack: number;  // ROE
-  shield: number;  // NCAV
-  maxUses: number; // PER(역방향) — 포켓몬식 PP(이 기술의 전투당 최대 사용 횟수)
-}
-
-// 손패(=이번 전투의 고정 기술셋)에 올라가는 카드 한 장(실제 종목 데이터 + 계산된 전투 스탯).
-export interface CombatCard {
-  instanceId: string; // 같은 종목 중복 보유분을 구분하기 위한 고유 id
-  ticker: string;
-  name: string;
-  item: any;           // 원본 종목 데이터(카드 아트/등급 표시용)
-  stats: CardStats;
-  usesLeft: number;    // 이번 전투에서 남은 PP — 전투 시작 시 stats.maxUses로 초기화
-  isStarter: boolean;  // 스타터 카드는 계정 덱(D1)에 저장되지 않음
+  attack: number; // ROE
+  shield: number; // NCAV
 }
 
 export type PassiveEffect = {
   blockPerTurn?: number;     // 턴 시작 시 자동 블록
-  drawBonus?: number;        // 전투 시작 시 뽑는 기술 수 증가
   maxHpBonus?: number;       // 최대 HP 증가
   damageReduce?: number;     // 적 공격 데미지 감소
   strBonus?: number;         // 이번 런 한정 힘(STR) 보너스
   dexBonus?: number;         // 이번 런 한정 민첩(DEX) 보너스
   lukBonus?: number;         // 이번 런 한정 행운(LUK) 보너스
   vitBonus?: number;         // 이번 런 한정 체력(VIT) 보너스
-  extraDie?: boolean;        // 카드 공격 주사위 굴림에 어드밴티지(2개 굴려 높은 값) 적용
+  extraDie?: boolean;        // 공격 기술 주사위 굴림에 어드밴티지(2개 굴려 높은 값) 적용
 };
 
 export type ActiveEffect =
@@ -39,6 +27,24 @@ export type ActiveEffect =
   | { kind: "heal"; amount: number }
   | { kind: "block"; amount: number }
   | { kind: "restorePP" }; // 보유한 모든 기술의 PP를 최대치로 회복
+
+// 직업별 고정 기술 — 종목 카드가 아니라 미리 정의된 세트(전사: 주먹 휘두르기/강타/방어/
+// 기력회복). power는 효과별 의미가 다름: attack=주사위 기본 데미지, shield=고정 블록량,
+// heal=고정 회복량. PP(usesLeft에 대응하는 SkillState.pp)는 던전 진행 내내 유지되며(전투를
+// 이겨도 자동 회복 안 됨) 상점의 PP 회복 물약으로만 채워진다.
+export type SkillEffectKind = "attack" | "shield" | "heal";
+export interface SkillDef {
+  id: string;
+  name: string;
+  effect: SkillEffectKind;
+  power: number;
+  maxPP: number;
+}
+export interface SkillState { skillId: string; pp: number }
+
+// 전투 중 하위 화면 — 매 내 턴마다 "action"(전투/아이템/도망치기/월드맵 선택)에서 시작해,
+// "전투"를 고르면 "skills"(기술 목록)로, "아이템"을 고르면 "items"(보유 아이템 사용)로 전환.
+export type BattleMenu = "action" | "skills" | "items";
 
 export type ItemKind = "passive" | "active";
 export interface ItemDef {

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -208,10 +208,10 @@ function ScoreInfo() {
           <b className="text-white">저평가 점수 (0~100)</b><br />
           NCAV·PBR·PER·ROE를 가중 평균해 점수화(값 없는 지표는 제외, 적자·자본잠식 등 음수 지표는 0점):
           <span className="block mt-1.5 space-y-0.5 text-neutral-300">
-            <span className="block">· NCAV 40% — 1.5배↑ 만점, 0.3배↓ 0점 (→ 전투 방어력)</span>
-            <span className="block">· PBR 25% — 0.3↓ 만점, 1.5↑ 0점 (→ 전투 코스트, 역방향)</span>
-            <span className="block">· PER 20% — 5↓ 만점, 20↑ 0점 (→ 전투 환급, 역방향)</span>
-            <span className="block">· ROE 15% — 18%↑ 만점, 3%↓ 0점 (→ 전투 공격력)</span>
+            <span className="block">· NCAV 40% — 1.5배↑ 만점, 0.3배↓ 0점 (→ 적 방어력/체력)</span>
+            <span className="block">· PBR 25% — 0.3↓ 만점, 1.5↑ 0점 (등급 산정에만 사용)</span>
+            <span className="block">· PER 20% — 5↓ 만점, 20↑ 0점 (등급 산정에만 사용)</span>
+            <span className="block">· ROE 15% — 18%↑ 만점, 3%↓ 0점 (→ 적 공격력)</span>
           </span>
         </span>
       )}
@@ -610,9 +610,11 @@ function GameContent() {
                       </div>
                     )}
                   </div>
-                  {run.ownedItems.length > 0 && (
+                  {/* 전투 중엔 아이템 사용이 행동 선택 메뉴("아이템")로만 이뤄지므로, 여긴 전투
+                      밖에서 보유 아이템을 훑어보는 용도로만 노출(설명만, 사용 불가). */}
+                  {run.ownedItems.length > 0 && run.phase !== "battling" && (
                     <div className="flex items-center justify-center gap-1.5 h-8 overflow-x-auto overflow-y-hidden flex-nowrap scrollbar-hide">
-                      <ItemBar ownedDefs={run.ownedDefs} ownedItems={run.ownedItems} canUseActive={run.phase === "battling"} onUseActive={run.useOwnedActiveItem} />
+                      <ItemBar ownedDefs={run.ownedDefs} ownedItems={run.ownedItems} canUseActive={false} onUseActive={run.useOwnedActiveItem} />
                     </div>
                   )}
                 </div>
@@ -630,25 +632,29 @@ function GameContent() {
               ) : run.enemy ? (
                 <div className="flex-1 min-h-0 flex flex-col">
                   <div className="flex-1 min-h-0 flex flex-col rounded-2xl overflow-hidden backdrop-blur-md bg-white/60 dark:bg-white/[0.03] border border-black/5 dark:border-white/10">
-                    <HandView cards={run.hand} onPlayCard={run.playHandCard}
-                      topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
-                      bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />}>
-                      <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={CLASS_DEFS[run.character.classId].name} introLabel={introLabel} />
-                    </HandView>
+                    {run.battleMenu === "action" ? (
+                      <HandView mode="action" onSelectAction={run.selectBattleAction}
+                        topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />}>
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={CLASS_DEFS[run.character.classId].name} introLabel={introLabel} />
+                      </HandView>
+                    ) : run.battleMenu === "skills" ? (
+                      <HandView mode="skills" skills={run.skills} onPlaySkill={run.useSkill} onBack={run.backToActionMenu}
+                        topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />}>
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={CLASS_DEFS[run.character.classId].name} introLabel={introLabel} />
+                      </HandView>
+                    ) : (
+                      <HandView mode="items" ownedItems={run.ownedItems} ownedDefs={run.ownedDefs} onUseItem={run.useOwnedActiveItem} onBack={run.backToActionMenu}
+                        topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />}>
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={CLASS_DEFS[run.character.classId].name} introLabel={introLabel} />
+                      </HandView>
+                    )}
                   </div>
                   <div className="shrink-0 pt-1.5">
                     <CombatLog entries={run.log} />
                   </div>
-                  {/* 모든 기술 PP 소진 + 쓸 액티브 아이템도 없는 극단적 상황에서만 노출되는 패스 —
-                      평소엔 기술/아이템 탭 자체가 곧 턴 진행이라 별도 버튼이 필요 없음. */}
-                  {run.hand.every(c => c.usesLeft <= 0) && !run.ownedDefs.some(d => d.kind === "active") && (
-                    <div className="shrink-0 pt-1.5 flex justify-center">
-                      <button type="button" onClick={run.passTurn}
-                        className="inline-flex items-center gap-1.5 px-6 py-2 rounded-2xl bg-gradient-to-r from-neutral-500 to-neutral-600 hover:brightness-110 text-white font-black text-sm shadow-[0_8px_24px_-8px_rgba(0,0,0,0.35)] active:scale-[0.98] transition-all">
-                        <Swords size={15} /> 턴 넘기기
-                      </button>
-                    </div>
-                  )}
                 </div>
               ) : null}
 
@@ -690,14 +696,14 @@ function GameContent() {
             </div>
             <div className="space-y-3">
               {[
-                { icon: "⚔️", text: <>카드는 이제 <b className="text-neutral-800 dark:text-neutral-100">기술</b>이에요. 손패에서 <b className="text-neutral-800 dark:text-neutral-100">탭하면 즉시 발동</b>! 공격력은 <b className="text-neutral-800 dark:text-neutral-100">0~N 범위</b>로 20면체 주사위를 굴려 실제 피해가 정해지고(ROE 기반), 방어력만큼 블록이 쌓여요(NCAV 기반).</> },
-                { icon: "🎲", text: <>주사위 눈이 <b className="text-amber-500 dark:text-amber-400">자연 20</b>이면 <b className="text-amber-500 dark:text-amber-400">크리티컬</b>(최대 피해의 2배)! 몬스터의 공격도 같은 방식으로 굴려요. 내 주사위는 화면 우하단, 적 주사위는 좌상단에 표시돼요.</> },
-                { icon: "💊", text: <>기술마다 전투당 사용 횟수(<b className="text-violet-600 dark:text-violet-400">PP</b>)가 있어요(PER 기반) — 다 쓰면 그 전투에서는 못 써요. 새 전투가 시작되면 기술이 새로 뽑히며 PP도 가득 채워져요.</> },
-                { icon: "⏭️", text: <>포켓몬처럼 <b className="text-neutral-800 dark:text-neutral-100">기술(또는 아이템) 하나</b>를 쓰면 곧바로 내 턴이 끝나고 적이 반격해요 — 따로 "턴 종료"를 누를 필요가 없어요.</> },
-                { icon: "🛒", text: <>층을 클리어할 때마다 <b className="text-neutral-800 dark:text-neutral-100">상점</b>에 들러 ❤️HP 회복 물약과 💊PP 회복 물약을 살 수 있어요. 전투 중 물약을 쓰면 그것도 한 번의 턴으로 계산돼요.</> },
+                { icon: "🗡️", text: <>매 턴 <b className="text-neutral-800 dark:text-neutral-100">전투/아이템/도망치기/월드맵</b> 중 행동을 골라요. <b className="text-neutral-800 dark:text-neutral-100">전투</b>를 고르면 전사의 고정 기술 4개(주먹 휘두르기·강타·방어·기력회복)가 나와요.</> },
+                { icon: "🎲", text: <>공격 기술(주먹 휘두르기·강타)은 <b className="text-neutral-800 dark:text-neutral-100">0~N 범위</b>로 20면체 주사위를 굴려 피해가 정해지고, 자연 20이면 <b className="text-amber-500 dark:text-amber-400">크리티컬</b>(최대 피해의 2배)! 방어는 블록을, 기력회복은 HP를 고정치만큼 즉시 채워요.</> },
+                { icon: "💊", text: <>기술마다 <b className="text-violet-600 dark:text-violet-400">PP 20</b>이 있고 쓸 때마다 1씩 줄어요 — <b className="text-neutral-800 dark:text-neutral-100">던전을 도는 내내 유지</b>되며(전투를 이겨도 안 채워짐) 상점의 PP 회복 물약으로만 채울 수 있어요.</> },
+                { icon: "⏭️", text: <>기술이나 아이템을 하나 쓰면 곧바로 내 턴이 끝나고 적이 반격해요 — 그 다음 다시 행동 선택부터 시작해요.</> },
+                { icon: "🏃", text: <><b className="text-neutral-800 dark:text-neutral-100">도망치기</b>는 이번 층을 포기하고 바로 상점으로, <b className="text-neutral-800 dark:text-neutral-100">월드맵</b>은 지금까지 성과를 저장하고 던전을 나가요.</> },
+                { icon: "🛒", text: <>층을 클리어할 때마다 <b className="text-neutral-800 dark:text-neutral-100">상점</b>에 들러 ❤️HP 회복 물약과 💊PP 회복 물약을 살 수 있어요.</> },
                 { icon: "🎒", text: <>3층마다 <b className="text-neutral-800 dark:text-neutral-100">패시브/액티브 아이템</b>을 하나 고를 수 있어요. 힘·민첩·행운·체력을 올려주는 스탯 아이템도 있어요.</> },
-                { icon: "🃏", text: <>적을 처치(층 클리어)하면 확률에 따라 <b className="text-neutral-800 dark:text-neutral-100">내 덱</b>에 카드가 수집돼요. 좋은 카드일수록 전투 스탯도 강해요.</> },
-                { icon: "🧭", text: <>층이 깊어질수록 <b className="text-neutral-800 dark:text-neutral-100">휴식</b>(무료 회복)·<b className="text-orange-500 dark:text-orange-400">정예</b>(강한 몬스터) 조우가 섞여 나와요. <b className="text-violet-600 dark:text-violet-400">10층마다는 보스</b>(같은 몬스터가 스탯 3배로 강화돼 등장)예요.</> },
+                { icon: "🃏", text: <>적을 처치(층 클리어)하면 확률에 따라 <b className="text-neutral-800 dark:text-neutral-100">내 덱</b>에 실제 종목 카드가 수집돼요(전투와는 별개인 도감 컬렉션). <b className="text-violet-600 dark:text-violet-400">10층마다는 보스</b>(같은 몬스터가 스탯 3배로 강화돼 등장)예요.</> },
               ].map((row, i) => (
                 <div key={i} className="flex items-start gap-2.5">
                   <span aria-hidden className="shrink-0 text-lg leading-none">{row.icon}</span>

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -7,18 +7,18 @@ import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { computeValueScore } from "@/lib/utils/valueScore";
 import { addDeckCard, getWallet, syncBestStreak, type DeckCardSnapshot } from "@/lib/features/deck/deckAPI";
 import {
-  buildRunDeck, drawHand, enemyForFloor, playCard as engPlayCard,
+  enemyForFloor, useSkillEffect as engUseSkillEffect,
   resolveEnemyTurn, useActiveItem as engUseActiveItem, checkOutcome, aggregatePassive,
   bossExtraChoiceChance,
-  HAND_SIZE, BASE_HP, VIT_HP_MULTIPLIER,
+  BASE_HP, VIT_HP_MULTIPLIER,
 } from "./combatEngine";
-import { ALL_ITEMS, STARTER_DECK, ITEM_OFFER_COUNT, PP_POTION_ITEM_ID, PP_POTION_COST, pickItemChoices, acquireChance } from "./gameData";
+import { ALL_ITEMS, SKILLS_BY_CLASS, ITEM_OFFER_COUNT, PP_POTION_ITEM_ID, PP_POTION_COST, pickItemChoices, acquireChance } from "./gameData";
 import { ACHIEVEMENTS } from "./gameCollectibles";
 import { useCharacter } from "./useCharacter";
 import { killXpFor, XP_PER_ATTACK } from "./characterEngine";
 import type {
-  Phase, EncounterType, CombatCard, ItemDef, OwnedItem, EnemyState, PlayerState, ActiveEffect, LogEntry, LogKind,
-  CharacterStats, AttackRollResult,
+  Phase, EncounterType, ItemDef, OwnedItem, EnemyState, PlayerState, ActiveEffect, LogEntry, LogKind,
+  CharacterStats, AttackRollResult, SkillState, BattleMenu,
 } from "./gameTypes";
 
 const safeNum = (v: any): number => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
@@ -60,8 +60,6 @@ function pickEncounter(roundNum: number): EncounterType {
 export const MERCHANT_HEAL_COST = 8;
 const REST_HEAL_FRAC = 0.3;
 
-type Pile = { draw: CombatCard[]; hand: CombatCard[]; discard: CombatCard[] };
-
 // 진행 중인 런 저장 — 다른 페이지를 다녀와도 이어지도록 함. 카드 데이터가 전부 인라인 스냅샷이라
 // (pool/deck 참조 없음) 그대로 JSON 직렬화/복원이 됨. packOpening/dropped/dropPrompt/saveFail은
 // 진행 중이던 setTimeout·fetch 콜백에 묶인 일시 상태라 저장 대상에서 제외(로드 시 기본값).
@@ -70,7 +68,7 @@ type SavedRun = {
   phase: Phase; roundNum: number; encounter: EncounterType; restHealed: boolean;
   gold: number; newBest: boolean;
   ownedItems: OwnedItem[]; itemChoices: ItemDef[] | null; activeBoost: { mult: number; roundsLeft: number } | null;
-  player: PlayerState; enemy: EnemyState | null; pile: Pile;
+  player: PlayerState; enemy: EnemyState | null; skillPp: SkillState[]; battleMenu: BattleMenu;
   log: LogEntry[]; lastResult: { win: boolean; goldGain?: number } | null;
   acquired: DeckCardSnapshot[];
 };
@@ -92,9 +90,14 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
 
   const [player, setPlayer] = useState<PlayerState>({ hp: BASE_HP, maxHp: BASE_HP, block: 0 });
   const [enemy, setEnemy] = useState<EnemyState | null>(null);
-  const [pile, setPile] = useState<Pile>({ draw: [], hand: [], discard: [] });
+  const [skillPp, setSkillPp] = useState<SkillState[]>([]); // 던전 진행 내내 유지(전투 승리로 안 채워짐) — PP 물약으로만 회복
+  const [battleMenu, setBattleMenu] = useState<BattleMenu>("action"); // 전투 중 하위 화면 — 매 내 턴마다 "action"에서 시작
 
   const { character, characterLoaded, gainXp } = useCharacter();
+  const skillDefs = useMemo(() => SKILLS_BY_CLASS[character.classId] ?? [], [character.classId]);
+  const skills = useMemo(() => skillDefs.map(def => ({
+    def, pp: skillPp.find(s => s.skillId === def.id)?.pp ?? def.maxPP,
+  })), [skillDefs, skillPp]);
   const [lastPlayerRoll, setLastPlayerRoll] = useState<AttackRollResult | null>(null);
   const [lastEnemyRoll, setLastEnemyRoll] = useState<AttackRollResult | null>(null);
 
@@ -162,7 +165,8 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       setItemChoices(saved.itemChoices ?? null);
       setActiveBoost(saved.activeBoost ?? null);
       setPlayer(saved.player); setEnemy(saved.enemy);
-      setPile(saved.pile ?? { draw: [], hand: [], discard: [] });
+      setSkillPp(saved.skillPp ?? []);
+      setBattleMenu(saved.battleMenu ?? "action");
       setLog(saved.log ?? []);
       setLastResult(saved.lastResult ?? null);
       setAcquired(saved.acquired ?? []);
@@ -222,9 +226,10 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     }).catch(() => setSaveFail("네트워크 오류"));
   }, [best, isLoggedIn, availableItemPool, unlockedLegendItems, setDeck, activeBoost, pushLog, gainXp, effectiveStats.luk]);
 
-  // 내 행동(기술/아이템/패스) 직후 곧바로 적 턴을 진행 — 1행동=1턴이라 별도 "턴 종료" 버튼이
-  // 없고, 카드/아이템을 쓴 함수들이 마지막에 이 함수 하나로 마무리한다. afterPlayer/afterEnemy는
-  // 이미 그 행동의 효과(데미지/블록/회복)까지 반영된 상태.
+  // 내 행동(기술/아이템) 직후 곧바로 적 턴을 진행 — 1행동=1턴이라 별도 "턴 종료" 버튼이 없고,
+  // 기술/아이템을 쓴 함수들이 마지막에 이 함수 하나로 마무리한다. afterPlayer/afterEnemy는 이미
+  // 그 행동의 효과(데미지/블록/회복)까지 반영된 상태. 전투가 계속되면 다음 내 턴을 위해 행동
+  // 선택 메뉴("action")로 돌아간다.
   const resolveTurn = useCallback((afterPlayer: PlayerState, afterEnemy: EnemyState) => {
     setEnemy(afterEnemy);
     if (checkOutcome(afterPlayer, afterEnemy) === "win") { setPlayer(afterPlayer); handleWin(afterEnemy, encounter, roundNum); return; }
@@ -235,46 +240,61 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     const critTxt = roll.isCrit ? " 💥크리티컬!" : "";
     pushLog("enemy", `${afterEnemy.item?.name ?? "적"}의 공격! 🎲${roll.faces.join("/")}${critTxt} → ⚔${roll.totalDamage} 중 🛡${blocked} 경감 → ${dmg} 피해`);
     setPlayer(finalPlayer);
-    if (finalPlayer.hp <= 0) { setPhase("over"); setLastResult({ win: false }); pushLog("system", "💀 쓰러졌습니다..."); }
+    if (finalPlayer.hp <= 0) { setPhase("over"); setLastResult({ win: false }); pushLog("system", "💀 쓰러졌습니다..."); return; }
+    setBattleMenu("action");
   }, [encounter, roundNum, passive, handleWin, pushLog]);
 
-  // 기술(카드) 발동 — 탭하면 즉시. PP(usesLeft) 소진 시 무시. 공격력은 주사위로 굴려서 정해짐.
-  const playHandCard = useCallback((instanceId: string) => {
+  // 기술 발동 — 행동 메뉴에서 "전투"를 고른 뒤 기술 목록에서 탭하면 즉시. PP 소진 시 무시.
+  // 공격 기술은 주사위로 굴려서 데미지가 정해지고, 방어/회복 기술은 고정치를 바로 적용.
+  const useSkill = useCallback((skillId: string) => {
     if (phase !== "battling" || !enemy) return;
-    const card = pile.hand.find(c => c.instanceId === instanceId);
-    if (!card || card.usesLeft <= 0) return;
-    const result = engPlayCard(player, enemy, card, passive, effectiveStats);
-    setPile(p => ({ ...p, hand: p.hand.map(c => c.instanceId === instanceId ? { ...c, usesLeft: c.usesLeft - 1 } : c) }));
-    gainXp(XP_PER_ATTACK);
-    setLastPlayerRoll(result.roll);
-    const critTxt = result.roll.isCrit ? " 💥크리티컬!" : "";
-    const parts = [`🎲${result.roll.faces.join("/")}${critTxt} → ⚔${result.roll.totalDamage} 피해`];
-    if (card.stats.shield > 0) parts.push(`🛡${card.stats.shield} 방어`);
-    pushLog("player", `${card.name} 발동 (PP ${card.usesLeft - 1}/${card.stats.maxUses}) — ${parts.join(", ")}`);
+    const skill = skills.find(s => s.def.id === skillId);
+    if (!skill || skill.pp <= 0) return;
+    const result = engUseSkillEffect(player, enemy, skill.def, passive, effectiveStats);
+    setSkillPp(prev => prev.map(s => s.skillId === skillId ? { ...s, pp: s.pp - 1 } : s));
+    const nextPp = skill.pp - 1;
+    if (result.roll) {
+      gainXp(XP_PER_ATTACK);
+      setLastPlayerRoll(result.roll);
+      const critTxt = result.roll.isCrit ? " 💥크리티컬!" : "";
+      pushLog("player", `${skill.def.name} 발동 (PP ${nextPp}/${skill.def.maxPP}) — 🎲${result.roll.faces.join("/")}${critTxt} → ⚔${result.roll.totalDamage} 피해`);
+    } else if (skill.def.effect === "shield") {
+      pushLog("player", `${skill.def.name} 발동 (PP ${nextPp}/${skill.def.maxPP}) — 🛡${skill.def.power} 방어`);
+    } else {
+      pushLog("player", `${skill.def.name} 발동 (PP ${nextPp}/${skill.def.maxPP}) — ❤️${skill.def.power} 회복`);
+    }
     resolveTurn(result.player, result.enemy);
-  }, [phase, enemy, pile.hand, passive, player, effectiveStats, pushLog, gainXp, resolveTurn]);
+  }, [phase, enemy, skills, passive, player, effectiveStats, pushLog, gainXp, resolveTurn]);
 
-  // 액티브 아이템 즉시 발동(1회 소모) — 기술과 동일하게 사용 즉시 턴을 소모.
+  // 액티브 아이템 즉시 발동(1회 소모) — 행동 메뉴에서 "아이템"을 고른 뒤 사용. 기술과 동일하게
+  // 사용 즉시 턴을 소모.
   const useOwnedActiveItem = useCallback((instanceId: string) => {
     if (phase !== "battling" || !enemy) return;
     const owned = ownedItems.find(o => o.instanceId === instanceId);
     const def = owned && ALL_ITEMS.find(d => d.id === owned.defId);
     if (!owned || !def || def.kind !== "active") return;
-    const r = engUseActiveItem(player, enemy, pile.hand, def.effect as ActiveEffect);
-    setPile(p => ({ ...p, hand: r.hand }));
+    const r = engUseActiveItem(player, enemy, skillPp, skillDefs, def.effect as ActiveEffect);
+    setSkillPp(r.skills);
     setOwnedItems(prev => prev.filter(o => o.instanceId !== instanceId));
     pushLog("item", `🎒 ${def.name} 사용 — ${def.desc}`);
     resolveTurn(r.player, r.enemy);
-  }, [phase, enemy, ownedItems, player, pile.hand, pushLog, resolveTurn]);
+  }, [phase, enemy, ownedItems, player, skillPp, skillDefs, pushLog, resolveTurn]);
 
-  // 모든 기술 PP 소진 + 쓸 아이템도 없는 극단적 상황에서만 노출되는 패스 — 아무 효과 없이 턴만 넘김.
-  const passTurn = useCallback(() => {
-    if (phase !== "battling" || !enemy) return;
-    pushLog("system", "쓸 수 있는 기술/아이템이 없어 턴을 넘깁니다.");
-    resolveTurn(player, enemy);
-  }, [phase, enemy, player, pushLog, resolveTurn]);
+  // 행동 메뉴 선택 — 전투(기술 목록)/아이템(보유 아이템 목록)은 하위 화면 전환만, 도망치기/
+  // 월드맵은 곧바로 던전 상태를 바꾸는 액션.
+  const selectBattleAction = useCallback((action: "fight" | "item" | "flee" | "map") => {
+    if (phase !== "battling") return;
+    if (action === "fight") setBattleMenu("skills");
+    else if (action === "item") setBattleMenu("items");
+    else if (action === "flee") {
+      pushLog("system", "🏃 전투에서 도망쳐 이번 층을 포기했습니다.");
+      setEnemy(null); setBattleMenu("action"); setPhase("shop");
+    } else if (action === "map") { setPhase("over"); }
+  }, [phase, pushLog]);
+  const backToActionMenu = useCallback(() => setBattleMenu("action"), []);
 
-  // 다음 라운드 진입 — 조우 판정 후 배틀(적 생성+기술셋 새로 드로우) 또는 이벤트(휴식)
+  // 다음 라운드 진입 — 조우 판정 후 배틀(적 생성) 또는 이벤트(휴식). 기술 PP는 손대지 않음
+  // (던전 진행 내내 유지, 회복은 상점 물약으로만).
   const advanceToRound = useCallback((nextRoundNum: number) => {
     const enc = pickEncounter(nextRoundNum);
     setRoundNum(nextRoundNum);
@@ -294,19 +314,17 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     const newEnemy = enemyForFloor(pool, nextRoundNum, enc as "battle" | "boss" | "elite");
     setEnemy(newEnemy);
     pushLog("system", `${enc === "boss" ? "👑" : enc === "elite" ? "🗡️" : "🐉"} ${newEnemy.item?.name ?? "적"} 등장! (HP ${newEnemy.maxHp})`);
-    setPile(prev => {
-      const carryDiscard = [...prev.discard, ...prev.hand];
-      const r = drawHand(prev.draw, carryDiscard, HAND_SIZE + passive.drawBonus);
-      return { draw: r.drawPile, hand: r.hand, discard: r.discardPile };
-    });
     setPlayer(p => ({ ...p, block: passive.blockPerTurn }));
+    setBattleMenu("action");
     setPhase("battling");
   }, [pool, passive, pushLog]);
 
   const nextRound = useCallback(() => { if (phase === "resolved") setPhase("shop"); }, [phase]);
   const proceedFromEvent = useCallback(() => { if (phase === "event") setPhase("shop"); }, [phase]);
   const proceedFromShop = useCallback(() => { if (phase === "shop") advanceToRound(roundNum + 1); }, [phase, roundNum, advanceToRound]);
-  const cashOut = useCallback(() => { if (phase === "resolved") setPhase("over"); }, [phase]);
+  // 던전 나가기("여기서 정리" 버튼 및 전투 중 행동 메뉴의 "월드맵") — resolved 화면뿐 아니라
+  // 진행 중인 어느 시점에서도 호출 가능(런이 이미 끝났거나 로딩 중일 때만 무시).
+  const cashOut = useCallback(() => { if (phase !== "over" && phase !== "loading") setPhase("over"); }, [phase]);
 
   // 매 층 상점 — HP 회복 물약(즉시 회복, 옛 떠돌이 상인 기능 재사용, merchant 조우 게이팅만 제거)
   const buyMerchantHeal = useCallback(() => {
@@ -337,11 +355,10 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
 
   const start = useCallback(() => {
     if (pool.length < 2) return;
-    const runDeck = buildRunDeck(deck, STARTER_DECK);
     const newEnemy = enemyForFloor(pool, 0, "battle");
-    const r = drawHand(runDeck, [], HAND_SIZE);
     setEnemy(newEnemy);
-    setPile({ draw: r.drawPile, hand: r.hand, discard: r.discardPile });
+    setSkillPp(skillDefs.map(def => ({ skillId: def.id, pp: def.maxPP })));
+    setBattleMenu("action");
     setOwnedItems([]); setItemChoices(null);
     setGold(0); setRoundNum(0); setEncounter("battle"); setRestHealed(false); setNewBest(false);
     setLastResult(null); setDropped(false); setDropPrompt(false); setSaveFail(null); setPackOpening(false); setAcquired([]);
@@ -349,7 +366,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     prevMaxHpRef.current = maxHp;
     setLog([{ id: "l0", kind: "system", text: `🐉 ${newEnemy.item?.name ?? "적"} 등장! (HP ${newEnemy.maxHp})` }]);
     setPhase("battling");
-  }, [pool, deck, maxHp]);
+  }, [pool, skillDefs, maxHp]);
 
   useEffect(() => { if (!started.current && pool.length >= 2 && characterLoaded) { started.current = true; start(); } }, [pool, characterLoaded, start]);
 
@@ -360,21 +377,21 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     if (phase === "over") { try { localStorage.removeItem(RUN_KEY); } catch { } return; }
     const saved: SavedRun = {
       phase, roundNum, encounter, restHealed, gold, newBest,
-      ownedItems, itemChoices, activeBoost, player, enemy, pile,
+      ownedItems, itemChoices, activeBoost, player, enemy, skillPp, battleMenu,
       log, lastResult, acquired,
     };
     try { localStorage.setItem(RUN_KEY, JSON.stringify(saved)); } catch { }
-  }, [phase, roundNum, encounter, restHealed, gold, newBest, ownedItems, itemChoices, activeBoost, player, enemy, pile, log, lastResult, acquired]);
+  }, [phase, roundNum, encounter, restHealed, gold, newBest, ownedItems, itemChoices, activeBoost, player, enemy, skillPp, battleMenu, log, lastResult, acquired]);
 
   const acquirePct = enemy ? Math.round(Math.min(0.95, acquireChance(enemy.item, roundNum + 1) * (activeBoost?.mult ?? 1)) * 100) : 0;
 
   return {
     phase, roundNum, encounter, restHealed, gold, best, newBest,
     ownedItems, ownedDefs, itemChoices, passive, maxHp, unlockedLegendItems, activeBoost,
-    player, enemy, hand: pile.hand, drawCount: pile.draw.length, log,
+    player, enemy, skills, battleMenu, log,
     lastResult, dropped, dropPrompt, saveFail, packOpening, acquired, acquirePct,
     character, effectiveStats, lastPlayerRoll, lastEnemyRoll,
-    start, playHandCard, useOwnedActiveItem, passTurn, nextRound, proceedFromEvent, proceedFromShop, cashOut,
+    start, useSkill, useOwnedActiveItem, selectBattleAction, backToActionMenu, nextRound, proceedFromEvent, proceedFromShop, cashOut,
     buyMerchantHeal, buyPpPotion, buyBoost, pickItem, skipItem,
   };
 }

--- a/cf-idiotquant/components/game/HandView.tsx
+++ b/cf-idiotquant/components/game/HandView.tsx
@@ -1,38 +1,108 @@
 "use client";
 
-// 손패(=이번 전투의 고정 기술셋) — 포켓몬처럼 탭하면 즉시 발동(드래그 폐기). PP(usesLeft)가
-// 0인 기술은 비활성화. 발동 로직 자체(피해 계산·적 턴 자동 진행)는 부모(useGameRun)에 위임.
+// 전투 하단 패널 — 매 내 턴마다 3가지 모드를 오간다: action(전투/아이템/도망치기/월드맵 선택)
+// → skills(기술 목록, PP 있으면 탭해서 즉시 발동) 또는 items(보유 액티브 아이템 사용). 세 모드
+// 모두 같은 높이(w-16 h-20 카드 한 줄)를 유지해 모드 전환 시 캔버스가 리사이즈되며 흔들리는
+// 문제(과거 HUD 배지 흔들림 이슈와 같은 원인)를 피한다.
 
 import { cn } from "@/lib/utils";
-import type { CombatCard } from "@/app/(game)/game/gameTypes";
+import type { SkillDef, ItemDef, OwnedItem } from "@/app/(game)/game/gameTypes";
 
-// 캔버스 높이를 지키기 위해(3줄 그리드는 세로 공간을 너무 많이 먹어 캔버스를 짜부라뜨림 —
-// 과거 HUD 배지 흔들림 이슈와 같은 원인) 옛 드래그 미니카드와 동일한 고정 크기 가로 한 줄로.
-// 탭하면 즉시 발동(드래그 대신).
-function SkillCard({ card, onPlay }: { card: CombatCard; onPlay: (instanceId: string) => void }) {
-  const usable = card.usesLeft > 0;
+type SkillRuntime = { def: SkillDef; pp: number };
+
+const CARD_CLASS = "shrink-0 w-16 h-20 rounded-lg border p-1 flex flex-col items-center justify-between select-none active:scale-95 transition-transform";
+const CARD_ON = "bg-white/90 dark:bg-white/[0.08] border-black/10 dark:border-white/15";
+const CARD_OFF = "bg-black/[0.03] dark:bg-white/[0.02] border-black/5 dark:border-white/5 opacity-40 cursor-not-allowed";
+
+function BackButton({ onBack }: { onBack: () => void }) {
   return (
-    <button type="button" disabled={!usable} onClick={() => onPlay(card.instanceId)}
-      className={cn("shrink-0 w-16 h-20 rounded-lg border p-1 flex flex-col items-center justify-between select-none active:scale-95 transition-transform",
-        usable
-          ? "bg-white/90 dark:bg-white/[0.08] border-black/10 dark:border-white/15"
-          : "bg-black/[0.03] dark:bg-white/[0.02] border-black/5 dark:border-white/5 opacity-40 cursor-not-allowed")}>
-      <p className="text-[8px] font-bold text-neutral-500 dark:text-neutral-400 truncate w-full text-center">{card.name}</p>
-      <div className="grid grid-cols-2 gap-x-1 text-[9px] font-black tabular-nums w-full">
-        <span className="text-rose-500 text-center text-[8px]">⚔0~{card.stats.attack}</span>
-        <span className="text-sky-500 text-center">🛡{card.stats.shield}</span>
-      </div>
-      <span className={cn("text-[8px] font-black tabular-nums", usable ? "text-violet-600 dark:text-violet-400" : "text-neutral-400")}>
-        PP {card.usesLeft}/{card.stats.maxUses}
-      </span>
+    <button type="button" onClick={onBack}
+      className={cn(CARD_CLASS, CARD_ON, "justify-center text-neutral-500 dark:text-neutral-400")}>
+      <span aria-hidden className="text-lg leading-none">◀</span>
+      <span className="text-[9px] font-bold">뒤로</span>
+      <span />
     </button>
+  );
+}
+
+const ACTIONS: { id: "fight" | "item" | "flee" | "map"; icon: string; label: string }[] = [
+  { id: "fight", icon: "⚔️", label: "전투" },
+  { id: "item", icon: "🎒", label: "아이템" },
+  { id: "flee", icon: "🏃", label: "도망치기" },
+  { id: "map", icon: "🗺️", label: "월드맵" },
+];
+function ActionMenu({ onSelect }: { onSelect: (action: "fight" | "item" | "flee" | "map") => void }) {
+  return (
+    <>
+      {ACTIONS.map(a => (
+        <button key={a.id} type="button" onClick={() => onSelect(a.id)} className={cn(CARD_CLASS, CARD_ON)}>
+          <span aria-hidden className="text-xl leading-none">{a.icon}</span>
+          <p className="text-[9px] font-bold text-neutral-600 dark:text-neutral-300 text-center leading-tight">{a.label}</p>
+          <span />
+        </button>
+      ))}
+    </>
+  );
+}
+
+const EFFECT_ICON = { attack: "⚔", shield: "🛡", heal: "❤️" } as const;
+function SkillMenu({ skills, onPlay, onBack }: { skills: SkillRuntime[]; onPlay: (skillId: string) => void; onBack: () => void }) {
+  return (
+    <>
+      <BackButton onBack={onBack} />
+      {skills.map(({ def, pp }) => {
+        const usable = pp > 0;
+        return (
+          <button key={def.id} type="button" disabled={!usable} onClick={() => onPlay(def.id)}
+            className={cn(CARD_CLASS, usable ? CARD_ON : CARD_OFF)}>
+            <p className="text-[8px] font-bold text-neutral-500 dark:text-neutral-400 truncate w-full text-center">{def.name}</p>
+            <span className="text-[9px] font-black tabular-nums">
+              {EFFECT_ICON[def.effect]}{def.effect === "attack" ? `0~${def.power}` : def.power}
+            </span>
+            <span className={cn("text-[8px] font-black tabular-nums", usable ? "text-violet-600 dark:text-violet-400" : "text-neutral-400")}>
+              PP {pp}/{def.maxPP}
+            </span>
+          </button>
+        );
+      })}
+    </>
+  );
+}
+
+function ItemMenu({ ownedItems, ownedDefs, onUse, onBack }: {
+  ownedItems: OwnedItem[]; ownedDefs: ItemDef[]; onUse: (instanceId: string) => void; onBack: () => void;
+}) {
+  return (
+    <>
+      <BackButton onBack={onBack} />
+      {ownedItems.length === 0 && (
+        <div className={cn(CARD_CLASS, CARD_OFF, "justify-center")}>
+          <span className="text-[9px] font-bold text-neutral-400 text-center leading-tight">보유<br />아이템<br />없음</span>
+        </div>
+      )}
+      {ownedItems.map(o => {
+        const def = ownedDefs.find(d => d.id === o.defId);
+        if (!def) return null;
+        const usable = def.kind === "active";
+        return (
+          <button key={o.instanceId} type="button" disabled={!usable} onClick={() => onUse(o.instanceId)}
+            className={cn(CARD_CLASS, usable ? CARD_ON : CARD_OFF)}>
+            <span aria-hidden className="text-lg leading-none">{def.icon}</span>
+            <p className="text-[8px] font-bold text-neutral-500 dark:text-neutral-400 truncate w-full text-center">{def.name}</p>
+            <span className={cn("text-[8px] font-black", usable ? "text-amber-600 dark:text-amber-400" : "text-neutral-400")}>
+              {usable ? "탭해서 사용" : "패시브"}
+            </span>
+          </button>
+        );
+      })}
+    </>
   );
 }
 
 // 포켓몬 대각선 배치용 — 적 정보 오버레이(주사위 등)는 좌상단, 내 정보 오버레이는 우하단에
 // 떠서 각자 반대편 코너(적 캐릭터=우상단, 내 캐릭터=좌하단)와 시선이 교차하게 배치. Phaser
 // 캔버스(CombatScene.ts)의 이름표+HP바가 그 좌상단/우하단 자리를 이미 쓰고 있어서, 이 DOM
-// 오버레이는 그 아래/위로 한 칸 밀어(top-[17%]/bottom-[17%]) 겹치지 않게 한다.
+// 오버레이는 그 아래/위로 한 칸 밀어(top-[17%]/bottom-[26%]) 겹치지 않게 한다.
 function Battlefield({ children, topLeftOverlay, bottomRightOverlay }: {
   children: React.ReactNode; topLeftOverlay?: React.ReactNode; bottomRightOverlay?: React.ReactNode;
 }) {
@@ -45,20 +115,27 @@ function Battlefield({ children, topLeftOverlay, bottomRightOverlay }: {
   );
 }
 
-export default function HandView({ cards, onPlayCard, topLeftOverlay, bottomRightOverlay, children }: {
-  cards: CombatCard[];
-  onPlayCard: (instanceId: string) => void;
+type HandViewProps = {
   topLeftOverlay?: React.ReactNode;
   bottomRightOverlay?: React.ReactNode;
   children: React.ReactNode;
-}) {
+} & (
+  | { mode: "action"; onSelectAction: (action: "fight" | "item" | "flee" | "map") => void }
+  | { mode: "skills"; skills: SkillRuntime[]; onPlaySkill: (skillId: string) => void; onBack: () => void }
+  | { mode: "items"; ownedItems: OwnedItem[]; ownedDefs: ItemDef[]; onUseItem: (instanceId: string) => void; onBack: () => void }
+);
+
+export default function HandView(props: HandViewProps) {
+  const { topLeftOverlay, bottomRightOverlay, children } = props;
   return (
     <>
       <div className="flex-1 min-h-0">
         <Battlefield topLeftOverlay={topLeftOverlay} bottomRightOverlay={bottomRightOverlay}>{children}</Battlefield>
       </div>
       <div className="shrink-0 flex items-center justify-center gap-1.5 py-1.5 overflow-x-auto">
-        {cards.map(card => <SkillCard key={card.instanceId} card={card} onPlay={onPlayCard} />)}
+        {props.mode === "action" ? <ActionMenu onSelect={props.onSelectAction} />
+          : props.mode === "skills" ? <SkillMenu skills={props.skills} onPlay={props.onPlaySkill} onBack={props.onBack} />
+            : <ItemMenu ownedItems={props.ownedItems} ownedDefs={props.ownedDefs} onUse={props.onUseItem} onBack={props.onBack} />}
       </div>
     </>
   );


### PR DESCRIPTION
## 작업 내용
- 종목 카드 기반 기술을 전사 고정 기술 4종(주먹 휘두르기/강타/방어/기력회복)으로 교체, 각 PP 20
- PP는 사용마다 1씩 감소하고 **던전 진행 내내 유지**(전투를 이겨도 자동 회복 안 됨) — 상점의 PP 회복 물약으로만 회복
- 카드 draw/hand/discard 파일 시스템(`buildRunDeck`/`drawHand`/`STARTER_DECK` 등) 전체 제거 — 더 이상 손패 개념 없음
- 전투 진입 시 **행동 선택 메뉴**(전투/아이템/도망치기/월드맵)부터 시작 — "전투" 선택 시 기술 목록으로 진입해 PP 있는 기술만 사용 가능
- **도망치기** = 이번 층을 포기하고 상점으로, **월드맵** = 지금까지 성과를 저장하고 던전 나가기
- 카드 수집("내 덱") 시스템은 유지하되 전투 스탯과 완전히 분리(순수 도감/수집 요소로 — 적 스탯 산정에는 계속 사용)

## 체크리스트
- [x] 로컬 테스트 완료 (`npx tsc --noEmit`, `npm run build`, 순수함수 단위검증, Playwright 실기기 터치 시나리오)
- [x] 보류된 세부 작업 없음

## 참고 사항
- Playwright(iPhone SE, CDP 실제 터치)로 확인: 행동 메뉴 4개 버튼 노출 → 전투 선택 시 기술 4개(PP 20/20)로 진입 → 기술 사용 시 PP 차감 + 적 자동 반격 + 행동 메뉴로 복귀 → 도망치기 시 상점행 → 월드맵 시 결과 화면("무사히 던전을 빠져나왔어요") → 층을 넘겨도 PP가 자동 회복되지 않음(상점 물약으로만 회복)을 모두 확인. 5층까지 봇으로 자동 진행해 페이지 에러 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_