### PR TITLE
feat(game): 파티 규모 3→6장 + 기본 선택을 저평가 점수 낮은 카드부터로 변경

### DIFF
--- a/cf-idiotquant/app/(game)/game/combatEngine.ts
+++ b/cf-idiotquant/app/(game)/game/combatEngine.ts
@@ -103,11 +103,42 @@ export function enemyForFloor(pool: any[], floor: number, encounter: EnemyEncoun
   return { item, stats, sectorType: sectorType(item), hp: maxHp, maxHp, nextAttack: attack, encounter };
 }
 
-// 파티 몬스터 공통 기술 템플릿 — 각 몬스터 자기 카드 스탯(attack/shield)으로 스케일된 4기술을
-// 갖는다(공격 약/강·방어·회복). PP는 기술마다 다른 예산을 둬 사용 판단에 무게를 준다.
-export function monsterSkills(stats: CardStats): SkillDef[] {
+// 육성(진화) — 파티 몬스터는 이번 런에서 전투로 얻는 경험치(xp)만큼 유아기→청년기→성인으로
+// 성장한다(런 종료 시 리셋, 계정에 영구 저장되지 않음). xp는 PartyMember에 그대로 저장하고
+// 단계/보정 스탯은 항상 이 파생 함수들로만 계산 — 저장된 값과 어긋나는 걸 원천 차단하기 위함
+// (파티 HP 표시 버그 때와 같은 이유).
+export type GrowthStage = 0 | 1 | 2;
+export const STAGE_LABELS = ["유아기", "청년기", "성인"] as const;
+const STAGE_XP_THRESHOLDS: [number, number, number] = [0, 50, 150];
+const STAGE_STAT_MULT = [1, 1.25, 1.5];
+export const XP_PER_MONSTER_ATTACK = 3; // 공격 기술 사용마다
+export const WIN_XP_BONUS = 15; // 층 클리어(승리) 시 추가
+
+export function stageForXp(xp: number): GrowthStage {
+  if (xp >= STAGE_XP_THRESHOLDS[2]) return 2;
+  if (xp >= STAGE_XP_THRESHOLDS[1]) return 1;
+  return 0;
+}
+// 성장 단계만큼 보정된 실전투 스탯 — monsterSkills/HP 계산 전부 이 값을 쓴다(원본 stats는
+// 카드 자체 base로 절대 안 건드림).
+export function growthStats(stats: CardStats, xp: number): CardStats {
+  const mult = STAGE_STAT_MULT[stageForXp(xp)];
+  return { attack: Math.max(1, Math.round(stats.attack * mult)), shield: Math.max(1, Math.round(stats.shield * mult)) };
+}
+export function growthMaxHp(stats: CardStats, xp: number): number {
+  return PARTY_BASE_HP + growthStats(stats, xp).shield * HP_PER_SHIELD_PLAYER;
+}
+
+// 파티 몬스터 공통 기술 템플릿 — 각 몬스터 자기 카드 스탯(attack/shield, 성장 보정 반영)으로
+// 스케일된 4기술을 갖는다(공격 약/강·방어·회복). 성인(stage 2)이 되면 "약공격"이 훨씬 강한
+// "필살기"로 바뀐다(해금) — 그리드가 정확히 4칸이라 5번째를 늘리는 대신 교체하는 방식.
+// PP는 기술마다 다른 예산을 둬 사용 판단에 무게를 준다.
+export function monsterSkills(stats: CardStats, stage: GrowthStage = 0): SkillDef[] {
+  const atk1: SkillDef = stage >= 2
+    ? { id: "ultimate", name: "필살기", effect: "attack", power: Math.round(stats.attack * 2.5), maxPP: 5 }
+    : { id: "atk1", name: "약공격", effect: "attack", power: stats.attack, maxPP: 20 };
   return [
-    { id: "atk1", name: "약공격", effect: "attack", power: stats.attack, maxPP: 20 },
+    atk1,
     { id: "atk2", name: "강공격", effect: "attack", power: Math.round(stats.attack * 1.8), maxPP: 10 },
     { id: "def1", name: "방어", effect: "shield", power: stats.shield, maxPP: 20 },
     { id: "heal1", name: "회복", effect: "heal", power: Math.max(1, Math.round((stats.attack + stats.shield) / 2)), maxPP: 8 },
@@ -115,7 +146,7 @@ export function monsterSkills(stats: CardStats): SkillDef[] {
 }
 
 // 던전 입장 시 파티 구성 — 파티 설정 화면에서 유저가 고른 카드(최대 PARTY_SIZE장, 순서 무관)를
-// 그대로 쓰고, 부족하면 STARTER_MONSTERS로 채운다. 런 내내 고정(중간 합류/이탈 없음).
+// 그대로 쓰고, 부족하면 STARTER_MONSTERS로 채운다. 런 내내 고정(중간 합류/이탈 없음), xp는 0부터.
 export function buildParty(chosenCards: any[]): PartyMember[] {
   const members: PartyMember[] = chosenCards.slice(0, PARTY_SIZE).map(card => {
     const stats = cardStats(card);
@@ -123,7 +154,7 @@ export function buildParty(chosenCards: any[]): PartyMember[] {
     return {
       instanceId: `p_${card.ticker}`, ticker: String(card.ticker), name: String(card.name),
       tone: computeValueScore(card).tone, sectorType: sectorType(card),
-      stats, hp: maxHp, maxHp,
+      stats, hp: maxHp, maxHp, xp: 0,
     };
   });
   let i = 0;
@@ -132,7 +163,7 @@ export function buildParty(chosenCards: any[]): PartyMember[] {
     const maxHp = PARTY_BASE_HP + starter.stats.shield * HP_PER_SHIELD_PLAYER;
     members.push({
       instanceId: `starter_${i}`, ticker: `STARTER${i}`, name: starter.name,
-      tone: "explore", sectorType: null, stats: starter.stats, hp: maxHp, maxHp,
+      tone: "explore", sectorType: null, stats: starter.stats, hp: maxHp, maxHp, xp: 0,
     });
     i++;
   }

--- a/cf-idiotquant/app/(game)/game/gameData.ts
+++ b/cf-idiotquant/app/(game)/game/gameData.ts
@@ -4,8 +4,8 @@
 import { computeValueScore } from "@/lib/utils/valueScore";
 import type { ItemDef, CardStats } from "./gameTypes";
 
-// 파티 규모 — 계정 덱(수집 카드) 중 우수한 상위 N장으로 던전 진입 시 파티를 구성.
-export const PARTY_SIZE = 3;
+// 파티 규모 — 던전 입장 전 파티 설정 화면에서 유저가 계정 덱 중 최대 이 수만큼 직접 고른다.
+export const PARTY_SIZE = 6;
 
 // 덱에 카드가 PARTY_SIZE보다 적을 때 채워 넣는 기본 몬스터(계정 덱엔 저장되지 않는 합성 스탯).
 // 실제 수집 카드보다 확실히 약하게 잡아 수집 동기를 유지한다.

--- a/cf-idiotquant/app/(game)/game/gameTypes.ts
+++ b/cf-idiotquant/app/(game)/game/gameTypes.ts
@@ -58,9 +58,10 @@ export interface PartyMember {
   name: string;
   tone: string; // computeValueScore(item).tone — 파티 화면 배지 색상용
   sectorType: string | null; // sectorTypes.sectorType(item) — 무속성이면 null
-  stats: CardStats;
+  stats: CardStats; // 카드 자체 base(육성 성장 미반영) — combatEngine.growthStats로 xp만큼 보정해서 씀
   hp: number;
-  maxHp: number;
+  maxHp: number; // 카드 자체 base maxHp(육성/트레이너 보너스 미반영) — 화면 표시는 파생값을 씀
+  xp: number; // 이번 런에서 이 몬스터가 쌓은 성장 경험치(런 종료 시 리셋) — combatEngine.stageForXp로 단계 산출
 }
 
 export type ItemKind = "passive" | "active";

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -678,25 +678,25 @@ function GameContent() {
                     {run.battleMenu === "action" ? (
                       <HandView mode="action" onSelectAction={run.selectBattleAction} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
-                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
                         <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} stage={run.activeStage} />
                       </HandView>
                     ) : run.battleMenu === "skills" ? (
                       <HandView mode="skills" skills={run.skills} onPlaySkill={run.useSkill} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
-                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
                         <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} stage={run.activeStage} />
                       </HandView>
                     ) : run.battleMenu === "items" ? (
                       <HandView mode="items" ownedItems={run.ownedItems} ownedDefs={run.ownedDefs} onUseItem={run.useOwnedActiveItem} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
-                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
                         <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} stage={run.activeStage} />
                       </HandView>
                     ) : (
                       <HandView mode="party" party={run.party} activeIndex={run.activeIndex} forced={run.forcedSwitch} onSwitchMember={run.switchMember} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
-                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
+                        bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
                         <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} stage={run.activeStage} />
                       </HandView>
                     )}

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -679,25 +679,25 @@ function GameContent() {
                       <HandView mode="action" onSelectAction={run.selectBattleAction} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} stage={run.activeStage} />
                       </HandView>
                     ) : run.battleMenu === "skills" ? (
                       <HandView mode="skills" skills={run.skills} onPlaySkill={run.useSkill} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} stage={run.activeStage} />
                       </HandView>
                     ) : run.battleMenu === "items" ? (
                       <HandView mode="items" ownedItems={run.ownedItems} ownedDefs={run.ownedDefs} onUseItem={run.useOwnedActiveItem} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} stage={run.activeStage} />
                       </HandView>
                     ) : (
                       <HandView mode="party" party={run.party} activeIndex={run.activeIndex} forced={run.forcedSwitch} onSwitchMember={run.switchMember} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} busy={run.busy}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} stage={run.activeStage} />
                       </HandView>
                     )}
                   </div>
@@ -747,6 +747,7 @@ function GameContent() {
                 { icon: "🗡️", text: <>매 턴 <b className="text-neutral-800 dark:text-neutral-100">전투/파티/아이템/도망치기</b> 중 행동을 골라요. <b className="text-neutral-800 dark:text-neutral-100">전투</b>를 고르면 지금 앞에 나온 몬스터의 기술 4개(약공격·강공격·방어·회복)가 나와요.</> },
                 { icon: "🎲", text: <>공격 기술은 <b className="text-neutral-800 dark:text-neutral-100">0~N 범위</b>로 20면체 주사위를 굴려 피해가 정해지고, 자연 20이면 <b className="text-amber-500 dark:text-amber-400">크리티컬</b>(최대 피해의 2배)! 방어는 블록을, 회복은 HP를 고정치만큼 즉시 채워요.</> },
                 { icon: "⚡", text: <>카드마다 업종이 있고 업종끼리 상성이 있어요 — 상성에서 <b className="text-emerald-600 dark:text-emerald-400">이기면 피해가 1.5배</b>, <b className="text-rose-500">지면 2/3배</b>로 줄어요.</> },
+                { icon: "🐣", text: <>몬스터는 전투에서 공격하거나 층을 클리어할 때마다 경험치를 얻어 <b className="text-neutral-800 dark:text-neutral-100">유아기 → 청년기 → 성인</b>으로 성장해요(이번 던전 한정, 나가면 리셋). 성장할수록 스탯이 오르고 실루엣도 커지며, 성인이 되면 "약공격"이 훨씬 강한 <b className="text-violet-600 dark:text-violet-400">필살기</b>로 진화해요.</> },
                 { icon: "💊", text: <>기술마다 정해진 PP가 있고 쓸 때마다 1씩 줄어요 — <b className="text-neutral-800 dark:text-neutral-100">던전을 도는 내내 유지</b>되며(전투를 이겨도 안 채워짐) 상점의 PP 회복 물약으로만 채울 수 있어요.</> },
                 { icon: "🔄", text: <><b className="text-neutral-800 dark:text-neutral-100">파티</b>에서 다른 몬스터로 교체할 수 있어요(교체도 턴을 소모해 적의 공격을 받아요). 몬스터가 쓰러지면 강제로 다음 몬스터를 골라야 하고, 파티 전원이 쓰러지면 던전이 끝나요.</> },
                 { icon: "🚪", text: <><b className="text-neutral-800 dark:text-neutral-100">도망치기</b>는 이번 층을 포기하고 바로 상점으로 가요. 지금까지 성과를 저장하고 던전에서 나가고 싶으면 상단의 🚪 버튼을 눌러요.</> },

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -489,7 +489,7 @@ function FloorGraph({ nodes }: { nodes: FloorNode[] }) {
   );
 }
 
-// 상단 HUD의 파티 요약 — 3마리를 작은 원으로, 지금 나와있는 몬스터는 링으로 강조하고
+// 상단 HUD의 파티 요약 — 파티원을 작은 원으로, 지금 나와있는 몬스터는 링으로 강조하고
 // 기절한 몬스터는 흐리게. 탭하면 바로 교체되진 않음(정보 표시 전용 — 실제 교체는 행동
 // 메뉴의 "파티"에서).
 function PartyStrip({ party, activeIndex }: { party: PartyMember[]; activeIndex: number }) {
@@ -743,7 +743,7 @@ function GameContent() {
             </div>
             <div className="space-y-3">
               {[
-                { icon: "🧩", text: <>던전 입장 전 <b className="text-neutral-800 dark:text-neutral-100">내 덱</b>에서 최대 3장을 직접 골라 <b className="text-neutral-800 dark:text-neutral-100">파티</b>를 꾸려요(저평가 점수 상위 3장이 기본 선택돼 있어요, 부족하면 기본 몬스터로 채워짐). 카드의 ROE·NCAV가 그대로 몬스터의 공격력·방어력이 돼요.</> },
+                { icon: "🧩", text: <>던전 입장 전 <b className="text-neutral-800 dark:text-neutral-100">내 덱</b>에서 최대 {PARTY_SIZE}장을 직접 골라 <b className="text-neutral-800 dark:text-neutral-100">파티</b>를 꾸려요(저평가 점수가 낮은 카드 {PARTY_SIZE}장이 기본 선택돼 있어요, 부족하면 기본 몬스터로 채워짐). 카드의 ROE·NCAV가 그대로 몬스터의 공격력·방어력이 돼요.</> },
                 { icon: "🗡️", text: <>매 턴 <b className="text-neutral-800 dark:text-neutral-100">전투/파티/아이템/도망치기</b> 중 행동을 골라요. <b className="text-neutral-800 dark:text-neutral-100">전투</b>를 고르면 지금 앞에 나온 몬스터의 기술 4개(약공격·강공격·방어·회복)가 나와요.</> },
                 { icon: "🎲", text: <>공격 기술은 <b className="text-neutral-800 dark:text-neutral-100">0~N 범위</b>로 20면체 주사위를 굴려 피해가 정해지고, 자연 20이면 <b className="text-amber-500 dark:text-amber-400">크리티컬</b>(최대 피해의 2배)! 방어는 블록을, 회복은 HP를 고정치만큼 즉시 채워요.</> },
                 { icon: "⚡", text: <>카드마다 업종이 있고 업종끼리 상성이 있어요 — 상성에서 <b className="text-emerald-600 dark:text-emerald-400">이기면 피해가 1.5배</b>, <b className="text-rose-500">지면 2/3배</b>로 줄어요.</> },
@@ -801,12 +801,12 @@ function GameContent() {
 }
 
 // 던전 입장 전 파티 설정 — 계정 덱에서 최대 PARTY_SIZE장을 직접 고른다(부족분은 스타터로
-// 채워짐, combatEngine.buildParty가 처리). 기본값은 저평가 점수 상위 PARTY_SIZE장을 미리
-// 선택해둬 그냥 바로 입장해도 되게 함(선택이 필수가 아님 — 커스터마이즈는 원할 때만).
+// 채워짐, combatEngine.buildParty가 처리). 기본값은 저평가 점수 하위(수치가 제일 낮은)
+// PARTY_SIZE장을 미리 선택해둬 그냥 바로 입장해도 되게 함(커스터마이즈는 원할 때만).
 function PartySetupScreen({ deck, isLoggedIn, onConfirm }: {
   deck: DeckItem[]; isLoggedIn: boolean; onConfirm: (tickers: string[]) => void;
 }) {
-  const ranked = useMemo(() => [...deck].sort((a, b) => computeValueScore(b).score - computeValueScore(a).score), [deck]);
+  const ranked = useMemo(() => [...deck].sort((a, b) => computeValueScore(a).score - computeValueScore(b).score), [deck]);
   const [selected, setSelected] = useState<string[]>(() => ranked.slice(0, PARTY_SIZE).map(c => c.ticker));
   const touchedRef = useRef(false);
   // deck이 늦게 도착(로그인 직후 등)해도 아직 유저가 손대기 전이면 기본 선택을 다시 계산
@@ -825,7 +825,7 @@ function PartySetupScreen({ deck, isLoggedIn, onConfirm }: {
     <div className="flex-1 min-h-0 flex flex-col">
       <div className="shrink-0 text-center mb-2 px-2">
         <p className="font-black text-neutral-900 dark:text-white">🧩 파티를 꾸리세요</p>
-        <p className="text-[11px] text-neutral-400 mt-0.5 break-keep">최대 {PARTY_SIZE}장까지 고를 수 있어요 — 부족한 자리는 스타터 몬스터로 채워져요</p>
+        <p className="text-[11px] text-neutral-400 mt-0.5 break-keep">최대 {PARTY_SIZE}장까지 고를 수 있어요(기본은 저평가 점수가 낮은 카드부터 선택돼 있어요) — 부족한 자리는 스타터 몬스터로 채워져요</p>
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto space-y-1.5 px-1 pb-2">
         {ranked.length === 0 && (

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -59,13 +59,6 @@ function pickEncounter(roundNum: number): EncounterType {
 
 export const MERCHANT_HEAL_COST = 8;
 const REST_HEAL_FRAC = 0.3;
-// 내 공격 결과를 본 뒤에야 적 반격이 이어지도록(그리고 마지막 타격 결과를 본 뒤에야 다음
-// 스텝으로 넘어가도록) 각 단계 사이에 두는 지연. prefers-reduced-motion이면 대폭 줄인다.
-const RESOLVE_STEP_MS = 750;
-const RESOLVE_STEP_MS_REDUCED = 150;
-function prefersReducedMotion(): boolean {
-  return typeof window !== "undefined" && !!window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
-}
 
 // 진행 중인 런 저장 — 다른 페이지를 다녀와도 이어지도록 함. 카드 데이터가 전부 인라인 스냅샷이라
 // (pool/deck 참조 없음) 그대로 JSON 직렬화/복원이 됨. packOpening/dropped/dropPrompt/saveFail은
@@ -107,15 +100,16 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   const [enemy, setEnemy] = useState<EnemyState | null>(null);
   const [skillPp, setSkillPp] = useState<SkillState[]>([]); // 던전 진행 내내 유지(전투 승리로 안 채워짐) — PP 물약으로만 회복
   const [battleMenu, setBattleMenu] = useState<BattleMenu>("action"); // 전투 중 하위 화면 — 매 내 턴마다 "action"에서 시작
-  // 내 행동 결과를 보여주는 중(→ 잠시 뒤 적 반격, 또는 마지막 타격 결과를 보여주는 중 → 잠시
-  // 뒤 다음 페이즈)에는 true — 그 사이 추가 입력을 막아 두 이벤트가 겹쳐 보이지 않게 한다.
-  const [turnBusy, setTurnBusy] = useState(false);
-  const pendingTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
-  const scheduleLater = useCallback((fn: () => void) => {
-    const id = setTimeout(fn, prefersReducedMotion() ? RESOLVE_STEP_MS_REDUCED : RESOLVE_STEP_MS);
-    pendingTimersRef.current.push(id);
-  }, []);
-  useEffect(() => () => { pendingTimersRef.current.forEach(clearTimeout); }, []);
+  // 내 행동(또는 적 반격) 결과를 보여준 뒤, 다음 단계(적 반격/행동 메뉴 복귀/강제 교체/게임오버)로
+  // 넘어가는 로직을 담아뒀다가 플레이어가 직접 다시 탭해야만(advancePendingAction) 실행되는
+  // 함수. null이면 대기 중인 다음 단계가 없다는 뜻(=평소처럼 행동 메뉴 등을 보여줌). 로그가
+  // 타이머로 순식간에 지나가버리지 않도록 자동 진행 대신 이 방식을 쓴다.
+  const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
+  const advancePendingAction = useCallback(() => {
+    if (!pendingAction) return;
+    setPendingAction(null);
+    pendingAction();
+  }, [pendingAction]);
 
   const { character, characterLoaded, gainXp } = useCharacter();
   const [lastPlayerRoll, setLastPlayerRoll] = useState<AttackRollResult | null>(null);
@@ -304,8 +298,8 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
 
   // 적의 반격 처리 공통 로직 — 내 행동 직후(resolveTurn) 또는 자발적 파티 교체 직후(switchMember)
   // 양쪽에서 호출. 반격 자체는 즉시 계산해 로그·HP를 반영하지만(전투 화면엔 그 결과가 곧바로
-  // 보임), 그다음 단계(행동 메뉴 복귀·강제 교체·런 종료)로 넘어가는 건 한 박자 늦춰서 이 반격의
-  // 결과를 눈으로 볼 시간을 준다.
+  // 보임), 그다음 단계(행동 메뉴 복귀·강제 교체·런 종료)로 넘어가는 건 pendingAction에 담아둬서
+  // 플레이어가 직접 탭해야만 실행되게 한다.
   const applyEnemyTurn = useCallback((afterPlayer: PlayerState, afterEnemy: EnemyState, member: PartyMember, idx: number, currentParty: PartyMember[]) => {
     const { player: finalPlayer, roll, effectiveness } = resolveEnemyTurn(afterPlayer, afterEnemy, passive, afterEnemy.sectorType, member.sectorType);
     setLastEnemyRoll(roll);
@@ -318,8 +312,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setParty(prev => prev.map((m, i) => i === idx ? { ...m, hp: finalPlayer.hp } : m));
     if (finalPlayer.hp <= 0) {
       const hasReserve = currentParty.some((m, i) => i !== idx && m.hp > 0);
-      scheduleLater(() => {
-        setTurnBusy(false);
+      setPendingAction(() => () => {
         if (hasReserve) {
           pushLog("system", `💥 ${member.name}이(가) 쓰러졌습니다! 다음 몬스터를 선택하세요.`);
           setBattleMenu("party");
@@ -329,32 +322,31 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       });
       return;
     }
-    scheduleLater(() => { setTurnBusy(false); setBattleMenu("action"); });
-  }, [passive, pushLog, scheduleLater]);
+    setPendingAction(() => () => setBattleMenu("action"));
+  }, [passive, pushLog]);
 
   // 내 행동(기술/아이템) 직후 적 턴을 진행 — 1행동=1턴이라 별도 "턴 종료" 버튼이 없고, 기술/
   // 아이템을 쓴 함수들이 마지막에 이 함수 하나로 마무리한다. afterPlayer/afterEnemy는 이미 그
-  // 행동의 효과(데미지/블록/회복)까지 반영된 상태 — 그 결과를 먼저 화면에 반영해 한 박자 보여준
-  // 뒤에야(scheduleLater) 적 반격(또는 승리 처리)으로 넘어간다.
+  // 행동의 효과(데미지/블록/회복)까지 반영된 상태 — 그 결과를 먼저 화면에 반영해두고, 적 반격
+  // (또는 승리 처리)은 pendingAction으로 넘겨 플레이어가 다시 탭할 때까지 기다린다.
   const resolveTurn = useCallback((afterPlayer: PlayerState, afterEnemy: EnemyState) => {
     setEnemy(afterEnemy);
     const idx = activeIndex, member = partyRaw[idx];
     if (!member) return;
     setParty(prev => prev.map((m, i) => i === idx ? { ...m, hp: afterPlayer.hp } : m));
     setPlayerHp(afterPlayer.hp); setPlayerBlock(afterPlayer.block);
-    setTurnBusy(true);
     if (checkOutcome(afterPlayer, afterEnemy) === "win") {
-      scheduleLater(() => { setTurnBusy(false); handleWin(afterEnemy, encounter, roundNum); });
+      setPendingAction(() => () => handleWin(afterEnemy, encounter, roundNum));
       return;
     }
-    scheduleLater(() => applyEnemyTurn(afterPlayer, afterEnemy, member, idx, partyRaw));
-  }, [activeIndex, partyRaw, encounter, roundNum, handleWin, applyEnemyTurn, scheduleLater]);
+    setPendingAction(() => () => applyEnemyTurn(afterPlayer, afterEnemy, member, idx, partyRaw));
+  }, [activeIndex, partyRaw, encounter, roundNum, handleWin, applyEnemyTurn]);
 
   // 기술 발동 — 행동 메뉴에서 "전투"를 고른 뒤 기술 목록에서 탭하면 즉시. PP 소진 시 무시.
   // 공격 기술은 주사위로 굴려서 데미지가 정해지고(+업종 상성 배율), 방어/회복 기술은 고정치를
   // 바로 적용.
   const useSkill = useCallback((skillId: string) => {
-    if (phase !== "battling" || !enemy || !activeMember || turnBusy) return;
+    if (phase !== "battling" || !enemy || !activeMember || pendingAction) return;
     const skill = skills.find(s => s.def.id === skillId);
     if (!skill || skill.pp <= 0) return;
     const result = engUseSkillEffect(player, enemy, skill.def, passive, effectiveStats, activeMember.sectorType, enemy.sectorType);
@@ -380,12 +372,12 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       pushLog("player", `${activeMember.name}의 ${skill.def.name}! (PP ${nextPp}/${skill.def.maxPP}) — ❤️${skill.def.power} 회복`);
     }
     resolveTurn(result.player, result.enemy);
-  }, [phase, enemy, activeMember, activeIndex, skills, passive, player, effectiveStats, turnBusy, pushLog, gainXp, grantMonsterXp, resolveTurn]);
+  }, [phase, enemy, activeMember, activeIndex, skills, passive, player, effectiveStats, pendingAction, pushLog, gainXp, grantMonsterXp, resolveTurn]);
 
   // 액티브 아이템 즉시 발동(1회 소모) — 행동 메뉴에서 "아이템"을 고른 뒤 사용. 기술과 동일하게
   // 사용 즉시 턴을 소모.
   const useOwnedActiveItem = useCallback((instanceId: string) => {
-    if (phase !== "battling" || !enemy || turnBusy) return;
+    if (phase !== "battling" || !enemy || pendingAction) return;
     const owned = ownedItems.find(o => o.instanceId === instanceId);
     const def = owned && ALL_ITEMS.find(d => d.id === owned.defId);
     if (!owned || !def || def.kind !== "active") return;
@@ -394,13 +386,13 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setOwnedItems(prev => prev.filter(o => o.instanceId !== instanceId));
     pushLog("item", `🎒 ${def.name} 사용 — ${def.desc}`);
     resolveTurn(r.player, r.enemy);
-  }, [phase, enemy, ownedItems, player, skillPp, skillDefsByOwner, turnBusy, pushLog, resolveTurn]);
+  }, [phase, enemy, ownedItems, player, skillPp, skillDefsByOwner, pendingAction, pushLog, resolveTurn]);
 
   // 파티 교체 — 강제(활성 몬스터 기절 직후, battleMenu==="party"이고 player.hp<=0)면 턴을 소모하지
   // 않고 곧바로 행동 선택으로 복귀. 자발적(행동 메뉴 "파티"에서 직접 선택)이면 실제 기술처럼 턴을
   // 소모해 곧바로 적의 공격을 받는다(교체에 대가가 있어야 유의미한 선택이 됨).
   const switchMember = useCallback((instanceId: string) => {
-    if (phase !== "battling" || turnBusy) return;
+    if (phase !== "battling" || pendingAction) return;
     const idx = partyRaw.findIndex(m => m.instanceId === instanceId);
     if (idx < 0 || idx === activeIndex) return;
     const member = partyRaw[idx];
@@ -412,17 +404,16 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     pushLog("system", `🔄 ${member.name}이(가) 앞으로 나섭니다!`);
     if (forced) { setBattleMenu("action"); return; }
     if (!enemy) { setBattleMenu("action"); return; }
-    // 자발적 교체도 턴을 소모 — "교체됨" 결과를 한 박자 보여준 뒤에야 적의 반격으로 넘어간다.
-    setTurnBusy(true);
-    scheduleLater(() => applyEnemyTurn({ hp: member.hp, maxHp: growthMaxHp(member.stats, member.xp) + passiveVitBonus, block: passive.blockPerTurn }, enemy, member, idx, partyRaw));
-  }, [phase, partyRaw, activeIndex, playerHp, passive, passiveVitBonus, enemy, turnBusy, pushLog, applyEnemyTurn, scheduleLater]);
+    // 자발적 교체도 턴을 소모 — "교체됨" 결과를 보여준 뒤 플레이어가 탭해야 적의 반격으로 넘어간다.
+    setPendingAction(() => () => applyEnemyTurn({ hp: member.hp, maxHp: growthMaxHp(member.stats, member.xp) + passiveVitBonus, block: passive.blockPerTurn }, enemy, member, idx, partyRaw));
+  }, [phase, partyRaw, activeIndex, playerHp, passive, passiveVitBonus, enemy, pendingAction, pushLog, applyEnemyTurn]);
 
   // 행동 메뉴 선택 — 전투(기술 목록)/파티(교체)/아이템(보유 아이템 목록)은 하위 화면 전환만,
   // 도망치기는 곧바로 던전 상태를 바꾸는 액션. 던전 나가기(구 "월드맵")는 이제 행동 메뉴가
   // 아니라 상단 HUD의 상시 버튼(cashOut)으로 이동했다 — 정확히 4칸인 메뉴에 파티 교체 자리를
   // 마련하기 위함.
   const selectBattleAction = useCallback((action: "fight" | "party" | "item" | "flee") => {
-    if (phase !== "battling" || turnBusy) return;
+    if (phase !== "battling" || pendingAction) return;
     if (action === "fight") setBattleMenu("skills");
     else if (action === "party") setBattleMenu("party");
     else if (action === "item") setBattleMenu("items");
@@ -430,8 +421,8 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       pushLog("system", "🏃 전투에서 도망쳐 이번 층을 포기했습니다.");
       setEnemy(null); setBattleMenu("action"); setPhase("shop");
     }
-  }, [phase, turnBusy, pushLog]);
-  const backToActionMenu = useCallback(() => { if (playerHp > 0 && !turnBusy) setBattleMenu("action"); }, [playerHp, turnBusy]);
+  }, [phase, pendingAction, pushLog]);
+  const backToActionMenu = useCallback(() => { if (playerHp > 0 && !pendingAction) setBattleMenu("action"); }, [playerHp, pendingAction]);
 
   // 다음 라운드 진입 — 조우 판정 후 배틀(적 생성) 또는 이벤트(휴식). 기술 PP는 손대지 않음
   // (던전 진행 내내 유지, 회복은 상점 물약으로만). 활성 몬스터는 층 클리어 시점에 항상 생존 중
@@ -547,7 +538,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   return {
     phase, roundNum, encounter, restHealed, gold, best, newBest,
     ownedItems, ownedDefs, itemChoices, passive, unlockedLegendItems, activeBoost,
-    player, enemy, party, activeIndex, activeStage, forcedSwitch, busy: turnBusy, skills, battleMenu, log,
+    player, enemy, party, activeIndex, activeStage, forcedSwitch, pending: pendingAction !== null, advance: advancePendingAction, skills, battleMenu, log,
     lastResult, dropped, dropPrompt, saveFail, packOpening, acquired, acquirePct,
     character, effectiveStats, lastPlayerRoll, lastEnemyRoll,
     start, promptNewRun, useSkill, useOwnedActiveItem, switchMember, selectBattleAction, backToActionMenu, nextRound, proceedFromEvent, proceedFromShop, cashOut,

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -10,7 +10,7 @@ import {
   enemyForFloor, buildParty, monsterSkills, useSkillEffect as engUseSkillEffect,
   resolveEnemyTurn, useActiveItem as engUseActiveItem, checkOutcome, aggregatePassive,
   bossExtraChoiceChance,
-  VIT_HP_MULTIPLIER,
+  VIT_HP_MULTIPLIER, stageForXp, growthStats, growthMaxHp, STAGE_LABELS, XP_PER_MONSTER_ATTACK, WIN_XP_BONUS,
 } from "./combatEngine";
 import { ALL_ITEMS, ITEM_OFFER_COUNT, PP_POTION_ITEM_ID, PP_POTION_COST, pickItemChoices, acquireChance } from "./gameData";
 import { ACHIEVEMENTS } from "./gameCollectibles";
@@ -160,20 +160,21 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   }), [character.stats, passive]);
 
   const activeMember = partyRaw[activeIndex] ?? null;
-  // 활성 몬스터의 최대 HP = 카드 자체 base(파티 구성 시 고정) + 트레이너 공용 보너스(패시브
-  // maxHpBonus + 체력 스탯) — 몬스터를 교체해도 이 공용 보너스는 그대로 따라붙는다. maxHp는
-  // 항상 파생값으로만 계산하고 별도 state로 들고 있지 않는다(교체 시 증분 적용 같은 동기화
-  // 버그를 원천 차단하기 위함 — state로 들고 있으면 교체마다 직접 갱신해야 해서 어긋나기 쉬움).
+  const activeStage = activeMember ? stageForXp(activeMember.xp) : 1;
+  // 활성 몬스터의 최대 HP = 카드 자체 base를 성장 단계(xp)만큼 보정한 값(growthMaxHp) +
+  // 트레이너 공용 보너스(패시브 maxHpBonus + 체력 스탯) — 몬스터를 교체해도 이 공용 보너스는
+  // 그대로 따라붙는다. maxHp는 항상 파생값으로만 계산하고 별도 state로 들고 있지 않는다(교체·
+  // 성장 시 증분 적용 같은 동기화 버그를 원천 차단하기 위함).
   const passiveVitBonus = passive.maxHpBonus + effectiveStats.vit * VIT_HP_MULTIPLIER;
-  const activeMaxHp = activeMember ? activeMember.maxHp + passiveVitBonus : 0;
+  const activeMaxHp = activeMember ? growthMaxHp(activeMember.stats, activeMember.xp) + passiveVitBonus : 0;
   const player: PlayerState = useMemo(() => ({ hp: playerHp, maxHp: activeMaxHp, block: playerBlock }), [playerHp, activeMaxHp, playerBlock]);
 
-  // party(state)의 maxHp는 카드 자체 base만 담고 있어(트레이너 공용 보너스 미포함) — 그걸 그대로
-  // 파티 화면/HUD에 표시하면 활성 몬스터의 경우 캔버스 HP바(player.maxHp, 보너스 포함)와 숫자가
-  // 어긋나 보였다(예: 25/20처럼 hp가 maxHp를 넘는 표기). 화면에 보여줄 땐 전원에게 똑같이
-  // passiveVitBonus를 더한 파생 뷰를 쓴다 — 활성 몬스터는 activeMaxHp와 정확히 같은 값이 된다.
+  // party(state)의 maxHp는 카드 자체 base만 담고 있어(성장·트레이너 공용 보너스 미포함) — 그걸
+  // 그대로 파티 화면/HUD에 표시하면 활성 몬스터의 경우 캔버스 HP바(player.maxHp, 보너스 포함)와
+  // 숫자가 어긋나 보였다. 화면에 보여줄 땐 각자의 성장 단계(growthMaxHp)에 트레이너 공용
+  // 보너스(passiveVitBonus)까지 더한 파생 뷰를 쓴다 — 활성 몬스터는 activeMaxHp와 정확히 같아짐.
   const party: PartyMember[] = useMemo(
-    () => partyRaw.map(m => ({ ...m, maxHp: m.maxHp + passiveVitBonus })),
+    () => partyRaw.map(m => ({ ...m, maxHp: growthMaxHp(m.stats, m.xp) + passiveVitBonus })),
     [partyRaw, passiveVitBonus],
   );
 
@@ -187,11 +188,17 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     prevBonusRef.current = passiveVitBonus;
   }, [passiveVitBonus, activeMaxHp]);
 
-  const skillDefs = useMemo(() => activeMember ? monsterSkills(activeMember.stats) : [], [activeMember]);
+  const skillDefs = useMemo(
+    () => activeMember ? monsterSkills(growthStats(activeMember.stats, activeMember.xp), stageForXp(activeMember.xp)) : [],
+    [activeMember],
+  );
   const skills = useMemo(() => skillDefs.map(def => ({
     def, pp: skillPp.find(s => s.ownerId === activeMember?.instanceId && s.skillId === def.id)?.pp ?? def.maxPP,
   })), [skillDefs, skillPp, activeMember]);
-  const skillDefsByOwner = useMemo(() => new Map(partyRaw.map(m => [m.instanceId, monsterSkills(m.stats)])), [partyRaw]);
+  const skillDefsByOwner = useMemo(
+    () => new Map(partyRaw.map(m => [m.instanceId, monsterSkills(growthStats(m.stats, m.xp), stageForXp(m.xp))])),
+    [partyRaw],
+  );
 
   const started = useRef(false); // 자동 새 런 시작 가드 — 아래 복원이 성공하면 true로 설정해 덮어쓰지 않게 함
 
@@ -204,19 +211,22 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       if (!raw) return;
       const saved: SavedRun = JSON.parse(raw);
       if (!saved || !saved.party || saved.party.length === 0 || !saved.phase || saved.phase === "over") return;
+      // 육성(진화) 기능 이전에 저장된 v2 스키마는 party 원소에 xp 필드가 없다 — 없으면 0(유아기)
+      // 으로 채워서 복원(스키마 자체를 또 올릴 만큼 큰 변경은 아니라 여기서 방어적으로 보정).
+      const restoredParty = saved.party.map(m => ({ ...m, xp: m.xp ?? 0 }));
       setPhase(saved.phase); setRoundNum(saved.roundNum); setEncounter(saved.encounter);
       setRestHealed(saved.restHealed); setGold(saved.gold); setNewBest(saved.newBest ?? false);
       setOwnedItems(saved.ownedItems ?? []);
       setItemChoices(saved.itemChoices ?? null);
       setActiveBoost(saved.activeBoost ?? null);
-      setParty(saved.party); setActiveIndex(saved.activeIndex ?? 0);
+      setParty(restoredParty); setActiveIndex(saved.activeIndex ?? 0);
       setPlayerHp(saved.playerHp); setPlayerBlock(saved.playerBlock ?? 0);
       setEnemy(saved.enemy);
       // saved.skillPp가 비어있으면(스키마 손상 등) 기술별 PP를 추적할 항목이 하나도 없어 이후
       // .map() 갱신이 대상을 못 찾고 조용히 무시되는 버그가 과거에 있었음(구 단일 캐릭터 스키마
       // 때) — 그때는 복원된 파티 기준으로 풀피 새로 채워서 복원한다.
       setSkillPp(saved.skillPp && saved.skillPp.length > 0 ? saved.skillPp
-        : saved.party.flatMap(m => monsterSkills(m.stats).map(def => ({ ownerId: m.instanceId, skillId: def.id, pp: def.maxPP }))));
+        : restoredParty.flatMap(m => monsterSkills(growthStats(m.stats, m.xp), stageForXp(m.xp)).map(def => ({ ownerId: m.instanceId, skillId: def.id, pp: def.maxPP }))));
       setBattleMenu(saved.battleMenu ?? "action");
       setLog(saved.log ?? []);
       setLastResult(saved.lastResult ?? null);
@@ -225,11 +235,27 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     } catch { /* 손상된 저장값은 무시하고 새 런으로 진행 */ }
   }, []);
 
+  // 육성(진화) — 이번 런에서 몬스터별로 쌓이는 경험치(파티 xp)를 지급. 유아기→청년기→성인
+  // 경계를 넘으면 로그를 남긴다(스탯/기술 변화는 growthStats·monsterSkills가 xp를 다시 읽어
+  // 자동 반영하므로 여기선 xp 갱신 + 알림만 하면 됨).
+  const grantMonsterXp = useCallback((idx: number, amount: number) => {
+    const member = partyRaw[idx];
+    if (!member) return;
+    const prevStage = stageForXp(member.xp);
+    const nextXp = member.xp + amount;
+    const nextStage = stageForXp(nextXp);
+    setParty(prev => prev.map((m, i) => i === idx ? { ...m, xp: nextXp } : m));
+    if (nextStage > prevStage) {
+      pushLog("system", `✨ ${member.name}이(가) ${STAGE_LABELS[nextStage]}(으)로 진화했습니다! 스탯이 오르고 기술이 강해졌어요.`);
+    }
+  }, [partyRaw, pushLog]);
+
   // 승리(층 클리어) 공통 처리 — 최고기록·골드·아이템 제공·카드 수집 판정
   const handleWin = useCallback((beatenEnemy: EnemyState, enc: EncounterType, floor: number) => {
     const nt = floor + 1; // 클리어한 층수(0-indexed floor → 1부터)
     pushLog("system", `🏆 ${beatenEnemy.item?.name ?? "적"}을(를) 처치했습니다!`);
     gainXp(killXpFor(beatenEnemy.item));
+    grantMonsterXp(activeIndex, WIN_XP_BONUS);
     if (nt > best) {
       setBest(nt); setNewBest(true);
       try { localStorage.setItem(bestKey, String(nt)); } catch { }
@@ -274,7 +300,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
         setSaveFail(deckFailReason(res));
       }
     }).catch(() => setSaveFail("네트워크 오류"));
-  }, [best, isLoggedIn, availableItemPool, unlockedLegendItems, setDeck, activeBoost, pushLog, gainXp, effectiveStats.luk]);
+  }, [best, isLoggedIn, availableItemPool, unlockedLegendItems, setDeck, activeBoost, pushLog, gainXp, effectiveStats.luk, activeIndex, grantMonsterXp]);
 
   // 적의 반격 처리 공통 로직 — 내 행동 직후(resolveTurn) 또는 자발적 파티 교체 직후(switchMember)
   // 양쪽에서 호출. 반격 자체는 즉시 계산해 로그·HP를 반영하지만(전투 화면엔 그 결과가 곧바로
@@ -332,7 +358,14 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     const skill = skills.find(s => s.def.id === skillId);
     if (!skill || skill.pp <= 0) return;
     const result = engUseSkillEffect(player, enemy, skill.def, passive, effectiveStats, activeMember.sectorType, enemy.sectorType);
-    setSkillPp(prev => prev.map(s => s.ownerId === activeMember.instanceId && s.skillId === skillId ? { ...s, pp: s.pp - 1 } : s));
+    // 성장으로 기술셋이 바뀌면(성인 진화로 "약공격"→"필살기" 등) skillPp에 그 skillId 항목이
+    // 아직 없을 수 있음 — .map()만으론 못 찾아 조용히 무시되므로(과거 PP 버그와 같은 원인)
+    // 없으면 새로 추가하는 upsert로 처리.
+    setSkillPp(prev => {
+      const idx = prev.findIndex(s => s.ownerId === activeMember.instanceId && s.skillId === skillId);
+      if (idx >= 0) { const next = [...prev]; next[idx] = { ...next[idx], pp: next[idx].pp - 1 }; return next; }
+      return [...prev, { ownerId: activeMember.instanceId, skillId, pp: skill.def.maxPP - 1 }];
+    });
     const nextPp = skill.pp - 1;
     const effTxt = result.effectiveness === "super" ? " 업종 상성 우위!" : result.effectiveness === "weak" ? " 업종 상성 열세..." : "";
     if (result.roll) {
@@ -340,13 +373,14 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       setLastPlayerRoll(result.roll);
       const critTxt = result.roll.isCrit ? " 💥크리티컬!" : "";
       pushLog("player", `${activeMember.name}의 ${skill.def.name}! (PP ${nextPp}/${skill.def.maxPP}) — 🎲${result.roll.faces.join("/")}${critTxt}${effTxt} → ⚔${result.roll.totalDamage} 피해`);
+      grantMonsterXp(activeIndex, XP_PER_MONSTER_ATTACK);
     } else if (skill.def.effect === "shield") {
       pushLog("player", `${activeMember.name}의 ${skill.def.name}! (PP ${nextPp}/${skill.def.maxPP}) — 🛡${skill.def.power} 방어`);
     } else {
       pushLog("player", `${activeMember.name}의 ${skill.def.name}! (PP ${nextPp}/${skill.def.maxPP}) — ❤️${skill.def.power} 회복`);
     }
     resolveTurn(result.player, result.enemy);
-  }, [phase, enemy, activeMember, skills, passive, player, effectiveStats, turnBusy, pushLog, gainXp, resolveTurn]);
+  }, [phase, enemy, activeMember, activeIndex, skills, passive, player, effectiveStats, turnBusy, pushLog, gainXp, grantMonsterXp, resolveTurn]);
 
   // 액티브 아이템 즉시 발동(1회 소모) — 행동 메뉴에서 "아이템"을 고른 뒤 사용. 기술과 동일하게
   // 사용 즉시 턴을 소모.
@@ -380,7 +414,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     if (!enemy) { setBattleMenu("action"); return; }
     // 자발적 교체도 턴을 소모 — "교체됨" 결과를 한 박자 보여준 뒤에야 적의 반격으로 넘어간다.
     setTurnBusy(true);
-    scheduleLater(() => applyEnemyTurn({ hp: member.hp, maxHp: member.maxHp + passiveVitBonus, block: passive.blockPerTurn }, enemy, member, idx, partyRaw));
+    scheduleLater(() => applyEnemyTurn({ hp: member.hp, maxHp: growthMaxHp(member.stats, member.xp) + passiveVitBonus, block: passive.blockPerTurn }, enemy, member, idx, partyRaw));
   }, [phase, partyRaw, activeIndex, playerHp, passive, passiveVitBonus, enemy, turnBusy, pushLog, applyEnemyTurn, scheduleLater]);
 
   // 행동 메뉴 선택 — 전투(기술 목록)/파티(교체)/아이템(보유 아이템 목록)은 하위 화면 전환만,
@@ -513,7 +547,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   return {
     phase, roundNum, encounter, restHealed, gold, best, newBest,
     ownedItems, ownedDefs, itemChoices, passive, unlockedLegendItems, activeBoost,
-    player, enemy, party, activeIndex, forcedSwitch, busy: turnBusy, skills, battleMenu, log,
+    player, enemy, party, activeIndex, activeStage, forcedSwitch, busy: turnBusy, skills, battleMenu, log,
     lastResult, dropped, dropPrompt, saveFail, packOpening, acquired, acquirePct,
     character, effectiveStats, lastPlayerRoll, lastEnemyRoll,
     start, promptNewRun, useSkill, useOwnedActiveItem, switchMember, selectBattleAction, backToActionMenu, nextRound, proceedFromEvent, proceedFromShop, cashOut,

--- a/cf-idiotquant/components/game/CombatScene.ts
+++ b/cf-idiotquant/components/game/CombatScene.ts
@@ -181,6 +181,8 @@ function playerBody(col: number, row: number): boolean {
   return false;
 }
 const PLAYER_PALETTE = makePalette(0xb45309, 0x431407); // 가죽 갑옷 톤(호박빛 브라운)
+// 육성 단계(0=유아기/1=청년기/2=성인)별 실루엣 배율 — setPlayerStage에서 사용.
+const GROWTH_STAGE_SCALE = [0.72, 1, 1.3];
 
 // Phaser의 Text는 자체 해상도(resolution)로 텍스처를 굽는데 기본값 1이라 고밀도(레티나)
 // 모바일 화면에서 흐릿하게 보임 — devicePixelRatio만큼 올려서 선명하게 그린다(과도한 메모리
@@ -210,6 +212,7 @@ export default class CombatScene extends Phaser.Scene {
   private playerHpTag!: Phaser.GameObjects.Text;
   private playerCenterX = 0; private playerCenterY = 0;
   private playerHpBarX = 0; private playerHpBarY = 0; private playerHpBarW = 0;
+  private playerStage: number | null = null; // 육성 단계 — setPlayerStage 참고
 
   private introText!: Phaser.GameObjects.Text;
   private spec!: MonsterSpec;
@@ -405,6 +408,19 @@ export default class CombatScene extends Phaser.Scene {
 
   setPlayerHp(hp: number, maxHp: number) {
     this.drawHpBar(this.playerHpGfx, this.playerHpNumText, this.playerHpBarX, this.playerHpBarY, this.playerHpBarW, hp, maxHp);
+  }
+
+  // 육성(진화) — 유아기/청년기/성인 단계별로 실루엣 크기를 다르게 스케일(작게→기본→크게)해서
+  // 자라는 느낌을 준다. 실제로 단계가 바뀔 때만(최초 마운트 제외) 반짝임 연출을 곁들인다.
+  setPlayerStage(stage: number) {
+    if (this.playerStage === stage) return;
+    const first = this.playerStage === null;
+    this.playerStage = stage;
+    const scale = GROWTH_STAGE_SCALE[stage] ?? 1;
+    this.tweens.killTweensOf(this.playerGfx);
+    if (first) { this.playerGfx.setScale(scale); return; }
+    this.tweens.add({ targets: this.playerGfx, scale, duration: 380, ease: "Back.easeOut" });
+    this.cameras.main.flash(220, 253, 224, 71); // 옅은 금색 플래시로 진화 순간 강조
   }
 
   // 살아있는 느낌을 주는 대기 애니메이션 — 위치를 옮기는 트윈 대신 몇 개 픽셀만 주기적으로

--- a/cf-idiotquant/components/game/HandView.tsx
+++ b/cf-idiotquant/components/game/HandView.tsx
@@ -137,7 +137,7 @@ function ItemMenu({ ownedItems, ownedDefs, onUse, onBack, busy }: {
 }
 
 // 파티 교체 — forced(활성 몬스터가 방금 기절)면 취소 화살표를 없애 반드시 하나를 골라야 함.
-// 3마리 고정이라 그리드 4칸 중 하나는 항상 빈 자리로 남는다.
+// 파티가 6마리라 2x2 그리드엔 안 들어가서 ItemMenu와 같은 가로 스크롤 스트립으로 나열한다.
 function PartyMenu({ party, activeIndex, forced, onSwitch, onBack, busy }: {
   party: PartyMember[]; activeIndex: number; forced: boolean;
   onSwitch: (instanceId: string) => void; onBack: () => void; busy: boolean;
@@ -145,14 +145,14 @@ function PartyMenu({ party, activeIndex, forced, onSwitch, onBack, busy }: {
   return (
     <>
       {!forced && <BackColumn onBack={onBack} disabled={busy} />}
-      <Grid2x2>
+      <div className="flex items-center gap-1 h-full w-[168px] shrink-0 overflow-x-auto">
         {party.map((m, i) => {
           const fainted = m.hp <= 0;
           const isActive = i === activeIndex;
           const usable = !fainted && !isActive && !busy;
           return (
             <button key={m.instanceId} type="button" disabled={!usable} onClick={() => onSwitch(m.instanceId)}
-              className={cn(CELL_CLASS, usable ? CELL_ON : CELL_OFF)}>
+              className={cn(CELL_CLASS, "w-16 shrink-0", usable ? CELL_ON : CELL_OFF)}>
               <p className="text-[8px] font-bold text-neutral-500 dark:text-neutral-400 truncate w-full text-center">
                 {isActive ? "▶ " : ""}{m.name}
               </p>
@@ -163,10 +163,7 @@ function PartyMenu({ party, activeIndex, forced, onSwitch, onBack, busy }: {
             </button>
           );
         })}
-        <div className={cn(CELL_CLASS, CELL_OFF)}>
-          <span className="text-[8px] font-bold text-neutral-400">빈 자리</span>
-        </div>
-      </Grid2x2>
+      </div>
     </>
   );
 }

--- a/cf-idiotquant/components/game/HandView.tsx
+++ b/cf-idiotquant/components/game/HandView.tsx
@@ -10,6 +10,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { SkillDef, ItemDef, OwnedItem, PartyMember } from "@/app/(game)/game/gameTypes";
+import { stageForXp, STAGE_LABELS } from "@/app/(game)/game/combatEngine";
 
 type SkillRuntime = { def: SkillDef; pp: number };
 
@@ -159,7 +160,7 @@ function PartyMenu({ party, activeIndex, forced, onSwitch, onBack, busy }: {
               <span className={cn("text-[8px] font-black tabular-nums", fainted ? "text-neutral-400" : "text-emerald-600 dark:text-emerald-400")}>
                 {fainted ? "기절" : `${m.hp}/${m.maxHp}`}
               </span>
-              <span className="text-[7px] font-bold text-neutral-400 truncate w-full text-center">{m.sectorType ?? "무속성"}</span>
+              <span className="text-[7px] font-bold text-neutral-400 truncate w-full text-center">{STAGE_LABELS[stageForXp(m.xp)]} · {m.sectorType ?? "무속성"}</span>
             </button>
           );
         })}

--- a/cf-idiotquant/components/game/HandView.tsx
+++ b/cf-idiotquant/components/game/HandView.tsx
@@ -15,7 +15,9 @@ import { stageForXp, STAGE_LABELS } from "@/app/(game)/game/combatEngine";
 type SkillRuntime = { def: SkillDef; pp: number };
 
 const TYPE_SPEED_MS = 22; // 글자당 출력 간격 — 포켓몬 특유의 또박또박 타자기 속도
-function MessageBox({ text }: { text: string }) {
+// pending(다음 단계가 탭 대기 중)이면 텍스트박스 자체도 탭 가능하게 하고 우하단에 깜빡이는
+// "▼" 표시를 붙인다 — 포켓몬 클래식 메시지창의 "다음 텍스트 대기" 관습.
+function MessageBox({ text, pending, onAdvance }: { text: string; pending?: boolean; onAdvance?: () => void }) {
   const chars = useMemo(() => Array.from(text ?? ""), [text]);
   const [count, setCount] = useState(chars.length);
   useEffect(() => {
@@ -30,11 +32,26 @@ function MessageBox({ text }: { text: string }) {
     return () => clearInterval(id);
   }, [chars]);
   return (
-    <div className="flex-1 min-w-0 h-20 rounded-lg border-2 border-neutral-800 dark:border-neutral-200 bg-white dark:bg-[#1a1a1a] px-2.5 py-2 overflow-hidden">
+    <div onClick={pending ? onAdvance : undefined}
+      className={cn("relative flex-1 min-w-0 h-20 rounded-lg border-2 border-neutral-800 dark:border-neutral-200 bg-white dark:bg-[#1a1a1a] px-2.5 py-2 overflow-hidden",
+        pending && "cursor-pointer")}>
       <p className="text-[11px] leading-snug font-bold text-neutral-800 dark:text-neutral-100 break-keep">
         {chars.slice(0, count).join("")}
       </p>
+      {pending && <span aria-hidden className="absolute right-2 bottom-1 text-neutral-400 dark:text-neutral-500 animate-bounce">▼</span>}
     </div>
+  );
+}
+
+// 내 행동 결과(또는 마지막 타격 결과)를 보여준 채로 다음 단계(적 반격 등)를 탭할 때까지 붙잡아
+// 두는 프롬프트 — 그리드 자리를 통째로 대체해서 그 사이엔 다른 선택지를 아예 누를 수 없게 한다.
+function AdvancePrompt({ onAdvance }: { onAdvance: () => void }) {
+  return (
+    <button type="button" onClick={onAdvance}
+      className="h-full w-[168px] shrink-0 rounded-md border border-black/10 dark:border-white/15 bg-white/90 dark:bg-white/[0.08] flex flex-col items-center justify-center gap-0.5 active:scale-95 transition-transform">
+      <span aria-hidden className="text-lg leading-none animate-bounce">▶</span>
+      <span className="text-[9px] font-bold text-neutral-500 dark:text-neutral-400">탭해서 계속</span>
+    </button>
   );
 }
 
@@ -44,11 +61,10 @@ const CELL_OFF = "bg-black/[0.03] dark:bg-white/[0.02] border-black/5 dark:borde
 
 // 포켓몬 배틀 메뉴의 상시 취소 화살표(그리드 칸을 하나 차지하지 않고 옆에 따로 붙어 있음)를
 // 흉내낸 슬림 세로 버튼 — skills/items/party(강제 아닐 때만) 모드에서 노출.
-function BackColumn({ onBack, disabled }: { onBack: () => void; disabled?: boolean }) {
+function BackColumn({ onBack }: { onBack: () => void }) {
   return (
-    <button type="button" disabled={disabled} onClick={onBack} aria-label="뒤로"
-      className={cn("shrink-0 w-6 h-full rounded-md border border-black/10 dark:border-white/15 bg-white/70 dark:bg-white/[0.06] text-neutral-500 dark:text-neutral-400 flex items-center justify-center active:scale-95 transition-transform",
-        disabled && "opacity-40 cursor-not-allowed")}>
+    <button type="button" onClick={onBack} aria-label="뒤로"
+      className="shrink-0 w-6 h-full rounded-md border border-black/10 dark:border-white/15 bg-white/70 dark:bg-white/[0.06] text-neutral-500 dark:text-neutral-400 flex items-center justify-center active:scale-95 transition-transform">
       <span aria-hidden className="text-sm leading-none">◀</span>
     </button>
   );
@@ -66,11 +82,11 @@ const ACTIONS: { id: "fight" | "party" | "item" | "flee"; icon: string; label: s
   { id: "item", icon: "🎒", label: "아이템" },
   { id: "flee", icon: "🏃", label: "도망치기" },
 ];
-function ActionMenu({ onSelect, busy }: { onSelect: (action: "fight" | "party" | "item" | "flee") => void; busy: boolean }) {
+function ActionMenu({ onSelect }: { onSelect: (action: "fight" | "party" | "item" | "flee") => void }) {
   return (
     <Grid2x2>
       {ACTIONS.map(a => (
-        <button key={a.id} type="button" disabled={busy} onClick={() => onSelect(a.id)} className={cn(CELL_CLASS, busy ? CELL_OFF : CELL_ON)}>
+        <button key={a.id} type="button" onClick={() => onSelect(a.id)} className={cn(CELL_CLASS, CELL_ON)}>
           <span aria-hidden className="text-base leading-none">{a.icon}</span>
           <p className="text-[9px] font-bold text-neutral-600 dark:text-neutral-300 text-center leading-tight mt-0.5">{a.label}</p>
         </button>
@@ -80,13 +96,13 @@ function ActionMenu({ onSelect, busy }: { onSelect: (action: "fight" | "party" |
 }
 
 const EFFECT_ICON = { attack: "⚔", shield: "🛡", heal: "❤️" } as const;
-function SkillMenu({ skills, onPlay, onBack, busy }: { skills: SkillRuntime[]; onPlay: (skillId: string) => void; onBack: () => void; busy: boolean }) {
+function SkillMenu({ skills, onPlay, onBack }: { skills: SkillRuntime[]; onPlay: (skillId: string) => void; onBack: () => void }) {
   return (
     <>
-      <BackColumn onBack={onBack} disabled={busy} />
+      <BackColumn onBack={onBack} />
       <Grid2x2>
         {skills.map(({ def, pp }) => {
-          const usable = pp > 0 && !busy;
+          const usable = pp > 0;
           return (
             <button key={def.id} type="button" disabled={!usable} onClick={() => onPlay(def.id)}
               className={cn(CELL_CLASS, usable ? CELL_ON : CELL_OFF)}>
@@ -105,12 +121,12 @@ function SkillMenu({ skills, onPlay, onBack, busy }: { skills: SkillRuntime[]; o
   );
 }
 
-function ItemMenu({ ownedItems, ownedDefs, onUse, onBack, busy }: {
-  ownedItems: OwnedItem[]; ownedDefs: ItemDef[]; onUse: (instanceId: string) => void; onBack: () => void; busy: boolean;
+function ItemMenu({ ownedItems, ownedDefs, onUse, onBack }: {
+  ownedItems: OwnedItem[]; ownedDefs: ItemDef[]; onUse: (instanceId: string) => void; onBack: () => void;
 }) {
   return (
     <>
-      <BackColumn onBack={onBack} disabled={busy} />
+      <BackColumn onBack={onBack} />
       <div className="flex items-center gap-1 h-full w-[168px] shrink-0 overflow-x-auto">
         {ownedItems.length === 0 && (
           <div className={cn(CELL_CLASS, CELL_OFF, "w-full")}>
@@ -120,7 +136,7 @@ function ItemMenu({ ownedItems, ownedDefs, onUse, onBack, busy }: {
         {ownedItems.map(o => {
           const def = ownedDefs.find(d => d.id === o.defId);
           if (!def) return null;
-          const usable = def.kind === "active" && !busy;
+          const usable = def.kind === "active";
           return (
             <button key={o.instanceId} type="button" disabled={!usable} onClick={() => onUse(o.instanceId)}
               className={cn(CELL_CLASS, "w-16 shrink-0", usable ? CELL_ON : CELL_OFF)}>
@@ -139,18 +155,18 @@ function ItemMenu({ ownedItems, ownedDefs, onUse, onBack, busy }: {
 
 // 파티 교체 — forced(활성 몬스터가 방금 기절)면 취소 화살표를 없애 반드시 하나를 골라야 함.
 // 파티가 6마리라 2x2 그리드엔 안 들어가서 ItemMenu와 같은 가로 스크롤 스트립으로 나열한다.
-function PartyMenu({ party, activeIndex, forced, onSwitch, onBack, busy }: {
+function PartyMenu({ party, activeIndex, forced, onSwitch, onBack }: {
   party: PartyMember[]; activeIndex: number; forced: boolean;
-  onSwitch: (instanceId: string) => void; onBack: () => void; busy: boolean;
+  onSwitch: (instanceId: string) => void; onBack: () => void;
 }) {
   return (
     <>
-      {!forced && <BackColumn onBack={onBack} disabled={busy} />}
+      {!forced && <BackColumn onBack={onBack} />}
       <div className="flex items-center gap-1 h-full w-[168px] shrink-0 overflow-x-auto">
         {party.map((m, i) => {
           const fainted = m.hp <= 0;
           const isActive = i === activeIndex;
-          const usable = !fainted && !isActive && !busy;
+          const usable = !fainted && !isActive;
           return (
             <button key={m.instanceId} type="button" disabled={!usable} onClick={() => onSwitch(m.instanceId)}
               className={cn(CELL_CLASS, "w-16 shrink-0", usable ? CELL_ON : CELL_OFF)}>
@@ -190,9 +206,10 @@ type HandViewProps = {
   topLeftOverlay?: React.ReactNode;
   bottomRightOverlay?: React.ReactNode;
   children: React.ReactNode;
-  // 내 행동 결과를 보여주고 적 반격으로 넘어가는 사이(또는 마지막 타격 결과를 보여주고 다음
-  // 페이즈로 넘어가는 사이) true — 그 사이엔 모든 선택지를 비활성화해 입력이 겹치지 않게 한다.
-  busy?: boolean;
+  // 내 행동 결과(또는 마지막 타격 결과)를 보여준 채로 다음 단계(적 반격 등)가 유저의 탭을
+  // 기다리는 중이면 true — 그 사이엔 그리드 자리를 AdvancePrompt 하나로 통째로 대체한다.
+  pending?: boolean;
+  onAdvance?: () => void;
 } & (
   | { mode: "action"; onSelectAction: (action: "fight" | "party" | "item" | "flee") => void }
   | { mode: "skills"; skills: SkillRuntime[]; onPlaySkill: (skillId: string) => void; onBack: () => void }
@@ -201,21 +218,22 @@ type HandViewProps = {
 );
 
 export default function HandView(props: HandViewProps) {
-  const { message, topLeftOverlay, bottomRightOverlay, children, busy = false } = props;
+  const { message, topLeftOverlay, bottomRightOverlay, children, pending = false, onAdvance } = props;
   return (
     <>
       <div className="flex-1 min-h-0">
         <Battlefield topLeftOverlay={topLeftOverlay} bottomRightOverlay={bottomRightOverlay}>{children}</Battlefield>
       </div>
       {/* 포켓몬 클래식 구도 — 왼쪽은 메시지 텍스트박스(타자기 효과), 오른쪽은 선택 그리드
-          (전투/파티/아이템/도망치기 또는 기술/아이템/파티원 목록). 전부 h-20으로 높이를 맞춰서
-          모드가 바뀌어도 이 행 전체 높이가 안 흔들린다. */}
+          (전투/파티/아이템/도망치기 또는 기술/아이템/파티원 목록, pending이면 AdvancePrompt로
+          대체). 전부 h-20으로 높이를 맞춰서 모드가 바뀌어도 이 행 전체 높이가 안 흔들린다. */}
       <div className="shrink-0 flex items-stretch gap-1.5 py-1.5">
-        <MessageBox text={message} />
-        {props.mode === "action" ? <ActionMenu onSelect={props.onSelectAction} busy={busy} />
-          : props.mode === "skills" ? <SkillMenu skills={props.skills} onPlay={props.onPlaySkill} onBack={props.onBack} busy={busy} />
-            : props.mode === "items" ? <ItemMenu ownedItems={props.ownedItems} ownedDefs={props.ownedDefs} onUse={props.onUseItem} onBack={props.onBack} busy={busy} />
-              : <PartyMenu party={props.party} activeIndex={props.activeIndex} forced={props.forced} onSwitch={props.onSwitchMember} onBack={props.onBack} busy={busy} />}
+        <MessageBox text={message} pending={pending} onAdvance={onAdvance} />
+        {pending ? <AdvancePrompt onAdvance={onAdvance!} />
+          : props.mode === "action" ? <ActionMenu onSelect={props.onSelectAction} />
+            : props.mode === "skills" ? <SkillMenu skills={props.skills} onPlay={props.onPlaySkill} onBack={props.onBack} />
+              : props.mode === "items" ? <ItemMenu ownedItems={props.ownedItems} ownedDefs={props.ownedDefs} onUse={props.onUseItem} onBack={props.onBack} />
+                : <PartyMenu party={props.party} activeIndex={props.activeIndex} forced={props.forced} onSwitch={props.onSwitchMember} onBack={props.onBack} />}
       </div>
     </>
   );

--- a/cf-idiotquant/components/game/PhaserCombatCanvas.tsx
+++ b/cf-idiotquant/components/game/PhaserCombatCanvas.tsx
@@ -7,11 +7,12 @@
 import { useEffect, useRef } from "react";
 import type { EnemyState, PlayerState } from "@/app/(game)/game/gameTypes";
 
-export default function PhaserCombatCanvas({ enemy, player, playerName, introLabel }: {
+export default function PhaserCombatCanvas({ enemy, player, playerName, introLabel, stage }: {
   enemy: EnemyState | null;
   player: PlayerState;
   playerName: string; // 좌하단 내 캐릭터 정보 박스에 표시(클래스명, 예: "전사")
   introLabel: string | null; // 조우 진입 시 부모가 짧게(한 렌더) 세팅 — 보스/정예만
+  stage: number; // 활성 몬스터의 육성 단계(0=유아기/1=청년기/2=성인) — 실루엣 크기에 반영
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<import("./CombatScene").default | null>(null);
@@ -26,6 +27,8 @@ export default function PhaserCombatCanvas({ enemy, player, playerName, introLab
   latestPlayerRef.current = player;
   const latestPlayerNameRef = useRef(playerName);
   latestPlayerNameRef.current = playerName;
+  const latestStageRef = useRef(stage);
+  latestStageRef.current = stage;
 
   useEffect(() => {
     let disposed = false;
@@ -57,6 +60,7 @@ export default function PhaserCombatCanvas({ enemy, player, playerName, introLab
         }
         scene.setPlayerName?.(latestPlayerNameRef.current);
         scene.setPlayerHp?.(latestPlayerRef.current.hp, latestPlayerRef.current.maxHp);
+        scene.setPlayerStage?.(latestStageRef.current);
       });
       const ro = new ResizeObserver(() => {
         if (!containerRef.current) return;
@@ -97,6 +101,9 @@ export default function PhaserCombatCanvas({ enemy, player, playerName, introLab
 
   // 이름 변경(사실상 초기 1회) — 좌하단 정보 박스 라벨
   useEffect(() => { sceneRef.current?.setPlayerName?.(playerName); }, [playerName]);
+
+  // 육성 단계 변화 — 진화 시 실루엣 크기 변경 + 플래시(최초 마운트 값 반영 시엔 무연출).
+  useEffect(() => { sceneRef.current?.setPlayerStage?.(stage); }, [stage]);
 
   // 플레이어 HP/블록 변화 → 피격/방어 이펙트 + HP바 갱신
   useEffect(() => {


### PR DESCRIPTION
## 작업 내용
- **파티 규모 3 → 6장**: `gameData.PARTY_SIZE`를 6으로 변경. 파티 설정 화면·파티 교체 메뉴·전투 로직 모두 이 상수 하나로 동작해 자동 반영됨
- **기본 선택을 저평가 점수가 낮은 카드부터로 변경**: 기존엔 저평가 점수 상위(가장 좋은) 카드가 기본 선택돼 있었는데, 이제 하위(수치가 제일 낮은) 카드부터 선택되도록 정렬을 반전
- **파티 교체 메뉴 레이아웃 변경**: 기존엔 2x2 고정 그리드(3마리+빈 자리 1칸)였는데 6마리는 안 들어가서, 보유 아이템 목록과 같은 가로 스크롤 스트립으로 교체

## 체크리스트
- [x] 로컬 테스트 완료 (`npx tsc --noEmit`, `npm run build`, Playwright로 실기기 터치 시뮬레이션)
- [x] 보류된 세부 작업 없음

## 참고 사항
- Playwright로 목업 덱(저평가 점수가 뚜렷이 갈리는 8장)을 채운 상태에서 확인: 파티 설정 화면 기본 선택이 정확히 "6/6"이고 점수가 가장 낮은 카드부터 순서대로 체크돼 있음, 확인 버튼을 누르면 그 선택 그대로 파티가 구성됨, 파티 교체 메뉴가 가로 스크롤로 6마리를 전부 보여주고 빈 자리 칸은 더 이상 안 뜸.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_