### PR TITLE
fix(game): 전투 진행을 순차적으로 + 파티 HP 표시 오차 수정

### DIFF
--- a/cf-idiotquant/app/(game)/game/combatEngine.ts
+++ b/cf-idiotquant/app/(game)/game/combatEngine.ts
@@ -114,11 +114,10 @@ export function monsterSkills(stats: CardStats): SkillDef[] {
   ];
 }
 
-// 던전 입장 시 파티 구성 — 계정 덱(수집한 종목 카드)에서 저평가 점수 상위 PARTY_SIZE장을 뽑고,
-// 부족하면 STARTER_MONSTERS로 채운다. 런 내내 고정(중간 합류/이탈 없음).
-export function buildParty(deckCards: any[]): PartyMember[] {
-  const sorted = [...deckCards].sort((a, b) => computeValueScore(b).score - computeValueScore(a).score);
-  const members: PartyMember[] = sorted.slice(0, PARTY_SIZE).map(card => {
+// 던전 입장 시 파티 구성 — 파티 설정 화면에서 유저가 고른 카드(최대 PARTY_SIZE장, 순서 무관)를
+// 그대로 쓰고, 부족하면 STARTER_MONSTERS로 채운다. 런 내내 고정(중간 합류/이탈 없음).
+export function buildParty(chosenCards: any[]): PartyMember[] {
+  const members: PartyMember[] = chosenCards.slice(0, PARTY_SIZE).map(card => {
     const stats = cardStats(card);
     const maxHp = PARTY_BASE_HP + stats.shield * HP_PER_SHIELD_PLAYER;
     return {

--- a/cf-idiotquant/app/(game)/game/gameTypes.ts
+++ b/cf-idiotquant/app/(game)/game/gameTypes.ts
@@ -1,6 +1,6 @@
 // 가치투자 덱빌더 — 공유 타입. React/Phaser 비의존.
 
-export type Phase = "loading" | "battling" | "resolved" | "over" | "event" | "shop";
+export type Phase = "loading" | "partySetup" | "battling" | "resolved" | "over" | "event" | "shop";
 export type EncounterType = "battle" | "boss" | "rest" | "elite";
 export type EnemyEncounter = "battle" | "boss" | "elite"; // 실제로 적이 등장하는 조우만(휴식 제외)
 

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -673,25 +673,25 @@ function GameContent() {
                     {run.battleMenu === "action" ? (
                       <HandView mode="action" onSelectAction={run.selectBattleAction} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
-                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />}>
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
                         <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} />
                       </HandView>
                     ) : run.battleMenu === "skills" ? (
                       <HandView mode="skills" skills={run.skills} onPlaySkill={run.useSkill} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
-                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />}>
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
                         <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} />
                       </HandView>
                     ) : run.battleMenu === "items" ? (
                       <HandView mode="items" ownedItems={run.ownedItems} ownedDefs={run.ownedDefs} onUseItem={run.useOwnedActiveItem} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
-                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />}>
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
                         <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} />
                       </HandView>
                     ) : (
                       <HandView mode="party" party={run.party} activeIndex={run.activeIndex} forced={run.forcedSwitch} onSwitchMember={run.switchMember} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
-                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />}>
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
                         <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} />
                       </HandView>
                     )}

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -31,7 +31,9 @@ import { cn } from "@/lib/utils";
 import { HOLO_THRESHOLD, PackReveal, AchievementBadges, ACHIEVEMENTS } from "./gameCollectibles";
 import { WalletChip, ConvertButton, ShopPanel, BOOST_ITEMS } from "./gameShop";
 import { useGameRun, deckTotal, type DeckItem, MERCHANT_HEAL_COST } from "./useGameRun";
-import { PP_POTION_COST } from "./gameData";
+import { PP_POTION_COST, PARTY_SIZE } from "./gameData";
+import { cardStats } from "./combatEngine";
+import { sectorType } from "./sectorTypes";
 import type { PartyMember } from "./gameTypes";
 import { EnemyIntentBadge, ItemBar, StatTile } from "@/components/game/CombatHud";
 import CharacterCard from "@/components/game/CharacterCard";
@@ -624,8 +626,9 @@ function GameContent() {
             </div>
           ) : (
             <div className={cn("w-full", run.phase === "over" ? "flex flex-col sm:flex-1 sm:min-h-0" : "flex flex-col flex-1 min-h-0")}>
-              {/* 상단 HUD — 던전 층수 + 적 정보만(내 캐릭터 관련 정보는 전부 하단 패널로 이동) */}
-              {run.phase !== "over" && (
+              {/* 상단 HUD — 던전 층수 + 적 정보만(내 캐릭터 관련 정보는 전부 하단 패널로 이동).
+                  파티 설정 화면은 아직 던전에 들어간 게 아니라 층수/적 정보가 의미 없어 제외. */}
+              {run.phase !== "over" && run.phase !== "partySetup" && (
                 <div className="shrink-0 mb-1 sm:mb-2 space-y-1">
                   {/* pr-9 — 우측 상단 구석에 고정된 게임 설명 버튼과 안 겹치게 오른쪽 여유 확보 */}
                   <div className="flex items-center justify-center gap-1.5 flex-wrap w-full pr-9">
@@ -661,6 +664,8 @@ function GameContent() {
               {run.phase === "over" ? (
                 <ResultScreen run={run} showResultDetail={showResultDetail} setShowResultDetail={setShowResultDetail}
                   isLoggedIn={isLoggedIn} deck={deck} catalog={catalog} />
+              ) : run.phase === "partySetup" ? (
+                <PartySetupScreen deck={deck} isLoggedIn={isLoggedIn} onConfirm={run.start} />
               ) : run.phase === "shop" ? (
                 <ShopScreen run={run} />
               ) : run.phase === "event" ? (
@@ -701,8 +706,9 @@ function GameContent() {
 
               {/* 하단 — 내 캐릭터 정보(상시 노출, 구 "용사 상태창" 모달 대체). HP는 이제 포켓몬식
                   캔버스(대각선 배치)에 표시되므로 여기선 제외 — 항목 수는 phase에만 의존(전투
-                  중 실시간으로는 안 바뀜)이라 그리드 칸 수가 흔들릴 일은 없음. */}
-              {run.phase !== "over" && (
+                  중 실시간으로는 안 바뀜)이라 그리드 칸 수가 흔들릴 일은 없음. 파티 설정 화면은
+                  카드 목록이 스크롤 공간을 다 써야 해서 제외. */}
+              {run.phase !== "over" && run.phase !== "partySetup" && (
                 <div className="shrink-0 mt-1.5 space-y-1">
                   <CharacterCard character={run.character} effectiveStats={run.effectiveStats} />
                   <div className={cn("grid gap-1.5", run.phase === "battling" ? "grid-cols-4" : "grid-cols-2")}>
@@ -737,7 +743,7 @@ function GameContent() {
             </div>
             <div className="space-y-3">
               {[
-                { icon: "🃏", text: <>던전에 입장하면 <b className="text-neutral-800 dark:text-neutral-100">내 덱</b>의 저평가 점수 상위 3장(부족하면 기본 몬스터로 보충)이 <b className="text-neutral-800 dark:text-neutral-100">파티</b>가 돼요. 카드의 ROE·NCAV가 그대로 몬스터의 공격력·방어력이 돼요.</> },
+                { icon: "🧩", text: <>던전 입장 전 <b className="text-neutral-800 dark:text-neutral-100">내 덱</b>에서 최대 3장을 직접 골라 <b className="text-neutral-800 dark:text-neutral-100">파티</b>를 꾸려요(저평가 점수 상위 3장이 기본 선택돼 있어요, 부족하면 기본 몬스터로 채워짐). 카드의 ROE·NCAV가 그대로 몬스터의 공격력·방어력이 돼요.</> },
                 { icon: "🗡️", text: <>매 턴 <b className="text-neutral-800 dark:text-neutral-100">전투/파티/아이템/도망치기</b> 중 행동을 골라요. <b className="text-neutral-800 dark:text-neutral-100">전투</b>를 고르면 지금 앞에 나온 몬스터의 기술 4개(약공격·강공격·방어·회복)가 나와요.</> },
                 { icon: "🎲", text: <>공격 기술은 <b className="text-neutral-800 dark:text-neutral-100">0~N 범위</b>로 20면체 주사위를 굴려 피해가 정해지고, 자연 20이면 <b className="text-amber-500 dark:text-amber-400">크리티컬</b>(최대 피해의 2배)! 방어는 블록을, 회복은 HP를 고정치만큼 즉시 채워요.</> },
                 { icon: "⚡", text: <>카드마다 업종이 있고 업종끼리 상성이 있어요 — 상성에서 <b className="text-emerald-600 dark:text-emerald-400">이기면 피해가 1.5배</b>, <b className="text-rose-500">지면 2/3배</b>로 줄어요.</> },
@@ -790,6 +796,68 @@ function GameContent() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+// 던전 입장 전 파티 설정 — 계정 덱에서 최대 PARTY_SIZE장을 직접 고른다(부족분은 스타터로
+// 채워짐, combatEngine.buildParty가 처리). 기본값은 저평가 점수 상위 PARTY_SIZE장을 미리
+// 선택해둬 그냥 바로 입장해도 되게 함(선택이 필수가 아님 — 커스터마이즈는 원할 때만).
+function PartySetupScreen({ deck, isLoggedIn, onConfirm }: {
+  deck: DeckItem[]; isLoggedIn: boolean; onConfirm: (tickers: string[]) => void;
+}) {
+  const ranked = useMemo(() => [...deck].sort((a, b) => computeValueScore(b).score - computeValueScore(a).score), [deck]);
+  const [selected, setSelected] = useState<string[]>(() => ranked.slice(0, PARTY_SIZE).map(c => c.ticker));
+  const touchedRef = useRef(false);
+  // deck이 늦게 도착(로그인 직후 등)해도 아직 유저가 손대기 전이면 기본 선택을 다시 계산
+  useEffect(() => { if (!touchedRef.current) setSelected(ranked.slice(0, PARTY_SIZE).map(c => c.ticker)); }, [ranked]);
+
+  const toggle = (ticker: string) => {
+    touchedRef.current = true;
+    setSelected(prev => {
+      if (prev.includes(ticker)) return prev.filter(t => t !== ticker);
+      if (prev.length >= PARTY_SIZE) return prev;
+      return [...prev, ticker];
+    });
+  };
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      <div className="shrink-0 text-center mb-2 px-2">
+        <p className="font-black text-neutral-900 dark:text-white">🧩 파티를 꾸리세요</p>
+        <p className="text-[11px] text-neutral-400 mt-0.5 break-keep">최대 {PARTY_SIZE}장까지 고를 수 있어요 — 부족한 자리는 스타터 몬스터로 채워져요</p>
+      </div>
+      <div className="flex-1 min-h-0 overflow-y-auto space-y-1.5 px-1 pb-2">
+        {ranked.length === 0 && (
+          <div className="text-center text-xs text-neutral-400 py-10 break-keep">
+            {isLoggedIn ? "아직 모은 카드가 없어요 — 스타터 몬스터로 시작해요." : "로그인하면 모은 카드로 파티를 꾸릴 수 있어요 — 지금은 스타터 몬스터로 시작해요."}
+          </div>
+        )}
+        {ranked.map(card => {
+          const stats = cardStats(card);
+          const type = sectorType(card);
+          const tone = computeValueScore(card).tone;
+          const isSel = selected.includes(card.ticker);
+          return (
+            <button key={card.ticker} type="button" onClick={() => toggle(card.ticker)}
+              className={cn("w-full flex items-center gap-2 px-3 py-2 rounded-xl border text-left transition-colors active:scale-[0.99]",
+                isSel ? "bg-emerald-500/10 border-emerald-500/50" : "bg-white/70 dark:bg-white/[0.05] border-black/5 dark:border-white/10")}>
+              <span className="w-2 h-2 rounded-full shrink-0" style={{ background: TIER[tone]?.glow }} />
+              <div className="flex-1 min-w-0">
+                <p className="text-xs font-bold text-neutral-800 dark:text-neutral-100 truncate">{card.name}</p>
+                <p className="text-[10px] text-neutral-400">{type ?? "무속성"} · ⚔{stats.attack} 🛡{stats.shield}</p>
+              </div>
+              {isSel && <span aria-hidden className="text-emerald-500 shrink-0">✅</span>}
+            </button>
+          );
+        })}
+      </div>
+      <div className="shrink-0 pt-2 px-1">
+        <button type="button" onClick={() => onConfirm(selected)}
+          className="w-full inline-flex items-center justify-center gap-2 px-6 py-2.5 rounded-2xl bg-gradient-to-r from-[#16a34a] to-[#15803d] hover:brightness-110 text-white font-black text-sm shadow-[0_8px_24px_-8px_rgba(22,163,74,0.55)] active:scale-[0.98] transition-all">
+          <Swords size={16} /> 던전 입장 ({selected.length}/{PARTY_SIZE} 선택)
+        </button>
+      </div>
     </div>
   );
 }
@@ -934,7 +1002,7 @@ function ResultScreen({ run, showResultDetail, setShowResultDetail, isLoggedIn, 
         )}
       </div>
       <div className="shrink-0 px-5 pb-3 pt-2 border-t border-black/5 dark:border-white/10">
-        <button onClick={run.start}
+        <button onClick={run.promptNewRun}
           className="w-full inline-flex items-center justify-center gap-2 px-6 py-2.5 rounded-2xl bg-gradient-to-r from-[#16a34a] to-[#15803d] hover:brightness-110 text-white font-black text-sm shadow-[0_8px_24px_-8px_rgba(22,163,74,0.55)] active:scale-[0.98] transition-all">
           <Swords size={16} /> 새 던전 입장
         </button>

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -59,6 +59,13 @@ function pickEncounter(roundNum: number): EncounterType {
 
 export const MERCHANT_HEAL_COST = 8;
 const REST_HEAL_FRAC = 0.3;
+// 내 공격 결과를 본 뒤에야 적 반격이 이어지도록(그리고 마지막 타격 결과를 본 뒤에야 다음
+// 스텝으로 넘어가도록) 각 단계 사이에 두는 지연. prefers-reduced-motion이면 대폭 줄인다.
+const RESOLVE_STEP_MS = 750;
+const RESOLVE_STEP_MS_REDUCED = 150;
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+}
 
 // 진행 중인 런 저장 — 다른 페이지를 다녀와도 이어지도록 함. 카드 데이터가 전부 인라인 스냅샷이라
 // (pool/deck 참조 없음) 그대로 JSON 직렬화/복원이 됨. packOpening/dropped/dropPrompt/saveFail은
@@ -93,13 +100,22 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
 
   // 파티 — 계정 덱 상위 카드로 던전 입장 시 구성, 런 내내 고정. activeIndex가 지금 전투 중인
   // 몬스터. playerHp/playerBlock은 그 활성 몬스터의 실시간 전투 상태(block은 매 적 턴 리셋).
-  const [party, setParty] = useState<PartyMember[]>([]);
+  const [partyRaw, setParty] = useState<PartyMember[]>([]); // 카드 자체 base만 담은 원본(트레이너 공용 보너스 미포함) — 화면 표시는 아래 파생 party를 쓴다
   const [activeIndex, setActiveIndex] = useState(0);
   const [playerHp, setPlayerHp] = useState(0);
   const [playerBlock, setPlayerBlock] = useState(0);
   const [enemy, setEnemy] = useState<EnemyState | null>(null);
   const [skillPp, setSkillPp] = useState<SkillState[]>([]); // 던전 진행 내내 유지(전투 승리로 안 채워짐) — PP 물약으로만 회복
   const [battleMenu, setBattleMenu] = useState<BattleMenu>("action"); // 전투 중 하위 화면 — 매 내 턴마다 "action"에서 시작
+  // 내 행동 결과를 보여주는 중(→ 잠시 뒤 적 반격, 또는 마지막 타격 결과를 보여주는 중 → 잠시
+  // 뒤 다음 페이즈)에는 true — 그 사이 추가 입력을 막아 두 이벤트가 겹쳐 보이지 않게 한다.
+  const [turnBusy, setTurnBusy] = useState(false);
+  const pendingTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const scheduleLater = useCallback((fn: () => void) => {
+    const id = setTimeout(fn, prefersReducedMotion() ? RESOLVE_STEP_MS_REDUCED : RESOLVE_STEP_MS);
+    pendingTimersRef.current.push(id);
+  }, []);
+  useEffect(() => () => { pendingTimersRef.current.forEach(clearTimeout); }, []);
 
   const { character, characterLoaded, gainXp } = useCharacter();
   const [lastPlayerRoll, setLastPlayerRoll] = useState<AttackRollResult | null>(null);
@@ -143,7 +159,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     vit: character.stats.vit + passive.vitBonus,
   }), [character.stats, passive]);
 
-  const activeMember = party[activeIndex] ?? null;
+  const activeMember = partyRaw[activeIndex] ?? null;
   // 활성 몬스터의 최대 HP = 카드 자체 base(파티 구성 시 고정) + 트레이너 공용 보너스(패시브
   // maxHpBonus + 체력 스탯) — 몬스터를 교체해도 이 공용 보너스는 그대로 따라붙는다. maxHp는
   // 항상 파생값으로만 계산하고 별도 state로 들고 있지 않는다(교체 시 증분 적용 같은 동기화
@@ -151,6 +167,15 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   const passiveVitBonus = passive.maxHpBonus + effectiveStats.vit * VIT_HP_MULTIPLIER;
   const activeMaxHp = activeMember ? activeMember.maxHp + passiveVitBonus : 0;
   const player: PlayerState = useMemo(() => ({ hp: playerHp, maxHp: activeMaxHp, block: playerBlock }), [playerHp, activeMaxHp, playerBlock]);
+
+  // party(state)의 maxHp는 카드 자체 base만 담고 있어(트레이너 공용 보너스 미포함) — 그걸 그대로
+  // 파티 화면/HUD에 표시하면 활성 몬스터의 경우 캔버스 HP바(player.maxHp, 보너스 포함)와 숫자가
+  // 어긋나 보였다(예: 25/20처럼 hp가 maxHp를 넘는 표기). 화면에 보여줄 땐 전원에게 똑같이
+  // passiveVitBonus를 더한 파생 뷰를 쓴다 — 활성 몬스터는 activeMaxHp와 정확히 같은 값이 된다.
+  const party: PartyMember[] = useMemo(
+    () => partyRaw.map(m => ({ ...m, maxHp: m.maxHp + passiveVitBonus })),
+    [partyRaw, passiveVitBonus],
+  );
 
   // 트레이너 공용 보너스(패시브+체력 스탯)가 늘어난 만큼 활성 몬스터 HP도 즉시 채워줌(아이템을
   // 새로 주웠을 때만 반응 — activeMaxHp 자체는 교체할 때도 바뀌므로 이 값에 직접 걸면 교체할
@@ -166,7 +191,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   const skills = useMemo(() => skillDefs.map(def => ({
     def, pp: skillPp.find(s => s.ownerId === activeMember?.instanceId && s.skillId === def.id)?.pp ?? def.maxPP,
   })), [skillDefs, skillPp, activeMember]);
-  const skillDefsByOwner = useMemo(() => new Map(party.map(m => [m.instanceId, monsterSkills(m.stats)])), [party]);
+  const skillDefsByOwner = useMemo(() => new Map(partyRaw.map(m => [m.instanceId, monsterSkills(m.stats)])), [partyRaw]);
 
   const started = useRef(false); // 자동 새 런 시작 가드 — 아래 복원이 성공하면 true로 설정해 덮어쓰지 않게 함
 
@@ -252,7 +277,9 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   }, [best, isLoggedIn, availableItemPool, unlockedLegendItems, setDeck, activeBoost, pushLog, gainXp, effectiveStats.luk]);
 
   // 적의 반격 처리 공통 로직 — 내 행동 직후(resolveTurn) 또는 자발적 파티 교체 직후(switchMember)
-  // 양쪽에서 호출. 활성 몬스터가 쓰러지면: 남은 파티원이 있으면 강제 교체 화면으로, 없으면 런 종료.
+  // 양쪽에서 호출. 반격 자체는 즉시 계산해 로그·HP를 반영하지만(전투 화면엔 그 결과가 곧바로
+  // 보임), 그다음 단계(행동 메뉴 복귀·강제 교체·런 종료)로 넘어가는 건 한 박자 늦춰서 이 반격의
+  // 결과를 눈으로 볼 시간을 준다.
   const applyEnemyTurn = useCallback((afterPlayer: PlayerState, afterEnemy: EnemyState, member: PartyMember, idx: number, currentParty: PartyMember[]) => {
     const { player: finalPlayer, roll, effectiveness } = resolveEnemyTurn(afterPlayer, afterEnemy, passive, afterEnemy.sectorType, member.sectorType);
     setLastEnemyRoll(roll);
@@ -265,34 +292,43 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setParty(prev => prev.map((m, i) => i === idx ? { ...m, hp: finalPlayer.hp } : m));
     if (finalPlayer.hp <= 0) {
       const hasReserve = currentParty.some((m, i) => i !== idx && m.hp > 0);
-      if (hasReserve) {
-        pushLog("system", `💥 ${member.name}이(가) 쓰러졌습니다! 다음 몬스터를 선택하세요.`);
-        setBattleMenu("party");
-      } else {
-        setPhase("over"); setLastResult({ win: false }); pushLog("system", "💀 파티 전원이 쓰러졌습니다...");
-      }
+      scheduleLater(() => {
+        setTurnBusy(false);
+        if (hasReserve) {
+          pushLog("system", `💥 ${member.name}이(가) 쓰러졌습니다! 다음 몬스터를 선택하세요.`);
+          setBattleMenu("party");
+        } else {
+          setPhase("over"); setLastResult({ win: false }); pushLog("system", "💀 파티 전원이 쓰러졌습니다...");
+        }
+      });
       return;
     }
-    setBattleMenu("action");
-  }, [passive, pushLog]);
+    scheduleLater(() => { setTurnBusy(false); setBattleMenu("action"); });
+  }, [passive, pushLog, scheduleLater]);
 
-  // 내 행동(기술/아이템) 직후 곧바로 적 턴을 진행 — 1행동=1턴이라 별도 "턴 종료" 버튼이 없고,
-  // 기술/아이템을 쓴 함수들이 마지막에 이 함수 하나로 마무리한다. afterPlayer/afterEnemy는 이미
-  // 그 행동의 효과(데미지/블록/회복)까지 반영된 상태.
+  // 내 행동(기술/아이템) 직후 적 턴을 진행 — 1행동=1턴이라 별도 "턴 종료" 버튼이 없고, 기술/
+  // 아이템을 쓴 함수들이 마지막에 이 함수 하나로 마무리한다. afterPlayer/afterEnemy는 이미 그
+  // 행동의 효과(데미지/블록/회복)까지 반영된 상태 — 그 결과를 먼저 화면에 반영해 한 박자 보여준
+  // 뒤에야(scheduleLater) 적 반격(또는 승리 처리)으로 넘어간다.
   const resolveTurn = useCallback((afterPlayer: PlayerState, afterEnemy: EnemyState) => {
     setEnemy(afterEnemy);
-    const idx = activeIndex, member = party[idx];
+    const idx = activeIndex, member = partyRaw[idx];
     if (!member) return;
     setParty(prev => prev.map((m, i) => i === idx ? { ...m, hp: afterPlayer.hp } : m));
-    if (checkOutcome(afterPlayer, afterEnemy) === "win") { setPlayerHp(afterPlayer.hp); setPlayerBlock(afterPlayer.block); handleWin(afterEnemy, encounter, roundNum); return; }
-    applyEnemyTurn(afterPlayer, afterEnemy, member, idx, party);
-  }, [activeIndex, party, encounter, roundNum, handleWin, applyEnemyTurn]);
+    setPlayerHp(afterPlayer.hp); setPlayerBlock(afterPlayer.block);
+    setTurnBusy(true);
+    if (checkOutcome(afterPlayer, afterEnemy) === "win") {
+      scheduleLater(() => { setTurnBusy(false); handleWin(afterEnemy, encounter, roundNum); });
+      return;
+    }
+    scheduleLater(() => applyEnemyTurn(afterPlayer, afterEnemy, member, idx, partyRaw));
+  }, [activeIndex, partyRaw, encounter, roundNum, handleWin, applyEnemyTurn, scheduleLater]);
 
   // 기술 발동 — 행동 메뉴에서 "전투"를 고른 뒤 기술 목록에서 탭하면 즉시. PP 소진 시 무시.
   // 공격 기술은 주사위로 굴려서 데미지가 정해지고(+업종 상성 배율), 방어/회복 기술은 고정치를
   // 바로 적용.
   const useSkill = useCallback((skillId: string) => {
-    if (phase !== "battling" || !enemy || !activeMember) return;
+    if (phase !== "battling" || !enemy || !activeMember || turnBusy) return;
     const skill = skills.find(s => s.def.id === skillId);
     if (!skill || skill.pp <= 0) return;
     const result = engUseSkillEffect(player, enemy, skill.def, passive, effectiveStats, activeMember.sectorType, enemy.sectorType);
@@ -310,12 +346,12 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       pushLog("player", `${activeMember.name}의 ${skill.def.name}! (PP ${nextPp}/${skill.def.maxPP}) — ❤️${skill.def.power} 회복`);
     }
     resolveTurn(result.player, result.enemy);
-  }, [phase, enemy, activeMember, skills, passive, player, effectiveStats, pushLog, gainXp, resolveTurn]);
+  }, [phase, enemy, activeMember, skills, passive, player, effectiveStats, turnBusy, pushLog, gainXp, resolveTurn]);
 
   // 액티브 아이템 즉시 발동(1회 소모) — 행동 메뉴에서 "아이템"을 고른 뒤 사용. 기술과 동일하게
   // 사용 즉시 턴을 소모.
   const useOwnedActiveItem = useCallback((instanceId: string) => {
-    if (phase !== "battling" || !enemy) return;
+    if (phase !== "battling" || !enemy || turnBusy) return;
     const owned = ownedItems.find(o => o.instanceId === instanceId);
     const def = owned && ALL_ITEMS.find(d => d.id === owned.defId);
     if (!owned || !def || def.kind !== "active") return;
@@ -324,16 +360,16 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setOwnedItems(prev => prev.filter(o => o.instanceId !== instanceId));
     pushLog("item", `🎒 ${def.name} 사용 — ${def.desc}`);
     resolveTurn(r.player, r.enemy);
-  }, [phase, enemy, ownedItems, player, skillPp, skillDefsByOwner, pushLog, resolveTurn]);
+  }, [phase, enemy, ownedItems, player, skillPp, skillDefsByOwner, turnBusy, pushLog, resolveTurn]);
 
   // 파티 교체 — 강제(활성 몬스터 기절 직후, battleMenu==="party"이고 player.hp<=0)면 턴을 소모하지
   // 않고 곧바로 행동 선택으로 복귀. 자발적(행동 메뉴 "파티"에서 직접 선택)이면 실제 기술처럼 턴을
   // 소모해 곧바로 적의 공격을 받는다(교체에 대가가 있어야 유의미한 선택이 됨).
   const switchMember = useCallback((instanceId: string) => {
-    if (phase !== "battling") return;
-    const idx = party.findIndex(m => m.instanceId === instanceId);
+    if (phase !== "battling" || turnBusy) return;
+    const idx = partyRaw.findIndex(m => m.instanceId === instanceId);
     if (idx < 0 || idx === activeIndex) return;
-    const member = party[idx];
+    const member = partyRaw[idx];
     if (member.hp <= 0) return;
     const forced = playerHp <= 0;
     setActiveIndex(idx);
@@ -342,15 +378,17 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     pushLog("system", `🔄 ${member.name}이(가) 앞으로 나섭니다!`);
     if (forced) { setBattleMenu("action"); return; }
     if (!enemy) { setBattleMenu("action"); return; }
-    applyEnemyTurn({ hp: member.hp, maxHp: member.maxHp + passiveVitBonus, block: passive.blockPerTurn }, enemy, member, idx, party);
-  }, [phase, party, activeIndex, playerHp, passive, passiveVitBonus, enemy, pushLog, applyEnemyTurn]);
+    // 자발적 교체도 턴을 소모 — "교체됨" 결과를 한 박자 보여준 뒤에야 적의 반격으로 넘어간다.
+    setTurnBusy(true);
+    scheduleLater(() => applyEnemyTurn({ hp: member.hp, maxHp: member.maxHp + passiveVitBonus, block: passive.blockPerTurn }, enemy, member, idx, partyRaw));
+  }, [phase, partyRaw, activeIndex, playerHp, passive, passiveVitBonus, enemy, turnBusy, pushLog, applyEnemyTurn, scheduleLater]);
 
   // 행동 메뉴 선택 — 전투(기술 목록)/파티(교체)/아이템(보유 아이템 목록)은 하위 화면 전환만,
   // 도망치기는 곧바로 던전 상태를 바꾸는 액션. 던전 나가기(구 "월드맵")는 이제 행동 메뉴가
   // 아니라 상단 HUD의 상시 버튼(cashOut)으로 이동했다 — 정확히 4칸인 메뉴에 파티 교체 자리를
   // 마련하기 위함.
   const selectBattleAction = useCallback((action: "fight" | "party" | "item" | "flee") => {
-    if (phase !== "battling") return;
+    if (phase !== "battling" || turnBusy) return;
     if (action === "fight") setBattleMenu("skills");
     else if (action === "party") setBattleMenu("party");
     else if (action === "item") setBattleMenu("items");
@@ -358,8 +396,8 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       pushLog("system", "🏃 전투에서 도망쳐 이번 층을 포기했습니다.");
       setEnemy(null); setBattleMenu("action"); setPhase("shop");
     }
-  }, [phase, pushLog]);
-  const backToActionMenu = useCallback(() => { if (playerHp > 0) setBattleMenu("action"); }, [playerHp]);
+  }, [phase, turnBusy, pushLog]);
+  const backToActionMenu = useCallback(() => { if (playerHp > 0 && !turnBusy) setBattleMenu("action"); }, [playerHp, turnBusy]);
 
   // 다음 라운드 진입 — 조우 판정 후 배틀(적 생성) 또는 이벤트(휴식). 기술 PP는 손대지 않음
   // (던전 진행 내내 유지, 회복은 상점 물약으로만). 활성 몬스터는 층 클리어 시점에 항상 생존 중
@@ -452,13 +490,15 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     if (typeof window === "undefined") return;
     if (phase === "loading") return;
     if (phase === "over") { try { localStorage.removeItem(RUN_KEY); } catch { } return; }
+    // party는 트레이너 보너스가 더해진 화면 표시용 파생값이라 저장하지 않는다(복원 시 다시
+    // 보너스를 더하면 이중으로 반영됨) — 원본 partyRaw를 저장한다.
     const saved: SavedRun = {
       phase, roundNum, encounter, restHealed, gold, newBest,
-      ownedItems, itemChoices, activeBoost, party, activeIndex, playerHp, playerBlock, enemy, skillPp, battleMenu,
+      ownedItems, itemChoices, activeBoost, party: partyRaw, activeIndex, playerHp, playerBlock, enemy, skillPp, battleMenu,
       log, lastResult, acquired,
     };
     try { localStorage.setItem(RUN_KEY, JSON.stringify(saved)); } catch { }
-  }, [phase, roundNum, encounter, restHealed, gold, newBest, ownedItems, itemChoices, activeBoost, party, activeIndex, playerHp, playerBlock, enemy, skillPp, battleMenu, log, lastResult, acquired]);
+  }, [phase, roundNum, encounter, restHealed, gold, newBest, ownedItems, itemChoices, activeBoost, partyRaw, activeIndex, playerHp, playerBlock, enemy, skillPp, battleMenu, log, lastResult, acquired]);
 
   const acquirePct = enemy ? Math.round(Math.min(0.95, acquireChance(enemy.item, roundNum + 1) * (activeBoost?.mult ?? 1)) * 100) : 0;
   const forcedSwitch = playerHp <= 0; // battleMenu==="party"일 때만 의미 있음(그 외엔 항상 false)
@@ -466,7 +506,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   return {
     phase, roundNum, encounter, restHealed, gold, best, newBest,
     ownedItems, ownedDefs, itemChoices, passive, unlockedLegendItems, activeBoost,
-    player, enemy, party, activeIndex, forcedSwitch, skills, battleMenu, log,
+    player, enemy, party, activeIndex, forcedSwitch, busy: turnBusy, skills, battleMenu, log,
     lastResult, dropped, dropPrompt, saveFail, packOpening, acquired, acquirePct,
     character, effectiveStats, lastPlayerRoll, lastEnemyRoll,
     start, useSkill, useOwnedActiveItem, switchMember, selectBattleAction, backToActionMenu, nextRound, proceedFromEvent, proceedFromShop, cashOut,

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -464,9 +464,12 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   }, []);
   const skipItem = useCallback(() => setItemChoices(null), []);
 
-  const start = useCallback(() => {
+  // selectedTickers — 파티 설정 화면에서 유저가 고른 카드(최대 PARTY_SIZE, 순서=선택 순서).
+  // 빈 배열이면(덱이 없거나 전부 건너뜀) 전원 스타터로 시작.
+  const start = useCallback((selectedTickers: string[] = []) => {
     if (pool.length < 2) return;
-    const newParty = buildParty(deck);
+    const chosen = selectedTickers.map(t => deck.find(d => d.ticker === t)).filter((c): c is DeckItem => !!c);
+    const newParty = buildParty(chosen);
     const newEnemy = enemyForFloor(pool, 0, "battle");
     setParty(newParty);
     setActiveIndex(0);
@@ -483,7 +486,11 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setPhase("battling");
   }, [pool, deck, effectiveStats.vit]);
 
-  useEffect(() => { if (!started.current && pool.length >= 2 && characterLoaded) { started.current = true; start(); } }, [pool, characterLoaded, start]);
+  // 준비되면(카드 풀+캐릭터 로드 완료) 곧바로 던전에 들어가지 않고 파티 설정 화면부터 보여준다.
+  // 이어할 저장된 런이 있었다면 복원 effect가 이미 started.current를 true로 만들어놨을 것.
+  useEffect(() => { if (!started.current && pool.length >= 2 && characterLoaded) { started.current = true; setPhase("partySetup"); } }, [pool, characterLoaded]);
+  // "새 던전 입장" — 곧바로 시작하지 않고 파티를 다시 고를 수 있게 설정 화면으로.
+  const promptNewRun = useCallback(() => { if (phase === "over") setPhase("partySetup"); }, [phase]);
 
   // 진행 중인 런 저장 — 다른 페이지로 이동했다 돌아와도 이어지도록. 런이 끝나면(over) 제거.
   useEffect(() => {
@@ -509,7 +516,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     player, enemy, party, activeIndex, forcedSwitch, busy: turnBusy, skills, battleMenu, log,
     lastResult, dropped, dropPrompt, saveFail, packOpening, acquired, acquirePct,
     character, effectiveStats, lastPlayerRoll, lastEnemyRoll,
-    start, useSkill, useOwnedActiveItem, switchMember, selectBattleAction, backToActionMenu, nextRound, proceedFromEvent, proceedFromShop, cashOut,
+    start, promptNewRun, useSkill, useOwnedActiveItem, switchMember, selectBattleAction, backToActionMenu, nextRound, proceedFromEvent, proceedFromShop, cashOut,
     buyMerchantHeal, buyPpPotion, buyBoost, pickItem, skipItem,
   };
 }

--- a/cf-idiotquant/components/game/HandView.tsx
+++ b/cf-idiotquant/components/game/HandView.tsx
@@ -43,10 +43,11 @@ const CELL_OFF = "bg-black/[0.03] dark:bg-white/[0.02] border-black/5 dark:borde
 
 // 포켓몬 배틀 메뉴의 상시 취소 화살표(그리드 칸을 하나 차지하지 않고 옆에 따로 붙어 있음)를
 // 흉내낸 슬림 세로 버튼 — skills/items/party(강제 아닐 때만) 모드에서 노출.
-function BackColumn({ onBack }: { onBack: () => void }) {
+function BackColumn({ onBack, disabled }: { onBack: () => void; disabled?: boolean }) {
   return (
-    <button type="button" onClick={onBack} aria-label="뒤로"
-      className="shrink-0 w-6 h-full rounded-md border border-black/10 dark:border-white/15 bg-white/70 dark:bg-white/[0.06] text-neutral-500 dark:text-neutral-400 flex items-center justify-center active:scale-95 transition-transform">
+    <button type="button" disabled={disabled} onClick={onBack} aria-label="뒤로"
+      className={cn("shrink-0 w-6 h-full rounded-md border border-black/10 dark:border-white/15 bg-white/70 dark:bg-white/[0.06] text-neutral-500 dark:text-neutral-400 flex items-center justify-center active:scale-95 transition-transform",
+        disabled && "opacity-40 cursor-not-allowed")}>
       <span aria-hidden className="text-sm leading-none">◀</span>
     </button>
   );
@@ -64,11 +65,11 @@ const ACTIONS: { id: "fight" | "party" | "item" | "flee"; icon: string; label: s
   { id: "item", icon: "🎒", label: "아이템" },
   { id: "flee", icon: "🏃", label: "도망치기" },
 ];
-function ActionMenu({ onSelect }: { onSelect: (action: "fight" | "party" | "item" | "flee") => void }) {
+function ActionMenu({ onSelect, busy }: { onSelect: (action: "fight" | "party" | "item" | "flee") => void; busy: boolean }) {
   return (
     <Grid2x2>
       {ACTIONS.map(a => (
-        <button key={a.id} type="button" onClick={() => onSelect(a.id)} className={cn(CELL_CLASS, CELL_ON)}>
+        <button key={a.id} type="button" disabled={busy} onClick={() => onSelect(a.id)} className={cn(CELL_CLASS, busy ? CELL_OFF : CELL_ON)}>
           <span aria-hidden className="text-base leading-none">{a.icon}</span>
           <p className="text-[9px] font-bold text-neutral-600 dark:text-neutral-300 text-center leading-tight mt-0.5">{a.label}</p>
         </button>
@@ -78,13 +79,13 @@ function ActionMenu({ onSelect }: { onSelect: (action: "fight" | "party" | "item
 }
 
 const EFFECT_ICON = { attack: "⚔", shield: "🛡", heal: "❤️" } as const;
-function SkillMenu({ skills, onPlay, onBack }: { skills: SkillRuntime[]; onPlay: (skillId: string) => void; onBack: () => void }) {
+function SkillMenu({ skills, onPlay, onBack, busy }: { skills: SkillRuntime[]; onPlay: (skillId: string) => void; onBack: () => void; busy: boolean }) {
   return (
     <>
-      <BackColumn onBack={onBack} />
+      <BackColumn onBack={onBack} disabled={busy} />
       <Grid2x2>
         {skills.map(({ def, pp }) => {
-          const usable = pp > 0;
+          const usable = pp > 0 && !busy;
           return (
             <button key={def.id} type="button" disabled={!usable} onClick={() => onPlay(def.id)}
               className={cn(CELL_CLASS, usable ? CELL_ON : CELL_OFF)}>
@@ -92,7 +93,7 @@ function SkillMenu({ skills, onPlay, onBack }: { skills: SkillRuntime[]; onPlay:
               <span className="text-[9px] font-black tabular-nums">
                 {EFFECT_ICON[def.effect]}{def.effect === "attack" ? `0~${def.power}` : def.power}
               </span>
-              <span className={cn("text-[8px] font-black tabular-nums", usable ? "text-violet-600 dark:text-violet-400" : "text-neutral-400")}>
+              <span className={cn("text-[8px] font-black tabular-nums", pp > 0 ? "text-violet-600 dark:text-violet-400" : "text-neutral-400")}>
                 PP {pp}/{def.maxPP}
               </span>
             </button>
@@ -103,12 +104,12 @@ function SkillMenu({ skills, onPlay, onBack }: { skills: SkillRuntime[]; onPlay:
   );
 }
 
-function ItemMenu({ ownedItems, ownedDefs, onUse, onBack }: {
-  ownedItems: OwnedItem[]; ownedDefs: ItemDef[]; onUse: (instanceId: string) => void; onBack: () => void;
+function ItemMenu({ ownedItems, ownedDefs, onUse, onBack, busy }: {
+  ownedItems: OwnedItem[]; ownedDefs: ItemDef[]; onUse: (instanceId: string) => void; onBack: () => void; busy: boolean;
 }) {
   return (
     <>
-      <BackColumn onBack={onBack} />
+      <BackColumn onBack={onBack} disabled={busy} />
       <div className="flex items-center gap-1 h-full w-[168px] shrink-0 overflow-x-auto">
         {ownedItems.length === 0 && (
           <div className={cn(CELL_CLASS, CELL_OFF, "w-full")}>
@@ -118,14 +119,14 @@ function ItemMenu({ ownedItems, ownedDefs, onUse, onBack }: {
         {ownedItems.map(o => {
           const def = ownedDefs.find(d => d.id === o.defId);
           if (!def) return null;
-          const usable = def.kind === "active";
+          const usable = def.kind === "active" && !busy;
           return (
             <button key={o.instanceId} type="button" disabled={!usable} onClick={() => onUse(o.instanceId)}
               className={cn(CELL_CLASS, "w-16 shrink-0", usable ? CELL_ON : CELL_OFF)}>
               <span aria-hidden className="text-base leading-none">{def.icon}</span>
               <p className="text-[8px] font-bold text-neutral-500 dark:text-neutral-400 truncate w-full text-center">{def.name}</p>
-              <span className={cn("text-[8px] font-black", usable ? "text-amber-600 dark:text-amber-400" : "text-neutral-400")}>
-                {usable ? "탭해서 사용" : "패시브"}
+              <span className={cn("text-[8px] font-black", def.kind === "active" ? "text-amber-600 dark:text-amber-400" : "text-neutral-400")}>
+                {def.kind === "active" ? "탭해서 사용" : "패시브"}
               </span>
             </button>
           );
@@ -137,18 +138,18 @@ function ItemMenu({ ownedItems, ownedDefs, onUse, onBack }: {
 
 // 파티 교체 — forced(활성 몬스터가 방금 기절)면 취소 화살표를 없애 반드시 하나를 골라야 함.
 // 3마리 고정이라 그리드 4칸 중 하나는 항상 빈 자리로 남는다.
-function PartyMenu({ party, activeIndex, forced, onSwitch, onBack }: {
+function PartyMenu({ party, activeIndex, forced, onSwitch, onBack, busy }: {
   party: PartyMember[]; activeIndex: number; forced: boolean;
-  onSwitch: (instanceId: string) => void; onBack: () => void;
+  onSwitch: (instanceId: string) => void; onBack: () => void; busy: boolean;
 }) {
   return (
     <>
-      {!forced && <BackColumn onBack={onBack} />}
+      {!forced && <BackColumn onBack={onBack} disabled={busy} />}
       <Grid2x2>
         {party.map((m, i) => {
           const fainted = m.hp <= 0;
           const isActive = i === activeIndex;
-          const usable = !fainted && !isActive;
+          const usable = !fainted && !isActive && !busy;
           return (
             <button key={m.instanceId} type="button" disabled={!usable} onClick={() => onSwitch(m.instanceId)}
               className={cn(CELL_CLASS, usable ? CELL_ON : CELL_OFF)}>
@@ -191,6 +192,9 @@ type HandViewProps = {
   topLeftOverlay?: React.ReactNode;
   bottomRightOverlay?: React.ReactNode;
   children: React.ReactNode;
+  // 내 행동 결과를 보여주고 적 반격으로 넘어가는 사이(또는 마지막 타격 결과를 보여주고 다음
+  // 페이즈로 넘어가는 사이) true — 그 사이엔 모든 선택지를 비활성화해 입력이 겹치지 않게 한다.
+  busy?: boolean;
 } & (
   | { mode: "action"; onSelectAction: (action: "fight" | "party" | "item" | "flee") => void }
   | { mode: "skills"; skills: SkillRuntime[]; onPlaySkill: (skillId: string) => void; onBack: () => void }
@@ -199,7 +203,7 @@ type HandViewProps = {
 );
 
 export default function HandView(props: HandViewProps) {
-  const { message, topLeftOverlay, bottomRightOverlay, children } = props;
+  const { message, topLeftOverlay, bottomRightOverlay, children, busy = false } = props;
   return (
     <>
       <div className="flex-1 min-h-0">
@@ -210,10 +214,10 @@ export default function HandView(props: HandViewProps) {
           모드가 바뀌어도 이 행 전체 높이가 안 흔들린다. */}
       <div className="shrink-0 flex items-stretch gap-1.5 py-1.5">
         <MessageBox text={message} />
-        {props.mode === "action" ? <ActionMenu onSelect={props.onSelectAction} />
-          : props.mode === "skills" ? <SkillMenu skills={props.skills} onPlay={props.onPlaySkill} onBack={props.onBack} />
-            : props.mode === "items" ? <ItemMenu ownedItems={props.ownedItems} ownedDefs={props.ownedDefs} onUse={props.onUseItem} onBack={props.onBack} />
-              : <PartyMenu party={props.party} activeIndex={props.activeIndex} forced={props.forced} onSwitch={props.onSwitchMember} onBack={props.onBack} />}
+        {props.mode === "action" ? <ActionMenu onSelect={props.onSelectAction} busy={busy} />
+          : props.mode === "skills" ? <SkillMenu skills={props.skills} onPlay={props.onPlaySkill} onBack={props.onBack} busy={busy} />
+            : props.mode === "items" ? <ItemMenu ownedItems={props.ownedItems} ownedDefs={props.ownedDefs} onUse={props.onUseItem} onBack={props.onBack} busy={busy} />
+              : <PartyMenu party={props.party} activeIndex={props.activeIndex} forced={props.forced} onSwitch={props.onSwitchMember} onBack={props.onBack} busy={busy} />}
       </div>
     </>
   );


### PR DESCRIPTION
## 작업 내용
- **내 공격 → 적 반격 순차 진행**: 기존엔 내 행동 직후 같은 틱에서 적 반격까지 한번에 처리돼 두 결과가 겹쳐 보였음. 이제 내 공격 결과를 먼저 반영·표시한 뒤 750ms(접근성 설정 `prefers-reduced-motion`이면 150ms) 지연 후에야 적 반격이 이어지도록 분리. 그 사이(`turnBusy`)엔 행동 메뉴/기술/아이템/파티 교체 버튼이 전부 비활성화돼 입력이 겹치지 않음
- **전투 종료 시 마지막 타격 결과를 보여준 뒤 전환**: 승리(적 HP 0)·패배(파티 전멸)·강제 교체 모두 같은 지연을 적용해, 화면이 곧바로 다음 페이즈(결과 화면/상점/파티 선택)로 넘어가지 않고 마지막 공격의 결과(로그·HP 변화)를 먼저 보여줌
- **파티원 HP 표시 오차 수정**: 트레이너 공용 보너스(패시브 `maxHpBonus` + 체력 스탯, 기본 VIT 10만으로도 +20)가 활성 몬스터의 전투 캔버스 HP바에는 반영되지만 파티 화면(교체 메뉴)의 최대 HP 표시에는 빠져 있어, 같은 몬스터인데 화면마다 다른 수치가 보이던 버그 수정 — 파티 상태의 원본은 카드 자체 base만 유지하고, 화면에 노출하는 파생 값에서 전원에게 동일하게 보너스를 더하도록 정리

## 체크리스트
- [x] 로컬 테스트 완료 (`npx tsc --noEmit`, `npm run build`, Playwright로 실기기 터치 시뮬레이션)
- [x] 보류된 세부 작업 없음

## 참고 사항
- Playwright로 확인: (1) 기술 탭 직후엔 내 공격 로그만 추가되고 적 반격 로그는 아직 없으며 지연 중 버튼이 disabled, (2) 750ms 후 적 반격 로그 추가, (3) 적 HP가 0이 된 순간에도 phase는 여전히 `battling`으로 유지되다가 지연 후 `resolved`로 전환, (4) 파티 화면의 몬스터별 최대 HP가 트레이너 보너스(+20)까지 정확히 반영된 값으로 표시(수정 전엔 카드 base 값만 표시).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_