### PR TITLE
fix(game): 전투 캔버스 배경 흰색 전환 + 기술 시전 이펙트 추가

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -723,25 +723,25 @@ function GameContent() {
                       <HandView mode="action" onSelectAction={run.selectBattleAction} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} lastSkillCast={run.lastSkillCast} />
                       </HandView>
                     ) : run.battleMenu === "skills" ? (
                       <HandView mode="skills" skills={run.skills} onPlaySkill={run.useSkill} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} lastSkillCast={run.lastSkillCast} />
                       </HandView>
                     ) : run.battleMenu === "items" ? (
                       <HandView mode="items" ownedItems={run.ownedItems} ownedDefs={run.ownedDefs} onUseItem={run.useOwnedActiveItem} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} lastSkillCast={run.lastSkillCast} />
                       </HandView>
                     ) : (
                       <HandView mode="party" party={run.party} activeIndex={run.activeIndex} forced={run.forcedSwitch} onSwitchMember={run.switchMember} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} lastSkillCast={run.lastSkillCast} />
                       </HandView>
                     )}
                   </div>

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -15,7 +15,7 @@ import { ALL_ITEMS, RELIC_POOL, ITEM_OFFER_COUNT, START_GOLD, MERCHANT_FREE_POOL
 import { ACHIEVEMENTS } from "./gameCollectibles";
 import type {
   Phase, EncounterType, ItemDef, OwnedItem, EnemyState, PlayerState, ActiveEffect, LogEntry, LogKind,
-  CharacterStats, AttackRollResult, SkillState, BattleMenu, PartyMember, MerchantOfferDef, ActiveBuffs,
+  CharacterStats, AttackRollResult, SkillState, BattleMenu, PartyMember, MerchantOfferDef, ActiveBuffs, SkillEffectKind,
 } from "./gameTypes";
 
 // 떠돌이 상인이 매번 제시하는 오퍼(무료 3 + 유료 3) — 풀 자체가 정확히 6개라 무작위 추첨 없이
@@ -118,6 +118,10 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
 
   const [lastPlayerRoll, setLastPlayerRoll] = useState<AttackRollResult | null>(null);
   const [lastEnemyRoll, setLastEnemyRoll] = useState<AttackRollResult | null>(null);
+  // 기술을 쓴 순간의 Phaser 시전 이펙트 트리거 — seq를 매번 올려서 같은 kind를 연달아 써도
+  // (예: 약공격→약공격) useEffect의 값 변화 감지가 매번 새로 걸리게 한다.
+  const [lastSkillCast, setLastSkillCast] = useState<{ kind: SkillEffectKind; seq: number } | null>(null);
+  const skillCastSeq = useRef(0);
   // 이번 전투에서 레벨업한 종목 목록 — 전투 하나가 끝날 때(handleWin 진입 시점)까지 쌓아뒀다가
   // "resolved" 화면에서 한 번에 보여준다. 다음 전투 시작(advanceToRound/start)에서 비운다.
   const [levelUps, setLevelUps] = useState<{ instanceId: string; name: string; from: number; to: number }[]>([]);
@@ -416,6 +420,8 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
         ? { ...skill.def, power: Math.round(skill.def.power * activeBuffs.def.mult) }
         : skill.def;
     const result = engUseSkillEffect(player, enemy, buffedDef, passive, effectiveStats, activeMember.sectorType, enemy.sectorType);
+    skillCastSeq.current += 1;
+    setLastSkillCast({ kind: skill.def.effect, seq: skillCastSeq.current });
     // 성장으로 기술셋이 바뀌면(성인 진화로 "약공격"→"필살기" 등) skillPp에 그 skillId 항목이
     // 아직 없을 수 있음 — .map()만으론 못 찾아 조용히 무시되므로(과거 PP 버그와 같은 원인)
     // 없으면 새로 추가하는 upsert로 처리.
@@ -640,7 +646,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     merchantOffers, activeBuffs,
     player, enemy, party, activeIndex, activeLevel, passiveVitBonus, forcedSwitch, pending: pendingAction !== null, advance: advancePendingAction, skills, skillDefsByOwner, skillPp, battleMenu, log,
     lastResult, dropped, dropPrompt, saveFail, packOpening, acquired, acquirePct, levelUps,
-    effectiveStats, lastPlayerRoll, lastEnemyRoll,
+    effectiveStats, lastPlayerRoll, lastEnemyRoll, lastSkillCast,
     hasSavedRun, resumeRun,
     start, promptNewRun, useSkill, useOwnedActiveItem, switchMember, selectBattleAction, backToActionMenu, nextRound, proceedFromEvent, proceedFromShop, cashOut,
     applyMerchantOffer, buyBoost, pickItem, skipItem,

--- a/cf-idiotquant/components/game/CombatScene.ts
+++ b/cf-idiotquant/components/game/CombatScene.ts
@@ -112,11 +112,13 @@ const SLIME_PALETTES: Palette[] = [
   makePalette(0x6ee7b7, 0x0f766e), // 시폼
   makePalette(0x84cc16, 0x3f6212), // 올리브
 ];
+// 흰 배경에서도 실루엣이 묻히지 않도록(구 검정 배경 대비 대응) 옛 파스텔 톤보다 한두 단계
+// 진하게 조정 — 여전히 다른 종보다는 창백한 "유령" 톤을 유지.
 const GHOST_PALETTES: Palette[] = [
-  makePalette(0xf1f5f9, 0x94a3b8), // 슬레이트 화이트
-  makePalette(0xe0e7ff, 0x818cf8), // 라벤더
-  makePalette(0xdbeafe, 0x60a5fa), // 스카이 화이트
-  makePalette(0xfae8ff, 0xd8b4fe), // 연보라
+  makePalette(0xcbd5e1, 0x64748b), // 슬레이트
+  makePalette(0xa5b4fc, 0x6366f1), // 라벤더
+  makePalette(0x93c5fd, 0x3b82f6), // 스카이
+  makePalette(0xe9d5ff, 0xc084fc), // 연보라
 ];
 const BAT_PALETTES: Palette[] = [
   makePalette(0x6d28d9, 0x3b0764), // 퍼플
@@ -230,19 +232,19 @@ export default class CombatScene extends Phaser.Scene {
 
   create() {
     const w = this.scale.width, h = this.scale.height;
-    this.cameras.main.setBackgroundColor("#00000000");
+    this.cameras.main.setBackgroundColor("#ffffff");
     this.cell = Math.max(3, Math.floor(Math.min(w * 0.36, h * 0.34) / GRID));
 
     // 적 — 우상단 스프라이트 + 좌상단 정보(이름/HP태그/HP바/수치를 컨테이너로 묶어서 등장 시
     // 한 번에 슬라이드 인 시킴). HP태그("HP" 이탤릭 라벨)가 차지하는 폭만큼 바 자체는 살짝
-    // 줄여서 화면 왼쪽 끝을 벗어나지 않게 한다.
+    // 줄여서 화면 왼쪽 끝을 벗어나지 않게 한다. 흰 배경이라 텍스트는 짙은 색으로.
     const hpTagW = 16;
     this.enemyCenterX = w * 0.74; this.enemyCenterY = h * 0.30;
-    this.enemyLabel = this.add.text(w * 0.05, h * 0.04, "", { fontSize: "12px", color: "#ffffff", fontStyle: "bold", resolution: RES }).setOrigin(0, 0);
+    this.enemyLabel = this.add.text(w * 0.05, h * 0.04, "", { fontSize: "12px", color: "#1f2937", fontStyle: "bold", resolution: RES }).setOrigin(0, 0);
     this.enemyHpBarX = w * 0.05 + hpTagW; this.enemyHpBarY = h * 0.12; this.enemyHpBarW = w * 0.36 - hpTagW;
-    this.enemyHpTag = this.add.text(w * 0.05, this.enemyHpBarY + HP_BAR_H / 2, "HP", { fontSize: "9px", fontStyle: "italic", color: "#fde047", resolution: RES }).setOrigin(0, 0.5);
+    this.enemyHpTag = this.add.text(w * 0.05, this.enemyHpBarY + HP_BAR_H / 2, "HP", { fontSize: "9px", fontStyle: "italic", color: "#b45309", resolution: RES }).setOrigin(0, 0.5);
     this.enemyHpGfx = this.add.graphics();
-    this.enemyHpNumText = this.add.text(this.enemyHpBarX + this.enemyHpBarW / 2, this.enemyHpBarY + HP_BAR_H / 2, "", { fontFamily: "monospace", fontSize: "9px", color: "#ffffff", fontStyle: "bold", resolution: RES }).setOrigin(0.5);
+    this.enemyHpNumText = this.add.text(this.enemyHpBarX + this.enemyHpBarW / 2, this.enemyHpBarY + HP_BAR_H / 2, "", { fontFamily: "monospace", fontSize: "9px", color: "#1f2937", fontStyle: "bold", resolution: RES }).setOrigin(0.5);
     this.enemyInfoBox = this.add.container(0, 0, [this.enemyLabel, this.enemyHpTag, this.enemyHpGfx, this.enemyHpNumText]);
     this.enemyInfoRestX = 0;
     this.spec = randomMonster();
@@ -255,13 +257,13 @@ export default class CombatScene extends Phaser.Scene {
     this.playerGfx = this.add.graphics({ x: this.playerCenterX, y: this.playerCenterY });
     this.drawPlayer();
     this.playerHpBarW = w * 0.36 - hpTagW; this.playerHpBarX = w * 0.95 - this.playerHpBarW; this.playerHpBarY = h * 0.86;
-    this.playerHpTag = this.add.text(this.playerHpBarX - 3, this.playerHpBarY + HP_BAR_H / 2, "HP", { fontSize: "9px", fontStyle: "italic", color: "#fde047", resolution: RES }).setOrigin(1, 0.5);
-    this.playerLabel = this.add.text(w * 0.95, this.playerHpBarY - 4, "", { fontSize: "12px", color: "#ffffff", fontStyle: "bold", resolution: RES }).setOrigin(1, 1);
+    this.playerHpTag = this.add.text(this.playerHpBarX - 3, this.playerHpBarY + HP_BAR_H / 2, "HP", { fontSize: "9px", fontStyle: "italic", color: "#b45309", resolution: RES }).setOrigin(1, 0.5);
+    this.playerLabel = this.add.text(w * 0.95, this.playerHpBarY - 4, "", { fontSize: "12px", color: "#1f2937", fontStyle: "bold", resolution: RES }).setOrigin(1, 1);
     this.playerHpGfx = this.add.graphics();
-    this.playerHpNumText = this.add.text(this.playerHpBarX + this.playerHpBarW / 2, this.playerHpBarY + HP_BAR_H / 2, "", { fontFamily: "monospace", fontSize: "9px", color: "#ffffff", fontStyle: "bold", resolution: RES }).setOrigin(0.5);
+    this.playerHpNumText = this.add.text(this.playerHpBarX + this.playerHpBarW / 2, this.playerHpBarY + HP_BAR_H / 2, "", { fontFamily: "monospace", fontSize: "9px", color: "#1f2937", fontStyle: "bold", resolution: RES }).setOrigin(0.5);
     this.setPlayerHp(0, 1);
 
-    this.introText = this.add.text(w / 2, h / 2, "", { fontSize: "20px", color: "#facc15", fontStyle: "bold", resolution: RES })
+    this.introText = this.add.text(w / 2, h / 2, "", { fontSize: "20px", color: "#d97706", fontStyle: "bold", resolution: RES })
       .setOrigin(0.5).setAlpha(0).setDepth(10);
 
     this.startIdleAnim();
@@ -387,7 +389,7 @@ export default class CombatScene extends Phaser.Scene {
   // 되는 등장 연출을 재생한다(포켓몬의 "야생의 OO가 나타났다!" 등장 모먼트를 흉내).
   setEnemy(name: string, hp: number, maxHp: number, encounter: "battle" | "boss" | "elite" = "battle") {
     const prefix = encounter === "boss" ? "👑 보스 · " : encounter === "elite" ? "🗡️ 정예 · " : "";
-    const color = encounter === "boss" ? "#facc15" : encounter === "elite" ? "#c084fc" : "#ffffff";
+    const color = encounter === "boss" ? "#d97706" : encounter === "elite" ? "#9333ea" : "#1f2937";
     this.enemyLabel.setText(prefix + name).setColor(color);
     this.spec = randomMonster();
     this.blinking = false;
@@ -473,8 +475,38 @@ export default class CombatScene extends Phaser.Scene {
     this.time.delayedCall(700, () => this.tweens.add({ targets: this.introText, alpha: 0, duration: 250 }));
   }
 
+  // 기술을 쓴 순간 재생하는 시전 이펙트 — 결과(피해/블록/회복 숫자)는 이미 HP/블록 변화 감지로
+  // 따로 뜨므로(flashEnemyHit/flashPlayerBlock/playHeal), 여긴 "무엇을 시전했는지"를 즉시
+  // 보여주는 용도. attack은 내 스프라이트가 적 쪽으로 짧게 돌진했다 돌아오는 동작(타격을
+  // 날리는 느낌), shield/heal은 내 스프라이트 둘레로 고리가 번지며 퍼지는 연출.
+  playSkillCast(kind: "attack" | "shield" | "heal") {
+    if (kind === "attack") {
+      const dx = (this.enemyCenterX - this.playerCenterX) * 0.12;
+      const dy = (this.enemyCenterY - this.playerCenterY) * 0.12;
+      this.tweens.killTweensOf(this.playerGfx);
+      const baseScale = this.playerGfx.scaleX;
+      this.tweens.add({
+        targets: this.playerGfx, x: this.playerCenterX + dx, y: this.playerCenterY + dy,
+        scaleX: baseScale * 1.08, scaleY: baseScale * 1.08, duration: 90, yoyo: true, ease: "Quad.easeOut",
+      });
+      return;
+    }
+    this.playPulseRing(kind === "shield" ? 0x60a5fa : 0x4ade80);
+  }
+
+  private playPulseRing(color: number) {
+    const g = this.add.graphics({ x: this.playerCenterX, y: this.playerCenterY }).setDepth(4);
+    g.lineStyle(3, color, 1);
+    g.strokeCircle(0, 0, this.cell * 2.5);
+    g.setScale(0.4).setAlpha(1);
+    this.tweens.add({ targets: g, scale: 1.8, alpha: 0, duration: 450, ease: "Quad.easeOut", onComplete: () => g.destroy() });
+  }
+
   private popText(x: number, y: number, text: string, color: string) {
-    const t = this.add.text(x, y, text, { fontSize: "16px", color, fontStyle: "bold", resolution: RES }).setOrigin(0.5).setDepth(5);
+    const t = this.add.text(x, y, text, {
+      fontSize: "16px", color, fontStyle: "bold", resolution: RES,
+      stroke: "#ffffff", strokeThickness: 4,
+    }).setOrigin(0.5).setDepth(5);
     this.tweens.add({ targets: t, y: y - 30, alpha: 0, duration: 600, ease: "Quad.easeOut", onComplete: () => t.destroy() });
   }
 }

--- a/cf-idiotquant/components/game/PhaserCombatCanvas.tsx
+++ b/cf-idiotquant/components/game/PhaserCombatCanvas.tsx
@@ -5,14 +5,15 @@
 // page.tsx에서 dynamic(..., { ssr:false })로 불러와야 함(Phaser가 window/document를 참조).
 
 import { useEffect, useRef } from "react";
-import type { EnemyState, PlayerState } from "@/app/(game)/game/gameTypes";
+import type { EnemyState, PlayerState, SkillEffectKind } from "@/app/(game)/game/gameTypes";
 
-export default function PhaserCombatCanvas({ enemy, player, playerName, introLabel, level }: {
+export default function PhaserCombatCanvas({ enemy, player, playerName, introLabel, level, lastSkillCast }: {
   enemy: EnemyState | null;
   player: PlayerState;
   playerName: string; // 좌하단 내 캐릭터 정보 박스에 표시(활성 몬스터 이름)
   introLabel: string | null; // 조우 진입 시 부모가 짧게(한 렌더) 세팅 — 보스/정예만
   level: number; // 활성 몬스터의 육성 레벨 — 실루엣 크기에 반영
+  lastSkillCast?: { kind: SkillEffectKind; seq: number } | null; // 기술 시전 이펙트 트리거(seq가 바뀔 때마다 재생)
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const sceneRef = useRef<import("./CombatScene").default | null>(null);
@@ -104,6 +105,12 @@ export default function PhaserCombatCanvas({ enemy, player, playerName, introLab
 
   // 육성 레벨 변화 — 레벨업 시 실루엣 크기 변경 + 플래시(최초 마운트 값 반영 시엔 무연출).
   useEffect(() => { sceneRef.current?.setPlayerLevel?.(level); }, [level]);
+
+  // 기술 시전 이펙트 — seq가 바뀔 때마다(같은 기술을 연달아 써도) 재생.
+  useEffect(() => {
+    if (!lastSkillCast) return;
+    sceneRef.current?.playSkillCast?.(lastSkillCast.kind);
+  }, [lastSkillCast]);
 
   // 플레이어 HP/블록 변화 → 피격/방어 이펙트 + HP바 갱신
   useEffect(() => {


### PR DESCRIPTION
## Summary
- 게임 전투 캔버스 배경을 검정 → 흰색으로 변경(라벨/HP 텍스트를 짙은 색으로 교체해 대비 확보, 흰 배경에서 묻히던 유령 종 팔레트 보정, 팝업 텍스트에 흰 스트로크 추가)
- 기술 사용 시 즉시 재생되는 시전 이펙트 추가: 공격 기술은 캐릭터가 적 쪽으로 짧게 돌진했다 복귀, 방어/회복 기술은 캐릭터 둘레로 고리가 퍼지는 연출

## What changed
- `components/game/CombatScene.ts`: 카메라 배경색 `#ffffff`로 변경, 적/플레이어 이름·HP 수치 텍스트 색을 짙은 색(`#1f2937` 등)으로 교체, 보스/정예 라벨 색상도 흰 배경 기준으로 재조정, 유령(Ghost) 몬스터 팔레트를 한두 단계 진하게 조정(파스텔 톤이 흰 배경에 묻히는 문제 해결), 팝업 텍스트(`popText`)에 흰 스트로크 추가로 어떤 배경에서도 가독성 확보, `playSkillCast(kind)` 메서드 신규 추가(attack=돌진 트윈, shield/heal=고리 펄스 이펙트)
- `app/(game)/game/useGameRun.ts`: `lastSkillCast` 상태 추가(기술 종류 + seq), `useSkill`에서 기술 시전마다 seq를 증가시켜 노출
- `components/game/PhaserCombatCanvas.tsx`: `lastSkillCast` prop 추가, seq 변화를 감지해 `scene.playSkillCast()` 호출
- `app/(game)/game/page.tsx`: 4곳의 `PhaserCombatCanvas` 호출부에 `lastSkillCast={run.lastSkillCast}` 전달

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 성공
- [x] Playwright(모바일 뷰포트, `next start` 프로덕션 빌드 대상): 전투 캔버스 배경이 흰색으로 렌더링되고 이름/HP 텍스트가 짙은 색으로 잘 보임 확인, 유령 종 몬스터가 흰 배경에서도 또렷하게 보임 확인, 공격 기술 사용 시 데미지 반영 + 이펙트 재생 확인(콘솔 에러 없음), 방어 기술 사용 시 블록 수치 반영 + 시전 이펙트 재생 확인(콘솔 에러 없음)


---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_