### PR TITLE
feat(game): 포켓로그급 전투 씬 대격변 — 바이옴 배경 + 상태이상 + 연출/효과음 전면 강화

### DIFF
--- a/cf-idiotquant/app/(game)/game/combatEngine.ts
+++ b/cf-idiotquant/app/(game)/game/combatEngine.ts
@@ -6,7 +6,7 @@ import { sectorType, typeMultiplier } from "./sectorTypes";
 import { PARTY_SIZE, STARTER_MONSTERS } from "./gameData";
 import type {
   CardStats, PassiveEffect, ActiveEffect, ItemDef, EnemyState, PlayerState, SkillDef, SkillState,
-  CharacterStats, AttackRollOptions, AttackRollResult, EnemyEncounter, PartyMember,
+  CharacterStats, AttackRollOptions, AttackRollResult, EnemyEncounter, PartyMember, StatusKind,
 } from "./gameTypes";
 
 const PARTY_BASE_HP = 16;
@@ -53,6 +53,24 @@ export const FLEE_ROLL_THRESHOLD = 11;
 export function rollFlee(): { roll: number; success: boolean } {
   const roll = 1 + Math.floor(Math.random() * 20);
   return { roll, success: roll >= FLEE_ROLL_THRESHOLD };
+}
+
+// 상태이상 — 화상/독은 매 턴 최대 HP 비례 도트 피해, 마비는 행동이 확률로 실패. 부여 주체:
+// 강공격·필살기(플레이어 → 적, 화상), 적의 공격 적중(적 → 내 몬스터, 독/마비 중 랜덤).
+// 이미 상태이상이 있으면 덮어쓰지 않고, 전투가 끝나면(승리·도망 성공) 전부 해제된다.
+export const BURN_DOT_FRAC = 0.06;        // 화상: 매 턴 최대 HP의 6%
+export const POISON_DOT_FRAC = 0.09;      // 독: 매 턴 최대 HP의 9%
+export const PARALYSIS_SKIP_CHANCE = 0.25; // 마비: 행동(기술/적 공격)이 25% 확률로 실패
+export const ENEMY_STATUS_CHANCE = 0.15;  // 적 공격이 피해를 줬을 때 상태이상을 부여할 확률
+export const STATUS_LABELS: Record<StatusKind, { name: string; icon: string }> = {
+  burn: { name: "화상", icon: "🔥" },
+  poison: { name: "독", icon: "💜" },
+  paralysis: { name: "마비", icon: "⚡" },
+};
+export function statusDotDamage(kind: StatusKind, maxHp: number): number {
+  if (kind === "burn") return Math.max(1, Math.ceil(maxHp * BURN_DOT_FRAC));
+  if (kind === "poison") return Math.max(1, Math.ceil(maxHp * POISON_DOT_FRAC));
+  return 0; // 마비는 도트 피해 없음
 }
 
 // 2개 재무 지표(sub, 0~1 clamp01된 정규화 점수 — computeValueScore가 이미 계산)를 전투 스탯
@@ -143,11 +161,11 @@ export function growthMaxHp(stats: CardStats, xp: number): number {
 // PP는 기술마다 다른 예산을 둬 사용 판단에 무게를 준다.
 export function monsterSkills(stats: CardStats, level: number = 1): SkillDef[] {
   const atk1: SkillDef = level >= ULTIMATE_UNLOCK_LEVEL
-    ? { id: "ultimate", name: "필살기", effect: "attack", power: Math.round(stats.attack * 2.5), maxPP: 5 }
+    ? { id: "ultimate", name: "필살기", effect: "attack", power: Math.round(stats.attack * 2.5), maxPP: 5, statusChance: 0.3, statusKind: "burn" }
     : { id: "atk1", name: "약공격", effect: "attack", power: stats.attack, maxPP: 20 };
   return [
     atk1,
-    { id: "atk2", name: "강공격", effect: "attack", power: Math.round(stats.attack * 1.8), maxPP: 10 },
+    { id: "atk2", name: "강공격", effect: "attack", power: Math.round(stats.attack * 1.8), maxPP: 10, statusChance: 0.2, statusKind: "burn" },
     { id: "def1", name: "방어", effect: "shield", power: stats.shield, maxPP: 20 },
     { id: "heal1", name: "회복", effect: "heal", power: Math.max(1, Math.round((stats.attack + stats.shield) / 2)), maxPP: 8 },
   ];

--- a/cf-idiotquant/app/(game)/game/gameTypes.ts
+++ b/cf-idiotquant/app/(game)/game/gameTypes.ts
@@ -33,12 +33,19 @@ export type ActiveEffect =
 // 기본 데미지, shield=고정 블록량, heal=고정 회복량. PP는 던전 진행 내내 유지되며(전투를 이겨도
 // 자동 회복 안 됨) 상점의 PP 회복 물약으로만 채워진다.
 export type SkillEffectKind = "attack" | "shield" | "heal";
+
+// 상태이상 — 화상/독(매 턴 도트 피해), 마비(행동 실패 확률). 포켓몬류 관습을 따르되 3종만.
+// 몸에 붙은 상태이상은 그 전투가 끝나면(승리·도망 성공) 해제된다.
+export type StatusKind = "burn" | "poison" | "paralysis";
+
 export interface SkillDef {
   id: string;
   name: string;
   effect: SkillEffectKind;
   power: number;
   maxPP: number;
+  statusChance?: number;    // 공격 적중 시 상태이상 부여 확률(0~1) — 없으면 부여 안 함
+  statusKind?: StatusKind;  // 부여할 상태이상 종류(statusChance와 함께 지정)
 }
 // ownerId = 그 기술을 가진 파티 몬스터의 PartyMember.instanceId — 몬스터마다 같은 skillId를
 // 재사용하므로(공통 템플릿) PP는 반드시 (ownerId, skillId) 쌍으로 구분해야 한다.
@@ -62,6 +69,7 @@ export interface PartyMember {
   hp: number;
   maxHp: number; // 카드 자체 base maxHp(레벨/트레이너 보너스 미반영) — 화면 표시는 파생값을 씀
   xp: number; // 이번 런에서 이 몬스터가 쌓은 경험치(런 종료 시 리셋) — combatEngine.levelForXp로 레벨 산출
+  status?: StatusKind | null; // 현재 걸린 상태이상 — 전투 종료(승리·도망 성공) 시 해제
 }
 
 export type ItemKind = "passive" | "active";
@@ -111,6 +119,7 @@ export interface EnemyState {
   nextAttack: number; // 주사위 굴림의 base — 실제 피해는 0~nextAttack 범위에서 결정됨
   encounter: EnemyEncounter; // 정예/보스 상시 표시용
   level: number; // winXpFor의 상대 경험치 계산용(층수 + 보스/정예 배율로 산출)
+  status?: StatusKind | null; // 현재 걸린 상태이상 — 적이 쓰러지면 함께 사라짐
 }
 
 export interface PlayerState {

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -22,7 +22,7 @@ import {
   ArrowUp, ArrowDown, Layers, Copy, TrendingUp, Sparkles, ChevronDown, Lock, Info,
   Cpu, Dna, Landmark, CarFront, Ship, Construction, Zap, FlaskConical, Factory, RadioTower, Gamepad2,
   Soup, ShoppingCart, PlaneTakeoff, Shirt, Code2, Gem, Compass, Anchor, Map as MapIcon, Medal as MedalIcon,
-  BatteryCharging, Bot, Wallet, Flame, Trophy, Target, Swords, Crown, Loader2, X,
+  BatteryCharging, Bot, Wallet, Flame, Trophy, Target, Swords, Crown, Loader2, X, Volume2, VolumeX,
   type LucideIcon,
 } from "lucide-react";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
@@ -37,8 +37,10 @@ import { PARTY_SIZE } from "./gameData";
 import { cardStats, levelForXp, LEVEL_XP } from "./combatEngine";
 import { sectorType } from "./sectorTypes";
 import type { PartyMember, MerchantOfferDef, ActiveBuffs, ActiveBuff } from "./gameTypes";
+import { isMuted, setMuted } from "./sfx";
 import { EnemyIntentBadge, ItemBar, StatTile } from "@/components/game/CombatHud";
 import { DiceRow } from "@/components/game/DiceRow";
+import { biomeForFloor } from "@/components/game/biomes";
 
 const PhaserCombatCanvas = dynamic(() => import("@/components/game/PhaserCombatCanvas"), { ssr: false });
 const HandView = dynamic(() => import("@/components/game/HandView"), { ssr: false });
@@ -582,6 +584,12 @@ function GameContent() {
   const [showTutorial, setShowTutorial] = useState(false);
   const [showResultDetail, setShowResultDetail] = useState(false);
   const [introLabel, setIntroLabel] = useState<string | null>(null);
+  // 효과음 음소거 — localStorage와 동기화(초기값은 SSR 하이드레이션 어긋남 방지를 위해 effect에서 읽음)
+  const [soundMuted, setSoundMuted] = useState(false);
+  useEffect(() => { setSoundMuted(isMuted()); }, []);
+  const toggleMute = useCallback(() => {
+    setSoundMuted(prev => { setMuted(!prev); return !prev; });
+  }, []);
 
   useEffect(() => { dispatch(reqGetNcavDailyList("latest")); }, [dispatch]);
   useEffect(() => { for (const src of ALL_SECTOR_IMAGES) { const img = new window.Image(); img.src = src; } }, []);
@@ -677,7 +685,9 @@ function GameContent() {
                   {/* pr-9 — 우측 상단 구석에 고정된 게임 설명 버튼과 안 겹치게 오른쪽 여유 확보 */}
                   <div className="flex items-center justify-center gap-1.5 flex-wrap w-full pr-9">
                     <div className="flex items-center gap-1 pl-2 pr-1 py-1 rounded-2xl backdrop-blur-md bg-white/85 dark:bg-white/[0.06] border border-black/5 dark:border-white/10 shadow-[0_6px_18px_-8px_rgba(0,0,0,0.35)]">
-                      <span className="text-[9px] font-black text-neutral-400 uppercase tracking-wider pr-0.5 whitespace-nowrap">지하{run.roundNum + 1}층</span>
+                      <span className="text-[9px] font-black text-neutral-400 uppercase tracking-wider pr-0.5 whitespace-nowrap">
+                        {biomeForFloor(run.roundNum).emoji} {biomeForFloor(run.roundNum).name} · 지하{run.roundNum + 1}층
+                      </span>
                       <FloorGraph nodes={floorWindow} />
                     </div>
                     {run.phase === "battling" && run.party.length > 0 && (
@@ -723,25 +733,25 @@ function GameContent() {
                       <HandView mode="action" onSelectAction={run.selectBattleAction} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} lastSkillCast={run.lastSkillCast} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} floor={run.roundNum} activeStatus={run.activeStatus} lastSkillCast={run.lastSkillCast} />
                       </HandView>
                     ) : run.battleMenu === "skills" ? (
                       <HandView mode="skills" skills={run.skills} onPlaySkill={run.useSkill} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} lastSkillCast={run.lastSkillCast} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} floor={run.roundNum} activeStatus={run.activeStatus} lastSkillCast={run.lastSkillCast} />
                       </HandView>
                     ) : run.battleMenu === "items" ? (
                       <HandView mode="items" ownedItems={run.ownedItems} ownedDefs={run.ownedDefs} onUseItem={run.useOwnedActiveItem} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} lastSkillCast={run.lastSkillCast} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} floor={run.roundNum} activeStatus={run.activeStatus} lastSkillCast={run.lastSkillCast} />
                       </HandView>
                     ) : (
                       <HandView mode="party" party={run.party} activeIndex={run.activeIndex} forced={run.forcedSwitch} onSwitchMember={run.switchMember} onBack={run.backToActionMenu} message={latestLogText}
                         topLeftOverlay={<DiceRow label="적" roll={run.lastEnemyRoll} isPlayer={false} />}
                         bottomRightOverlay={<DiceRow label="나" roll={run.lastPlayerRoll} isPlayer compact />} pending={run.pending} onAdvance={run.advance}>
-                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} lastSkillCast={run.lastSkillCast} />
+                        <PhaserCombatCanvas enemy={run.enemy} player={run.player} playerName={activeMonsterName} introLabel={introLabel} level={run.activeLevel} floor={run.roundNum} activeStatus={run.activeStatus} lastSkillCast={run.lastSkillCast} />
                       </HandView>
                     )}
                   </div>
@@ -772,10 +782,14 @@ function GameContent() {
         </div>
       </div>
 
-      {/* 게임 설명 버튼 — 화면 우측 상단 구석 */}
+      {/* 게임 설명 · 효과음 토글 버튼 — 화면 우측 상단 구석에 세로로 나란히 */}
       <button type="button" onClick={() => setShowTutorial(true)} aria-label="게임 방법 보기"
         className="absolute top-2 right-2 z-20 inline-flex items-center justify-center w-8 h-8 rounded-full backdrop-blur-md bg-white/85 dark:bg-white/[0.06] border border-black/5 dark:border-white/10 shadow-[0_6px_18px_-8px_rgba(0,0,0,0.35)] text-neutral-500 dark:text-neutral-300 hover:text-[#16a34a] transition-colors">
         <Info size={14} />
+      </button>
+      <button type="button" onClick={toggleMute} aria-label={soundMuted ? "효과음 켜기" : "효과음 끄기"}
+        className="absolute top-11 right-2 z-20 inline-flex items-center justify-center w-8 h-8 rounded-full backdrop-blur-md bg-white/85 dark:bg-white/[0.06] border border-black/5 dark:border-white/10 shadow-[0_6px_18px_-8px_rgba(0,0,0,0.35)] text-neutral-500 dark:text-neutral-300 hover:text-[#16a34a] transition-colors">
+        {soundMuted ? <VolumeX size={14} /> : <Volume2 size={14} />}
       </button>
 
       {/* 방법 안내 */}
@@ -792,6 +806,8 @@ function GameContent() {
                 { icon: "🗡️", text: <>매 턴 <b className="text-neutral-800 dark:text-neutral-100">전투/파티/아이템/도망치기</b> 중 행동을 골라요. <b className="text-neutral-800 dark:text-neutral-100">전투</b>를 고르면 지금 앞에 나온 몬스터의 기술 4개(약공격·강공격·방어·회복)가 나와요. <b className="text-neutral-800 dark:text-neutral-100">도망치기</b>는 주사위를 굴려 성공하면 이번 층을 포기하고 상점으로, 실패하면 턴을 소모해 적의 반격을 받아요.</> },
                 { icon: "🎲", text: <>공격 기술은 <b className="text-neutral-800 dark:text-neutral-100">0~N 범위</b>로 20면체 주사위를 굴려 피해가 정해지고, 자연 20이면 <b className="text-amber-500 dark:text-amber-400">크리티컬</b>(최대 피해의 2배)! 방어는 블록을, 회복은 HP를 고정치만큼 즉시 채워요.</> },
                 { icon: "⚡", text: <>카드마다 업종이 있고 업종끼리 상성이 있어요 — 상성에서 <b className="text-emerald-600 dark:text-emerald-400">이기면 피해가 1.5배</b>, <b className="text-rose-500">지면 2/3배</b>로 줄어요.</> },
+                { icon: "🔥", text: <><b className="text-neutral-800 dark:text-neutral-100">상태이상</b>도 있어요 — 강공격·필살기는 적에게 <b className="text-orange-500">화상</b>(매 턴 도트 피해)을, 적의 공격은 내 몬스터에게 <b className="text-violet-600 dark:text-violet-400">독</b>(도트 피해)이나 <b className="text-amber-500">마비</b>(행동이 확률로 실패)를 걸 수 있어요. 상태이상은 그 전투가 끝나면 회복돼요.</> },
+                { icon: "🌋", text: <>던전은 <b className="text-neutral-800 dark:text-neutral-100">5층마다 바이옴</b>이 바뀌어요 — 초원 → 숲 → 사막 → 설원 → 동굴 → 화산 순환. 상단 HUD에서 지금 바이옴을 확인할 수 있어요.</> },
                 { icon: "🐣", text: <>몬스터는 전투에서 공격하거나 층을 클리어할 때마다 경험치를 얻어 <b className="text-neutral-800 dark:text-neutral-100">레벨업</b>해요(이번 던전 한정, 나가면 리셋 — 레벨업마다 경험치 100 필요). 비슷한 레벨의 적을 이기면 적당히, 더 강한 적을 이기면 더 많이 얻어요. 레벨이 오를수록 스탯이 오르고 실루엣도 커지며, <b className="text-neutral-800 dark:text-neutral-100">Lv.5</b>부터는 "약공격"이 훨씬 강한 <b className="text-violet-600 dark:text-violet-400">필살기</b>로 진화해요. 배틀이 끝나고 레벨업한 종목이 있으면 결과 화면에 표시돼요.</> },
                 { icon: "💊", text: <>기술마다 정해진 PP가 있고 쓸 때마다 1씩 줄어요 — <b className="text-neutral-800 dark:text-neutral-100">던전을 도는 내내 유지</b>되며(전투를 이겨도 안 채워짐) 상점의 PP 회복 물약을 사면 파티 전원의 PP가 즉시 가득 차요.</> },
                 { icon: "🔄", text: <><b className="text-neutral-800 dark:text-neutral-100">파티</b>에서 다른 몬스터로 교체할 수 있어요(교체도 턴을 소모해 적의 공격을 받아요). 몬스터가 쓰러지면 강제로 다음 몬스터를 골라야 하고, 파티 전원이 쓰러지면 던전이 끝나요.</> },

--- a/cf-idiotquant/app/(game)/game/sfx.ts
+++ b/cf-idiotquant/app/(game)/game/sfx.ts
@@ -1,0 +1,62 @@
+"use client";
+
+// 전투 효과음 — 외부 오디오 에셋 없이 WebAudio 오실레이터로 즉석 합성하는 레트로 게임 사운드.
+// 모든 호출은 유저 제스처(버튼 탭) 핸들러 안에서 일어나므로 AudioContext resume 제약과 충돌하지
+// 않는다. SSR/미지원 브라우저/음소거 상태에선 전부 조용히 no-op.
+
+const MUTE_KEY = "iq:game:muted";
+
+let ctx: AudioContext | null = null;
+function ac(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  const AC = window.AudioContext ?? (window as any).webkitAudioContext;
+  if (!AC) return null;
+  if (!ctx) ctx = new AC();
+  if (ctx.state === "suspended") ctx.resume().catch(() => { });
+  return ctx;
+}
+
+export function isMuted(): boolean {
+  if (typeof window === "undefined") return true;
+  try { return localStorage.getItem(MUTE_KEY) === "1"; } catch { return false; }
+}
+export function setMuted(muted: boolean) {
+  try { localStorage.setItem(MUTE_KEY, muted ? "1" : "0"); } catch { }
+}
+
+type ToneOpts = {
+  type?: OscillatorType;
+  vol?: number;
+  slideTo?: number; // 지정하면 재생 동안 주파수가 이 값까지 미끄러짐(타격 낙하음 등)
+  delay?: number;   // 초 단위 시작 지연(아르페지오 구성용)
+};
+function tone(freq: number, dur: number, { type = "square", vol = 0.035, slideTo, delay = 0 }: ToneOpts = {}) {
+  if (isMuted()) return;
+  const a = ac();
+  if (!a) return;
+  const t0 = a.currentTime + delay;
+  const osc = a.createOscillator();
+  const gain = a.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(freq, t0);
+  if (slideTo !== undefined) osc.frequency.exponentialRampToValueAtTime(Math.max(1, slideTo), t0 + dur);
+  gain.gain.setValueAtTime(vol, t0);
+  gain.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+  osc.connect(gain).connect(a.destination);
+  osc.start(t0);
+  osc.stop(t0 + dur + 0.02);
+}
+
+// 이벤트별 사운드 — 전부 짧은(0.1~0.5초) 레트로 톤 조합.
+export const sfx = {
+  attack() { tone(220, 0.12, { type: "square", slideTo: 90 }); },                       // 타격 — 낮게 떨어지는 펀치음
+  crit() { tone(330, 0.09, { slideTo: 120 }); tone(520, 0.14, { delay: 0.05, slideTo: 200, vol: 0.045 }); }, // 크리티컬 — 두 겹 강타
+  shield() { tone(150, 0.16, { type: "triangle", vol: 0.05 }); },                        // 방어 — 둔탁한 저음
+  heal() { [392, 523, 659].forEach((f, i) => tone(f, 0.12, { type: "triangle", delay: i * 0.07 })); }, // 회복 — 올라가는 3음
+  hurt() { tone(180, 0.16, { type: "sawtooth", slideTo: 70, vol: 0.04 }); },             // 피격 — 거친 하강음
+  faint() { tone(300, 0.45, { type: "sawtooth", slideTo: 40, vol: 0.045 }); },           // 기절 — 길게 무너지는 음
+  status() { tone(500, 0.07, { type: "square" }); tone(380, 0.09, { delay: 0.08 }); },   // 상태이상 — 삐빅 경고
+  levelup() { [523, 659, 784, 1047].forEach((f, i) => tone(f, 0.11, { delay: i * 0.08, vol: 0.045 })); }, // 레벨업 팡파르
+  victory() { [523, 523, 784].forEach((f, i) => tone(f, i === 2 ? 0.3 : 0.1, { delay: i * 0.11, vol: 0.045 })); }, // 승리 3음
+  flee() { tone(600, 0.2, { type: "triangle", slideTo: 1200 }); },                       // 도망 — 위로 슝
+};

--- a/cf-idiotquant/app/(game)/game/useGameRun.ts
+++ b/cf-idiotquant/app/(game)/game/useGameRun.ts
@@ -10,12 +10,14 @@ import {
   enemyForFloor, buildParty, monsterSkills, useSkillEffect as engUseSkillEffect,
   resolveEnemyTurn, useActiveItem as engUseActiveItem, checkOutcome, aggregatePassive, rollFlee,
   VIT_HP_MULTIPLIER, levelForXp, growthStats, growthMaxHp, ULTIMATE_UNLOCK_LEVEL, XP_PER_MONSTER_ATTACK, winXpFor,
+  STATUS_LABELS, statusDotDamage, PARALYSIS_SKIP_CHANCE, ENEMY_STATUS_CHANCE,
 } from "./combatEngine";
 import { ALL_ITEMS, RELIC_POOL, ITEM_OFFER_COUNT, START_GOLD, MERCHANT_FREE_POOL, MERCHANT_PAID_POOL, pickItemChoices, acquireChance } from "./gameData";
 import { ACHIEVEMENTS } from "./gameCollectibles";
+import { sfx } from "./sfx";
 import type {
   Phase, EncounterType, ItemDef, OwnedItem, EnemyState, PlayerState, ActiveEffect, LogEntry, LogKind,
-  CharacterStats, AttackRollResult, SkillState, BattleMenu, PartyMember, MerchantOfferDef, ActiveBuffs, SkillEffectKind,
+  CharacterStats, AttackRollResult, SkillState, BattleMenu, PartyMember, MerchantOfferDef, ActiveBuffs, SkillEffectKind, StatusKind,
 } from "./gameTypes";
 
 // 떠돌이 상인이 매번 제시하는 오퍼(무료 3 + 유료 3) — 풀 자체가 정확히 6개라 무작위 추첨 없이
@@ -289,6 +291,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     setParty(prev => prev.map((m, i) => i === idx ? { ...m, xp: nextXp } : m));
     if (nextLevel > prevLevel) {
       const unlockedUltimate = prevLevel < ULTIMATE_UNLOCK_LEVEL && nextLevel >= ULTIMATE_UNLOCK_LEVEL;
+      sfx.levelup();
       pushLog("system", `✨ ${member.name}이(가) Lv.${nextLevel}(으)로 레벨업했습니다!${unlockedUltimate ? " 필살기를 해금했어요!" : ""}`);
       setLevelUps(prev => {
         const i = prev.findIndex(l => l.instanceId === member.instanceId);
@@ -302,6 +305,9 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   const handleWin = useCallback((beatenEnemy: EnemyState, enc: EncounterType, floor: number) => {
     const nt = floor + 1; // 클리어한 층수(0-indexed floor → 1부터)
     pushLog("system", `🏆 ${beatenEnemy.item?.name ?? "적"}을(를) 처치했습니다!`);
+    sfx.victory();
+    // 전투가 끝나면 파티 전원의 상태이상 해제(상태이상은 그 전투 동안만 지속)
+    setParty(prev => prev.some(m => m.status) ? prev.map(m => m.status ? { ...m, status: null } : m) : prev);
     // 승리 경험치는 적 레벨(beatenEnemy.level) 대비 내 몬스터 레벨로 스케일됨(winXpFor) — 적이
     // 더 강하면(레벨이 높으면) 더 많이, 약하면 더 적게 받는다.
     if (activeMember) grantMonsterXp(activeIndex, winXpFor(levelForXp(activeMember.xp), beatenEnemy.level));
@@ -363,16 +369,42 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   // 보임), 그다음 단계(행동 메뉴 복귀·강제 교체·런 종료)로 넘어가는 건 pendingAction에 담아둬서
   // 플레이어가 직접 탭해야만 실행되게 한다.
   const applyEnemyTurn = useCallback((afterPlayer: PlayerState, afterEnemy: EnemyState, member: PartyMember, idx: number, currentParty: PartyMember[]) => {
-    const { player: finalPlayer, roll, effectiveness } = resolveEnemyTurn(afterPlayer, afterEnemy, passive, afterEnemy.sectorType, member.sectorType);
-    setLastEnemyRoll(roll);
-    const blocked = Math.min(roll.totalDamage, afterPlayer.block + passive.damageReduce);
-    const dmg = Math.max(0, roll.totalDamage - blocked);
-    const critTxt = roll.isCrit ? " 💥크리티컬!" : "";
-    const effTxt = effectiveness === "super" ? " (업종 상성 우위!)" : effectiveness === "weak" ? " (업종 상성 열세)" : "";
-    pushLog("enemy", `${afterEnemy.item?.name ?? "적"}의 공격! 🎲${roll.faces.join("/")}${critTxt}${effTxt} → ⚔${roll.totalDamage} 중 🛡${blocked} 경감 → ${dmg} 피해`);
-    setPlayerHp(finalPlayer.hp); setPlayerBlock(finalPlayer.block);
-    setParty(prev => prev.map((m, i) => i === idx ? { ...m, hp: finalPlayer.hp } : m));
-    if (finalPlayer.hp <= 0) {
+    let finalHp: number;
+    // 마비된 적은 확률로 행동 자체가 실패 — 이 경우에도 턴 경계이므로 블록은 다음 턴 기본치로 리셋.
+    if (afterEnemy.status === "paralysis" && Math.random() < PARALYSIS_SKIP_CHANCE) {
+      pushLog("enemy", `⚡ ${afterEnemy.item?.name ?? "적"}은(는) 몸이 저려 움직이지 못한다!`);
+      finalHp = afterPlayer.hp;
+      setPlayerBlock(passive.blockPerTurn);
+    } else {
+      const { player: finalPlayer, roll, effectiveness } = resolveEnemyTurn(afterPlayer, afterEnemy, passive, afterEnemy.sectorType, member.sectorType);
+      setLastEnemyRoll(roll);
+      const blocked = Math.min(roll.totalDamage, afterPlayer.block + passive.damageReduce);
+      const dmg = Math.max(0, roll.totalDamage - blocked);
+      const critTxt = roll.isCrit ? " 💥크리티컬!" : "";
+      const effTxt = effectiveness === "super" ? " (업종 상성 우위!)" : effectiveness === "weak" ? " (업종 상성 열세)" : "";
+      pushLog("enemy", `${afterEnemy.item?.name ?? "적"}의 공격! 🎲${roll.faces.join("/")}${critTxt}${effTxt} → ⚔${roll.totalDamage} 중 🛡${blocked} 경감 → ${dmg} 피해`);
+      if (dmg > 0) sfx.hurt();
+      finalHp = finalPlayer.hp;
+      setPlayerBlock(finalPlayer.block);
+      // 적 공격이 실제 피해를 줬으면 확률적으로 상태이상(독/마비 중 랜덤)을 부여 — 이미 걸려있으면 안 덮어씀.
+      if (dmg > 0 && finalHp > 0 && !member.status && Math.random() < ENEMY_STATUS_CHANCE) {
+        const kind: StatusKind = Math.random() < 0.5 ? "poison" : "paralysis";
+        setParty(prev => prev.map((m, i) => i === idx ? { ...m, status: kind } : m));
+        pushLog("system", `${STATUS_LABELS[kind].icon} ${member.name}은(는) ${STATUS_LABELS[kind].name} 상태가 되었다!`);
+        sfx.status();
+      }
+    }
+    // 내 몬스터의 화상/독 도트 피해 — 적 행동 성공 여부와 무관하게 턴 경계마다 1회. 이번 턴에
+    // 막 걸린 상태이상은 member 스냅샷엔 없으므로 다음 턴부터 아프기 시작한다.
+    if (finalHp > 0 && (member.status === "burn" || member.status === "poison")) {
+      const dot = statusDotDamage(member.status, afterPlayer.maxHp);
+      finalHp = Math.max(0, finalHp - dot);
+      pushLog("system", `${STATUS_LABELS[member.status].icon} ${member.name}은(는) ${STATUS_LABELS[member.status].name} 피해를 입었다! (-${dot})`);
+    }
+    setPlayerHp(finalHp);
+    setParty(prev => prev.map((m, i) => i === idx ? { ...m, hp: finalHp } : m));
+    if (finalHp <= 0) {
+      sfx.faint();
       const hasReserve = currentParty.some((m, i) => i !== idx && m.hp > 0);
       setPendingAction(() => () => {
         if (hasReserve) {
@@ -393,18 +425,26 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
   // (또는 승리 처리)은 pendingAction으로 넘겨 플레이어가 다시 탭할 때까지 기다린다. 상인 버프는
   // 여기서(기술·아이템 사용 공통 지점) 한 턴 소모한다.
   const resolveTurn = useCallback((afterPlayer: PlayerState, afterEnemy: EnemyState) => {
-    setEnemy(afterEnemy);
+    // 적의 화상/독 도트 피해 — 내 행동 하나가 곧 한 턴이므로 여기(턴 경계)서 1회 적용. 도트만으로
+    // 쓰러뜨리는 것도 가능하다(아래 checkOutcome이 도트 반영 후의 HP로 판정).
+    let e = afterEnemy;
+    if (e.hp > 0 && (e.status === "burn" || e.status === "poison")) {
+      const dot = statusDotDamage(e.status, e.maxHp);
+      e = { ...e, hp: Math.max(0, e.hp - dot) };
+      pushLog("system", `${STATUS_LABELS[e.status!].icon} ${e.item?.name ?? "적"}은(는) ${STATUS_LABELS[e.status!].name} 피해를 입었다! (-${dot})`);
+    }
+    setEnemy(e);
     const idx = activeIndex, member = partyRaw[idx];
     if (!member) return;
     setParty(prev => prev.map((m, i) => i === idx ? { ...m, hp: afterPlayer.hp } : m));
     setPlayerHp(afterPlayer.hp); setPlayerBlock(afterPlayer.block);
     tickBuffs();
-    if (checkOutcome(afterPlayer, afterEnemy) === "win") {
-      setPendingAction(() => () => handleWin(afterEnemy, encounter, roundNum));
+    if (checkOutcome(afterPlayer, e) === "win") {
+      setPendingAction(() => () => handleWin(e, encounter, roundNum));
       return;
     }
-    setPendingAction(() => () => applyEnemyTurn(afterPlayer, afterEnemy, member, idx, partyRaw));
-  }, [activeIndex, partyRaw, encounter, roundNum, handleWin, applyEnemyTurn, tickBuffs]);
+    setPendingAction(() => () => applyEnemyTurn(afterPlayer, e, member, idx, partyRaw));
+  }, [activeIndex, partyRaw, encounter, roundNum, handleWin, applyEnemyTurn, tickBuffs, pushLog]);
 
   // 기술 발동 — 행동 메뉴에서 "전투"를 고른 뒤 기술 목록에서 탭하면 즉시. PP 소진 시 무시.
   // 공격 기술은 주사위로 굴려서 데미지가 정해지고(+업종 상성 배율), 방어/회복 기술은 고정치를
@@ -414,6 +454,13 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     if (phase !== "battling" || !enemy || !activeMember || pendingAction) return;
     const skill = skills.find(s => s.def.id === skillId);
     if (!skill || skill.pp <= 0) return;
+    // 마비 — 확률적으로 이번 행동이 통째로 실패(PP는 소모 안 함, 턴만 소모하고 적의 반격을 받음).
+    if (activeMember.status === "paralysis" && Math.random() < PARALYSIS_SKIP_CHANCE) {
+      pushLog("system", `⚡ ${activeMember.name}은(는) 몸이 저려 움직일 수 없다!`);
+      sfx.status();
+      resolveTurn(player, enemy);
+      return;
+    }
     const buffedDef = activeBuffs.atk && skill.def.effect === "attack"
       ? { ...skill.def, power: Math.round(skill.def.power * activeBuffs.atk.mult) }
       : activeBuffs.def && skill.def.effect === "shield"
@@ -422,6 +469,13 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     const result = engUseSkillEffect(player, enemy, buffedDef, passive, effectiveStats, activeMember.sectorType, enemy.sectorType);
     skillCastSeq.current += 1;
     setLastSkillCast({ kind: skill.def.effect, seq: skillCastSeq.current });
+    // 강공격·필살기는 확률적으로 적에게 화상을 입힌다 — 이미 상태이상이 있으면 안 덮어씀.
+    let afterEnemy = result.enemy;
+    if (skill.def.statusChance && skill.def.statusKind && afterEnemy.hp > 0 && !afterEnemy.status && Math.random() < skill.def.statusChance) {
+      afterEnemy = { ...afterEnemy, status: skill.def.statusKind };
+      pushLog("system", `${STATUS_LABELS[skill.def.statusKind].icon} ${enemy.item?.name ?? "적"}은(는) ${STATUS_LABELS[skill.def.statusKind].name} 상태가 되었다!`);
+      sfx.status();
+    }
     // 성장으로 기술셋이 바뀌면(성인 진화로 "약공격"→"필살기" 등) skillPp에 그 skillId 항목이
     // 아직 없을 수 있음 — .map()만으론 못 찾아 조용히 무시되므로(과거 PP 버그와 같은 원인)
     // 없으면 새로 추가하는 upsert로 처리.
@@ -434,15 +488,18 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     const effTxt = result.effectiveness === "super" ? " 업종 상성 우위!" : result.effectiveness === "weak" ? " 업종 상성 열세..." : "";
     if (result.roll) {
       setLastPlayerRoll(result.roll);
+      if (result.roll.isCrit) sfx.crit(); else sfx.attack();
       const critTxt = result.roll.isCrit ? " 💥크리티컬!" : "";
       pushLog("player", `${activeMember.name}의 ${skill.def.name}! (PP ${nextPp}/${skill.def.maxPP}) — 🎲${result.roll.faces.join("/")}${critTxt}${effTxt} → ⚔${result.roll.totalDamage} 피해`);
       grantMonsterXp(activeIndex, XP_PER_MONSTER_ATTACK);
     } else if (skill.def.effect === "shield") {
+      sfx.shield();
       pushLog("player", `${activeMember.name}의 ${skill.def.name}! (PP ${nextPp}/${skill.def.maxPP}) — 🛡${skill.def.power} 방어`);
     } else {
+      sfx.heal();
       pushLog("player", `${activeMember.name}의 ${skill.def.name}! (PP ${nextPp}/${skill.def.maxPP}) — ❤️${skill.def.power} 회복`);
     }
-    resolveTurn(result.player, result.enemy);
+    resolveTurn(result.player, afterEnemy);
   }, [phase, enemy, activeMember, activeIndex, skills, passive, player, effectiveStats, pendingAction, activeBuffs, pushLog, grantMonsterXp, resolveTurn]);
 
   // 액티브 아이템 즉시 발동(1회 소모) — 행동 메뉴에서 "아이템"을 고른 뒤 사용. 기술과 동일하게
@@ -494,8 +551,13 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
       if (!enemy || !activeMember) return;
       const { roll, success } = rollFlee();
       if (success) {
+        sfx.flee();
         pushLog("system", `🏃 도망치는 중... 🎲${roll} → 성공! 이번 층을 포기하고 상점으로 갑니다.`);
-        setPendingAction(() => () => { setEnemy(null); setBattleMenu("action"); setPhase("shop"); });
+        setPendingAction(() => () => {
+          setEnemy(null); setBattleMenu("action"); setPhase("shop");
+          // 전투에서 벗어났으므로 상태이상도 해제(승리 시와 동일한 "전투 동안만" 규칙)
+          setParty(prev => prev.some(m => m.status) ? prev.map(m => m.status ? { ...m, status: null } : m) : prev);
+        });
       } else {
         pushLog("system", `🏃 도망치는 중... 🎲${roll} → 실패했습니다!`);
         setPendingAction(() => () => applyEnemyTurn(player, enemy, activeMember, activeIndex, partyRaw));
@@ -639,6 +701,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
 
   const acquirePct = enemy ? Math.round(Math.min(0.95, acquireChance(enemy.item, roundNum + 1) * (activeBoost?.mult ?? 1)) * 100) : 0;
   const forcedSwitch = playerHp <= 0; // battleMenu==="party"일 때만 의미 있음(그 외엔 항상 false)
+  const activeStatus = activeMember?.status ?? null; // 활성 몬스터의 상태이상 — 캔버스 배지 표시용
 
   return {
     phase, roundNum, encounter, restHealed, gold, best, newBest,
@@ -646,7 +709,7 @@ export function useGameRun(params: { pool: any[]; deck: DeckItem[]; setDeck: (fn
     merchantOffers, activeBuffs,
     player, enemy, party, activeIndex, activeLevel, passiveVitBonus, forcedSwitch, pending: pendingAction !== null, advance: advancePendingAction, skills, skillDefsByOwner, skillPp, battleMenu, log,
     lastResult, dropped, dropPrompt, saveFail, packOpening, acquired, acquirePct, levelUps,
-    effectiveStats, lastPlayerRoll, lastEnemyRoll, lastSkillCast,
+    effectiveStats, lastPlayerRoll, lastEnemyRoll, lastSkillCast, activeStatus,
     hasSavedRun, resumeRun,
     start, promptNewRun, useSkill, useOwnedActiveItem, switchMember, selectBattleAction, backToActionMenu, nextRound, proceedFromEvent, proceedFromShop, cashOut,
     applyMerchantOffer, buyBoost, pickItem, skipItem,

--- a/cf-idiotquant/components/game/CombatScene.ts
+++ b/cf-idiotquant/components/game/CombatScene.ts
@@ -1,17 +1,19 @@
 import Phaser from "phaser";
+import { biomeForFloor, biomeIndexForFloor, type BiomeDef } from "./biomes";
 
-// 가치투자 덱빌더 — 전투 씬(프로토타입 비주얼). 몬스터는 진짜 픽셀 격자(Graphics로 정사각형을
-// 하나하나 찍는 방식)로 그린 귀여운 블롭 캐릭터. 유니코드 글자 기반 ASCII 아트는 폰트마다
-// 모양이 달라지고 못생겨 보인다는 피드백을 받아 폐기하고, 격자 좌표만으로 매번 매끈한 실루엣을
-// 계산해 그리는 방식으로 바꿨다 — 조합이 아무리 랜덤해도 항상 매끈한 실루엣이 보장됨.
+// 가치투자 덱빌더 — 전투 씬. 포켓로그류 배틀 화면을 목표로 한 풀 렌더링:
+//  · 바이옴 배경(5층마다 초원→숲→사막→설원→동굴→화산 순환, biomes.ts) + 환경 파티클
+//  · 포켓몬식 전투 플랫폼(타원 받침) 위 대각선 구도(적=우상단, 나=좌하단)
+//  · 크림색 정보 패널(이름/Lv/HP바/상태이상 배지) — 어떤 바이옴 위에서도 항상 읽힘
+//  · HP바는 실제 값으로 즉시 꺾이지 않고 트윈으로 부드럽게 감소(포켓몬 특유의 "쭉 빠지는" 바)
+//  · 등장 슬라이드/공격 돌진+투사체/피격 플래시/기절 낙하 애니메이션, 타격 파티클
+// 몬스터는 절차 생성 픽셀 격자 아트(격자 좌표 판정 함수로 실루엣 계산 — 어떤 조합이든 매끈함).
 // 판정 로직은 전혀 없음 — combatEngine이 계산한 결과를 받아 재생만 한다.
 const GRID = 18;
 const CX = GRID / 2;
 const CY = 7; // 그래픽스 좌표계 원점 기준 행(캔버스 세로 중앙에 맞추는 용도, 특정 종과 무관)
 
-// 슬라임 — 돔(타원 상반부) + 정수리 뾰족점(고전 물방울형 슬라임 실루엣 관례 참고, 특정
-// 캐릭터 디자인을 그대로 베끼지 않고 형태 관례만 차용), 적도부터 아래는 바닥으로 갈수록
-// 폭이 점점 넓어지는 플레어(치마처럼 퍼짐)를 줘서 "바닥에 퍼져 앉은" 느낌을 낸다.
+// 슬라임 — 돔(타원 상반부) + 정수리 뾰족점, 적도 아래는 바닥으로 갈수록 퍼지는 플레어.
 const SLIME_RX = 5, SLIME_RY = 5.5, SLIME_EQ = 7, SLIME_BOTTOM = 13, SLIME_FLARE = 2.6;
 const SLIME_SPIKE_ROW_OFFSET = 1.5, SLIME_SPIKE_HALF_WIDTH = 0.6;
 function slimeBody(col: number, row: number): boolean {
@@ -21,17 +23,16 @@ function slimeBody(col: number, row: number): boolean {
     const ny = (row + 0.5 - SLIME_EQ) / SLIME_RY;
     const nx = dx / SLIME_RX;
     if (nx * nx + ny * ny <= 1) return true;
-    // 정수리 뾰족점 — 돔 타원 바로 위 한 줄만, 중앙 두 칸 폭으로 살짝 튀어나오게
     const nyBelow = (row + SLIME_SPIKE_ROW_OFFSET - SLIME_EQ) / SLIME_RY;
     return nyBelow * nyBelow <= 1 && Math.abs(dx) <= SLIME_SPIKE_HALF_WIDTH;
   }
-  const t = (row - SLIME_EQ) / (SLIME_BOTTOM - SLIME_EQ); // 0(적도) → 1(바닥)
+  const t = (row - SLIME_EQ) / (SLIME_BOTTOM - SLIME_EQ);
   const flared = SLIME_RX + t * SLIME_FLARE;
-  const maxRx = row >= SLIME_BOTTOM ? flared - 1 : flared; // 맨 아랫줄만 살짝 좁혀 모서리를 둥글게
+  const maxRx = row >= SLIME_BOTTOM ? flared - 1 : flared;
   return Math.abs(dx) <= maxRx;
 }
 
-// 유령 — 둥근 정수리 돔 + 곧은 몸통 옆선 + 바닥의 물결치는 다리 3갈래(고전 유령 실루엣 관례).
+// 유령 — 둥근 정수리 돔 + 곧은 몸통 옆선 + 바닥의 물결치는 다리 3갈래.
 const GHOST_TOP = 2, GHOST_EQ = 6, GHOST_RX = 4.5, GHOST_RY = 4, GHOST_LEGTOP = 13, GHOST_BOTTOM = 16;
 const GHOST_LEG_OFFSETS = [-3, 0, 3];
 function ghostBody(col: number, row: number): boolean {
@@ -42,8 +43,8 @@ function ghostBody(col: number, row: number): boolean {
     return nx * nx + ny * ny <= 1;
   }
   if (row <= GHOST_LEGTOP) return Math.abs(dx) <= GHOST_RX;
-  const t = (row - GHOST_LEGTOP) / (GHOST_BOTTOM - GHOST_LEGTOP); // 0(다리 시작) → 1(다리 끝)
-  const legHalf = 1.4 - t * 1.1; // 갈래마다 아래로 갈수록 뾰족하게 좁아짐
+  const t = (row - GHOST_LEGTOP) / (GHOST_BOTTOM - GHOST_LEGTOP);
+  const legHalf = 1.4 - t * 1.1;
   return GHOST_LEG_OFFSETS.some(off => Math.abs(dx - off) <= legHalf);
 }
 
@@ -56,13 +57,13 @@ function batBody(col: number, row: number): boolean {
   const nx = dx / BAT_HEAD_RX, ny = (row - BAT_HEAD_ROW) / BAT_HEAD_RY;
   if (row >= BAT_EAR_TOP && nx * nx + ny * ny <= 1) return true;
   if (row >= BAT_EAR_TOP && row <= BAT_EAR_BOTTOM) {
-    const t = (row - BAT_EAR_TOP) / (BAT_EAR_BOTTOM - BAT_EAR_TOP); // 0(귀 끝) → 1(머리와 만나는 지점)
+    const t = (row - BAT_EAR_TOP) / (BAT_EAR_BOTTOM - BAT_EAR_TOP);
     for (const earDx of [-1.6, 1.6]) {
       if (Math.abs(dx - earDx) <= 0.3 + t * 0.9) return true;
     }
   }
   if (row >= BAT_WING_TOP && row <= BAT_WING_BOTTOM) {
-    const t = 1 - Math.abs(row - BAT_WING_MID) / (BAT_WING_MID - BAT_WING_TOP); // 중간 행에서 가장 넓게 퍼짐
+    const t = 1 - Math.abs(row - BAT_WING_MID) / (BAT_WING_MID - BAT_WING_TOP);
     const reach = Math.max(0, t) * BAT_WING_REACH;
     if (dx <= -BAT_WING_ATTACH && dx >= -BAT_WING_ATTACH - reach) return true;
     if (dx >= BAT_WING_ATTACH && dx <= BAT_WING_ATTACH + reach) return true;
@@ -83,9 +84,33 @@ function mushroomBody(col: number, row: number): boolean {
   return false;
 }
 
-// 대기 애니메이션(숨쉬듯 눌렸다 펴지는 효과)용 공용 변형 — 아래 칸에서 당겨와 위쪽이 눌린
-// 것처럼 보이게 하고(수직 압축), 좌우 이웃 칸과 합쳐서 눌린 만큼 옆으로 퍼지게(수평 팽창)
-// 만든다. 종마다 따로 눌린 모양을 튜닝하지 않아도 어떤 실루엣이든 동일하게 적용됨.
+// 골렘 — 위아래 모서리가 좁아지는 바위 몸통 + 양옆 팔 덩어리(동굴/화산 바이옴에 어울리는 종).
+const GOLEM_TOP = 3, GOLEM_BOTTOM = 14, GOLEM_WIDE = 5.2, GOLEM_NARROW = 4;
+function golemBody(col: number, row: number): boolean {
+  const dx = col + 0.5 - CX;
+  if (row >= GOLEM_TOP && row <= GOLEM_BOTTOM) {
+    const half = (row < GOLEM_TOP + 2 || row > GOLEM_BOTTOM - 2) ? GOLEM_NARROW : GOLEM_WIDE;
+    if (Math.abs(dx) <= half) return true;
+  }
+  if (row >= 7 && row <= 11 && Math.abs(dx) >= GOLEM_WIDE && Math.abs(dx) <= GOLEM_WIDE + 1.8) return true;
+  return false;
+}
+
+// 새 — 작은 머리 + 부리 + 통통한 몸통 + 좌우 날개(부리가 있어 입은 안 그림 — mouthNone).
+function birdBody(col: number, row: number): boolean {
+  const dx = col + 0.5 - CX;
+  { const nx = dx / 3, ny = (row - 4) / 2.8; if (nx * nx + ny * ny <= 1) return true; }
+  if (row >= 6 && row <= 7 && Math.abs(dx) <= 1.4 - (row - 6) * 0.8) return true;
+  { const nx = dx / 4.6, ny = (row - 11) / 3.6; if (nx * nx + ny * ny <= 1) return true; }
+  if (row >= 9 && row <= 13) {
+    const t = 1 - Math.abs(row - 11) / 2.5;
+    const reach = Math.max(0, t) * 2.2;
+    if (Math.abs(dx) >= 4.4 && Math.abs(dx) <= 4.4 + reach) return true;
+  }
+  return false;
+}
+
+// 대기 애니메이션(숨쉬듯 눌렸다 펴지는 효과)용 공용 변형.
 function squish(col: number, row: number, base: (c: number, r: number) => boolean): boolean {
   const r = row + 1;
   return base(col, r) || base(col - 1, r) || base(col + 1, r);
@@ -100,51 +125,49 @@ function lighten(hex: number, amt: number): number {
 function makePalette(body: number, outline: number): Palette {
   return { body, outline, shine: lighten(body, 0.6) };
 }
-const BLUSH_COLOR = 0xfda4af; // 볼터치는 종과 무관하게 고정 분홍(몸 색과는 항상 대비됨)
+const BLUSH_COLOR = 0xfda4af;
 
-// 종마다 색상군을 고정해서(슬라임=초록, 유령=창백한 한색, 박쥐=어두운 보라, 버섯=따뜻한
-// 원색) 같은 종끼리는 늘 닮아 보이면서도 색조는 다양하게 섞이도록 함.
+// 종마다 색상군 고정 — 같은 종끼리는 늘 닮아 보이면서 색조는 다양하게.
 const SLIME_PALETTES: Palette[] = [
-  makePalette(0x4ade80, 0x15803d), // 에메랄드
-  makePalette(0x34d399, 0x047857), // 민트
-  makePalette(0xa3e635, 0x4d7c0f), // 라임
-  makePalette(0x22c55e, 0x14532d), // 포레스트
-  makePalette(0x6ee7b7, 0x0f766e), // 시폼
-  makePalette(0x84cc16, 0x3f6212), // 올리브
+  makePalette(0x4ade80, 0x15803d), makePalette(0x34d399, 0x047857), makePalette(0xa3e635, 0x4d7c0f),
+  makePalette(0x22c55e, 0x14532d), makePalette(0x6ee7b7, 0x0f766e), makePalette(0x84cc16, 0x3f6212),
 ];
-// 흰 배경에서도 실루엣이 묻히지 않도록(구 검정 배경 대비 대응) 옛 파스텔 톤보다 한두 단계
-// 진하게 조정 — 여전히 다른 종보다는 창백한 "유령" 톤을 유지.
 const GHOST_PALETTES: Palette[] = [
-  makePalette(0xcbd5e1, 0x64748b), // 슬레이트
-  makePalette(0xa5b4fc, 0x6366f1), // 라벤더
-  makePalette(0x93c5fd, 0x3b82f6), // 스카이
-  makePalette(0xe9d5ff, 0xc084fc), // 연보라
+  makePalette(0xcbd5e1, 0x64748b), makePalette(0xa5b4fc, 0x6366f1),
+  makePalette(0x93c5fd, 0x3b82f6), makePalette(0xe9d5ff, 0xc084fc),
 ];
 const BAT_PALETTES: Palette[] = [
-  makePalette(0x6d28d9, 0x3b0764), // 퍼플
-  makePalette(0x4c1d95, 0x2e1065), // 인디고
-  makePalette(0x581c87, 0x3b0764), // 플럼
-  makePalette(0x312e81, 0x1e1b4b), // 미드나잇
+  makePalette(0x6d28d9, 0x3b0764), makePalette(0x4c1d95, 0x2e1065),
+  makePalette(0x581c87, 0x3b0764), makePalette(0x312e81, 0x1e1b4b),
 ];
 const MUSHROOM_PALETTES: Palette[] = [
-  makePalette(0xef4444, 0x991b1b), // 레드캡
-  makePalette(0xf97316, 0xc2410c), // 오렌지캡
-  makePalette(0xa16207, 0x713f12), // 브라운캡
-  makePalette(0xeab308, 0x854d0e), // 옐로캡
+  makePalette(0xef4444, 0x991b1b), makePalette(0xf97316, 0xc2410c),
+  makePalette(0xa16207, 0x713f12), makePalette(0xeab308, 0x854d0e),
+];
+const GOLEM_PALETTES: Palette[] = [
+  makePalette(0x9ca3af, 0x4b5563), makePalette(0xa8a29e, 0x57534e),
+  makePalette(0x94a3b8, 0x475569), makePalette(0xa3a3a3, 0x525252),
+];
+const BIRD_PALETTES: Palette[] = [
+  makePalette(0xf87171, 0x991b1b), makePalette(0x60a5fa, 0x1d4ed8),
+  makePalette(0xfacc15, 0xa16207), makePalette(0x5eead4, 0x0f766e),
 ];
 
 type SpeciesDef = {
   inBody: (col: number, row: number) => boolean;
-  eyeRow: number; // 눈 중심 행(종마다 실루엣이 달라 얼굴 위치도 따로 지정)
+  eyeRow: number;
   mouthRow: number;
-  eyeGapOptions: number[]; // 종 너비에 맞는 눈 사이 간격 후보
+  eyeGapOptions: number[];
   palettes: Palette[];
+  mouthNone?: boolean; // 부리처럼 실루엣에 입이 포함된 종은 입을 따로 안 그림
 };
 const SPECIES: SpeciesDef[] = [
   { inBody: slimeBody, eyeRow: SLIME_EQ - 0.5, mouthRow: SLIME_EQ + 2, eyeGapOptions: [2, 3], palettes: SLIME_PALETTES },
   { inBody: ghostBody, eyeRow: 8, mouthRow: 10, eyeGapOptions: [2], palettes: GHOST_PALETTES },
   { inBody: batBody, eyeRow: 7, mouthRow: 9, eyeGapOptions: [1], palettes: BAT_PALETTES },
   { inBody: mushroomBody, eyeRow: 8, mouthRow: 9, eyeGapOptions: [2, 3], palettes: MUSHROOM_PALETTES },
+  { inBody: golemBody, eyeRow: 7, mouthRow: 10, eyeGapOptions: [2, 3], palettes: GOLEM_PALETTES },
+  { inBody: birdBody, eyeRow: 3.5, mouthRow: 6, eyeGapOptions: [1, 2], palettes: BIRD_PALETTES, mouthNone: true },
 ];
 
 type MouthKind = "smile" | "o" | "none";
@@ -156,13 +179,12 @@ function randomMonster(): MonsterSpec {
     species,
     palette: pick(species.palettes),
     eyeGap: pick(species.eyeGapOptions),
-    mouth: pick(["smile", "smile", "o", "none"]),
+    mouth: species.mouthNone ? "none" : pick(["smile", "smile", "o", "none"]),
     hasBlush: Math.random() < 0.5,
   };
 }
 
-// 내 캐릭터 뒷모습 실루엣 — 몬스터와 같은 절차적 픽셀 그리드 방식(둥근 머리 + 사다리꼴 등판 +
-// 다리 두 갈래), 얼굴이 안 보이는 뒷모습이라 눈/입/볼터치 없이 형태만. "전사" 톤(가죽 갑옷 톤).
+// 내 캐릭터 뒷모습 실루엣 — 둥근 머리 + 사다리꼴 등판 + 다리 두 갈래(가죽 갑옷 톤).
 const PLAYER_HEAD_RX = 2.3, PLAYER_HEAD_RY = 2.1, PLAYER_HEAD_ROW = 3;
 const PLAYER_TORSO_TOP = 5, PLAYER_TORSO_BOTTOM = 12, PLAYER_TORSO_TOP_HALF = 3.2, PLAYER_TORSO_BOTTOM_HALF = 4.4;
 const PLAYER_LEG_BOTTOM = 17, PLAYER_LEG_HALF = 1.5, PLAYER_LEG_OFFSET = 2.1;
@@ -182,9 +204,8 @@ function playerBody(col: number, row: number): boolean {
   }
   return false;
 }
-const PLAYER_PALETTE = makePalette(0xb45309, 0x431407); // 가죽 갑옷 톤(호박빛 브라운)
-// 육성(레벨)에 따른 실루엣 배율 — Lv1이 0.72(예전 "유아기"와 동일 크기)에서 시작해 레벨마다
-// 조금씩 커지고(필살기 해금 레벨인 Lv5쯤에서 대략 기본 크기 1.0), LEVEL_SCALE_MAX에서 멈춘다.
+const PLAYER_PALETTE = makePalette(0xb45309, 0x431407);
+// 육성(레벨)에 따른 실루엣 배율 — Lv1 0.72에서 시작해 레벨마다 커지고 상한에서 멈춤.
 const LEVEL_SCALE_BASE = 0.72;
 const LEVEL_SCALE_PER_LEVEL = 0.07;
 const LEVEL_SCALE_MAX = 1.6;
@@ -192,39 +213,52 @@ function levelToScale(level: number): number {
   return Math.min(LEVEL_SCALE_MAX, LEVEL_SCALE_BASE + (level - 1) * LEVEL_SCALE_PER_LEVEL);
 }
 
-// Phaser의 Text는 자체 해상도(resolution)로 텍스처를 굽는데 기본값 1이라 고밀도(레티나)
-// 모바일 화면에서 흐릿하게 보임 — devicePixelRatio만큼 올려서 선명하게 그린다(과도한 메모리
-// 사용 방지로 최대 3배로 제한).
+// Phaser Text의 텍스처 해상도 — 레티나 대응(최대 3배).
 const RES = typeof window !== "undefined" ? Math.min(window.devicePixelRatio || 1, 3) : 1;
 
 const HP_BAR_H = 8;
+const PANEL_H = 40;
+export type SceneStatusKind = "burn" | "poison" | "paralysis";
+const STATUS_CHIP: Record<SceneStatusKind, { label: string; bg: string }> = {
+  burn: { label: "화상", bg: "#f97316" },
+  poison: { label: "독", bg: "#a855f7" },
+  paralysis: { label: "마비", bg: "#eab308" },
+};
 
-// 포켓몬 클래식 대각선 배치 — 적(정면)은 우상단 스프라이트 + 좌상단 정보(이름+HP바), 내
-// 캐릭터(뒷모습)는 좌하단 스프라이트 + 우상단이 아닌 우하단 정보. 서로 반대편 코너에 정보를
-// 둬서 시선이 대각선으로 교차하게 배치하는 포켓몬 시리즈의 전통적인 배틀 화면 구도.
 export default class CombatScene extends Phaser.Scene {
+  // 배경/환경
+  private bgGfx!: Phaser.GameObjects.Graphics;
+  private ambient: Phaser.GameObjects.Particles.ParticleEmitter | null = null;
+  private biomeIdx = -1;
+
+  // 적 — 우상단 스프라이트 + 좌상단 정보 패널
   private enemyGfx!: Phaser.GameObjects.Graphics;
   private enemyLabel!: Phaser.GameObjects.Text;
+  private enemyLvText!: Phaser.GameObjects.Text;
   private enemyHpGfx!: Phaser.GameObjects.Graphics;
   private enemyHpNumText!: Phaser.GameObjects.Text;
-  private enemyHpTag!: Phaser.GameObjects.Text;
-  private enemyInfoBox!: Phaser.GameObjects.Container; // 라벨+HP바+태그 묶음 — 등장 시 슬라이드 인
+  private enemyStatusChip!: Phaser.GameObjects.Text;
+  private enemyPanelGfx!: Phaser.GameObjects.Graphics;
+  private enemyInfoBox!: Phaser.GameObjects.Container;
   private enemyCenterX = 0; private enemyCenterY = 0;
   private enemyHpBarX = 0; private enemyHpBarY = 0; private enemyHpBarW = 0;
-  private enemyInfoRestX = 0;
+  private shownEnemyHp = { v: 0 }; private enemyMaxHpShown = 1;
 
+  // 나 — 좌하단 스프라이트 + 우하단 정보 패널
   private playerGfx!: Phaser.GameObjects.Graphics;
   private playerLabel!: Phaser.GameObjects.Text;
+  private playerLvText!: Phaser.GameObjects.Text;
   private playerHpGfx!: Phaser.GameObjects.Graphics;
   private playerHpNumText!: Phaser.GameObjects.Text;
-  private playerHpTag!: Phaser.GameObjects.Text;
+  private playerStatusChip!: Phaser.GameObjects.Text;
   private playerCenterX = 0; private playerCenterY = 0;
   private playerHpBarX = 0; private playerHpBarY = 0; private playerHpBarW = 0;
-  private playerLevel: number | null = null; // 육성 레벨 — setPlayerLevel 참고
+  private shownPlayerHp = { v: 0 }; private playerMaxHpShown = 1;
+  private playerLevel: number | null = null;
 
   private introText!: Phaser.GameObjects.Text;
   private spec!: MonsterSpec;
-  private cell = 8; // 격자 한 칸의 화면 픽셀 크기(씬 크기에 맞춰 create에서 재계산)
+  private cell = 8;
   private blinking = false;
   private squished = false;
 
@@ -232,46 +266,202 @@ export default class CombatScene extends Phaser.Scene {
 
   create() {
     const w = this.scale.width, h = this.scale.height;
-    this.cameras.main.setBackgroundColor("#ffffff");
     this.cell = Math.max(3, Math.floor(Math.min(w * 0.36, h * 0.34) / GRID));
 
-    // 적 — 우상단 스프라이트 + 좌상단 정보(이름/HP태그/HP바/수치를 컨테이너로 묶어서 등장 시
-    // 한 번에 슬라이드 인 시킴). HP태그("HP" 이탤릭 라벨)가 차지하는 폭만큼 바 자체는 살짝
-    // 줄여서 화면 왼쪽 끝을 벗어나지 않게 한다. 흰 배경이라 텍스트는 짙은 색으로.
-    const hpTagW = 16;
-    this.enemyCenterX = w * 0.74; this.enemyCenterY = h * 0.30;
-    this.enemyLabel = this.add.text(w * 0.05, h * 0.04, "", { fontSize: "12px", color: "#1f2937", fontStyle: "bold", resolution: RES }).setOrigin(0, 0);
-    this.enemyHpBarX = w * 0.05 + hpTagW; this.enemyHpBarY = h * 0.12; this.enemyHpBarW = w * 0.36 - hpTagW;
-    this.enemyHpTag = this.add.text(w * 0.05, this.enemyHpBarY + HP_BAR_H / 2, "HP", { fontSize: "9px", fontStyle: "italic", color: "#b45309", resolution: RES }).setOrigin(0, 0.5);
-    this.enemyHpGfx = this.add.graphics();
-    this.enemyHpNumText = this.add.text(this.enemyHpBarX + this.enemyHpBarW / 2, this.enemyHpBarY + HP_BAR_H / 2, "", { fontFamily: "monospace", fontSize: "9px", color: "#1f2937", fontStyle: "bold", resolution: RES }).setOrigin(0.5);
-    this.enemyInfoBox = this.add.container(0, 0, [this.enemyLabel, this.enemyHpTag, this.enemyHpGfx, this.enemyHpNumText]);
-    this.enemyInfoRestX = 0;
+    // 파티클용 흰 원 텍스처(런타임 생성 — 외부 에셋 없음). tint로 색을 입혀 재사용.
+    if (!this.textures.exists("dot")) {
+      const g = this.make.graphics({ x: 0, y: 0 }, false);
+      g.fillStyle(0xffffff, 1);
+      g.fillCircle(3, 3, 3);
+      g.generateTexture("dot", 6, 6);
+      g.destroy();
+    }
+
+    this.bgGfx = this.add.graphics().setDepth(-10);
+    this.enemyCenterX = w * 0.72; this.enemyCenterY = h * 0.34;
+    this.playerCenterX = w * 0.26; this.playerCenterY = h * 0.66;
+    this.drawBackground(biomeForFloor(0));
+    this.biomeIdx = 0;
+    this.startAmbient(biomeForFloor(0));
+
+    // ---- 적 정보 패널(좌상단) — 크림 박스 위 이름/Lv/HP바/상태 배지 ----
+    const panelX = w * 0.03, panelY = h * 0.03, panelW = w * 0.46;
+    this.enemyPanelGfx = this.add.graphics().setDepth(5);
+    this.drawPanel(this.enemyPanelGfx, panelX, panelY, panelW, PANEL_H);
+    this.enemyLabel = this.add.text(panelX + 8, panelY + 5, "", { fontSize: "11px", color: "#1f2937", fontStyle: "bold", resolution: RES }).setOrigin(0, 0).setDepth(6);
+    this.enemyLvText = this.add.text(panelX + panelW - 8, panelY + 5, "", { fontSize: "9px", color: "#78716c", fontStyle: "bold", resolution: RES }).setOrigin(1, 0).setDepth(6);
+    this.enemyHpBarX = panelX + 8; this.enemyHpBarY = panelY + PANEL_H - 14; this.enemyHpBarW = panelW - 46;
+    this.enemyHpGfx = this.add.graphics().setDepth(6);
+    this.enemyHpNumText = this.add.text(panelX + panelW - 8, this.enemyHpBarY + HP_BAR_H / 2, "", { fontFamily: "monospace", fontSize: "9px", color: "#44403c", fontStyle: "bold", resolution: RES }).setOrigin(1, 0.5).setDepth(6);
+    this.enemyStatusChip = this.add.text(panelX + panelW - 8, panelY + 5, "", { fontSize: "8px", color: "#ffffff", fontStyle: "bold", resolution: RES, padding: { x: 4, y: 2 } }).setOrigin(1, 0).setDepth(7).setVisible(false);
+    this.enemyInfoBox = this.add.container(0, 0, [this.enemyPanelGfx, this.enemyLabel, this.enemyLvText, this.enemyHpGfx, this.enemyHpNumText, this.enemyStatusChip]).setDepth(5);
+
     this.spec = randomMonster();
-    this.enemyGfx = this.add.graphics({ x: this.enemyCenterX, y: this.enemyCenterY });
+    this.enemyGfx = this.add.graphics({ x: this.enemyCenterX, y: this.enemyCenterY }).setDepth(2);
     this.drawMonster();
-    this.setEnemyHp(0, 1);
+    this.shownEnemyHp.v = 0; this.enemyMaxHpShown = 1;
+    this.redrawEnemyHpBar();
 
-    // 나 — 좌하단 스프라이트(전투 내내 고정, 몬스터처럼 매 전투 재생성하지 않음) + 우하단 정보
-    this.playerCenterX = w * 0.26; this.playerCenterY = h * 0.72;
-    this.playerGfx = this.add.graphics({ x: this.playerCenterX, y: this.playerCenterY });
+    // ---- 내 정보 패널(우하단) ----
+    const pPanelW = w * 0.46, pPanelX = w * 0.97 - pPanelW, pPanelY = h * 0.97 - PANEL_H;
+    const playerPanelGfx = this.add.graphics().setDepth(5);
+    this.drawPanel(playerPanelGfx, pPanelX, pPanelY, pPanelW, PANEL_H);
+    this.playerLabel = this.add.text(pPanelX + 8, pPanelY + 5, "", { fontSize: "11px", color: "#1f2937", fontStyle: "bold", resolution: RES }).setOrigin(0, 0).setDepth(6);
+    this.playerLvText = this.add.text(pPanelX + pPanelW - 8, pPanelY + 5, "", { fontSize: "9px", color: "#78716c", fontStyle: "bold", resolution: RES }).setOrigin(1, 0).setDepth(6);
+    this.playerHpBarX = pPanelX + 8; this.playerHpBarY = pPanelY + PANEL_H - 14; this.playerHpBarW = pPanelW - 46;
+    this.playerHpGfx = this.add.graphics().setDepth(6);
+    this.playerHpNumText = this.add.text(pPanelX + pPanelW - 8, this.playerHpBarY + HP_BAR_H / 2, "", { fontFamily: "monospace", fontSize: "9px", color: "#44403c", fontStyle: "bold", resolution: RES }).setOrigin(1, 0.5).setDepth(6);
+    this.playerStatusChip = this.add.text(pPanelX + 8, pPanelY + 5, "", { fontSize: "8px", color: "#ffffff", fontStyle: "bold", resolution: RES, padding: { x: 4, y: 2 } }).setOrigin(0, 0).setDepth(7).setVisible(false);
+    // 이름이 상태 배지와 겹치지 않게, 배지가 켜지면 이름을 오른쪽으로 살짝 밀어준다(setPlayerStatus).
+
+    this.playerGfx = this.add.graphics({ x: this.playerCenterX, y: this.playerCenterY }).setDepth(2);
     this.drawPlayer();
-    this.playerHpBarW = w * 0.36 - hpTagW; this.playerHpBarX = w * 0.95 - this.playerHpBarW; this.playerHpBarY = h * 0.86;
-    this.playerHpTag = this.add.text(this.playerHpBarX - 3, this.playerHpBarY + HP_BAR_H / 2, "HP", { fontSize: "9px", fontStyle: "italic", color: "#b45309", resolution: RES }).setOrigin(1, 0.5);
-    this.playerLabel = this.add.text(w * 0.95, this.playerHpBarY - 4, "", { fontSize: "12px", color: "#1f2937", fontStyle: "bold", resolution: RES }).setOrigin(1, 1);
-    this.playerHpGfx = this.add.graphics();
-    this.playerHpNumText = this.add.text(this.playerHpBarX + this.playerHpBarW / 2, this.playerHpBarY + HP_BAR_H / 2, "", { fontFamily: "monospace", fontSize: "9px", color: "#1f2937", fontStyle: "bold", resolution: RES }).setOrigin(0.5);
-    this.setPlayerHp(0, 1);
+    this.shownPlayerHp.v = 0; this.playerMaxHpShown = 1;
+    this.redrawPlayerHpBar();
 
-    this.introText = this.add.text(w / 2, h / 2, "", { fontSize: "20px", color: "#d97706", fontStyle: "bold", resolution: RES })
-      .setOrigin(0.5).setAlpha(0).setDepth(10);
+    this.introText = this.add.text(w / 2, h * 0.46, "", {
+      fontSize: "15px", color: "#ffffff", fontStyle: "bold", resolution: RES,
+      backgroundColor: "rgba(15,23,42,0.78)", padding: { x: 12, y: 5 },
+    }).setOrigin(0.5).setAlpha(0).setDepth(10);
 
     this.startIdleAnim();
   }
 
-  // 격자 좌표(col,row 기준, 원점은 그리드 중앙)를 그래픽스 로컬 좌표(px)로 변환
+  // ---------- 배경(바이옴) ----------
+
+  // 층수 → 바이옴. 바이옴이 실제로 바뀔 때만 배경을 다시 그리고 환경 파티클을 갈아끼운다.
+  setFloor(floor: number) {
+    const idx = biomeIndexForFloor(floor);
+    if (idx === this.biomeIdx) return;
+    this.biomeIdx = idx;
+    const biome = biomeForFloor(floor);
+    this.drawBackground(biome);
+    this.startAmbient(biome);
+    this.cameras.main.flash(260, 255, 255, 255); // 장면 전환 플래시 — 바이옴이 바뀌었음을 알림
+  }
+
+  private drawBackground(biome: BiomeDef) {
+    const w = this.scale.width, h = this.scale.height;
+    const horizonY = h * 0.42;
+    const g = this.bgGfx;
+    g.clear();
+
+    // 하늘 — 위→아래 그라데이션
+    g.fillGradientStyle(biome.skyTop, biome.skyTop, biome.skyBottom, biome.skyBottom, 1);
+    g.fillRect(0, 0, w, horizonY + 6);
+    // 지면
+    g.fillGradientStyle(biome.ground, biome.ground, biome.groundDark, biome.groundDark, 1);
+    g.fillRect(0, horizonY, w, h - horizonY);
+
+    // 바이옴별 원경 장식 — 전부 단순 도형의 절차 드로잉(외부 에셋 없음)
+    const deco = biome.id;
+    if (deco === "grassland") {
+      g.fillStyle(biome.groundDark, 0.55);
+      g.fillEllipse(w * 0.2, horizonY, w * 0.5, h * 0.12);
+      g.fillEllipse(w * 0.75, horizonY, w * 0.6, h * 0.16);
+      g.fillStyle(0x16a34a, 0.5);
+      for (let i = 0; i < 7; i++) {
+        const x = (i + 0.5) * (w / 7), y = horizonY + 10 + (i % 3) * 8;
+        g.fillTriangle(x - 3, y + 6, x + 3, y + 6, x, y - 4);
+      }
+    } else if (deco === "forest") {
+      for (let i = 0; i < 6; i++) {
+        const x = (i + 0.5) * (w / 6), th = h * (0.14 + (i % 2) * 0.05);
+        g.fillStyle(0x14532d, 0.85);
+        g.fillTriangle(x - w * 0.07, horizonY + 4, x + w * 0.07, horizonY + 4, x, horizonY - th);
+        g.fillStyle(0x451a03, 0.8);
+        g.fillRect(x - 2, horizonY, 4, 8);
+      }
+    } else if (deco === "desert") {
+      g.fillStyle(0xf59e0b, 0.5);
+      g.fillEllipse(w * 0.3, horizonY, w * 0.7, h * 0.14);
+      g.fillEllipse(w * 0.85, horizonY, w * 0.5, h * 0.1);
+      // 선인장 한 그루
+      const cx2 = w * 0.12, cy2 = horizonY + h * 0.1;
+      g.fillStyle(0x15803d, 0.9);
+      g.fillRoundedRect(cx2 - 3, cy2 - 22, 6, 24, 3);
+      g.fillRoundedRect(cx2 - 12, cy2 - 16, 8, 5, 2.5);
+      g.fillRoundedRect(cx2 + 4, cy2 - 12, 8, 5, 2.5);
+    } else if (deco === "snow") {
+      g.fillStyle(0xf8fafc, 0.8);
+      g.fillEllipse(w * 0.25, horizonY, w * 0.6, h * 0.13);
+      g.fillEllipse(w * 0.8, horizonY, w * 0.55, h * 0.17);
+      for (const [tx, th] of [[0.1, 0.1], [0.55, 0.08], [0.92, 0.12]] as const) {
+        const x = w * tx;
+        g.fillStyle(0x0f766e, 0.75);
+        g.fillTriangle(x - 9, horizonY + 2, x + 9, horizonY + 2, x, horizonY - h * th);
+      }
+    } else if (deco === "cave") {
+      // 천장 종유석 + 빛나는 수정
+      g.fillStyle(0x1e293b, 0.9);
+      for (let i = 0; i < 6; i++) {
+        const x = (i + 0.5) * (w / 6), len = h * (0.06 + (i % 3) * 0.04);
+        g.fillTriangle(x - 7, 0, x + 7, 0, x, len);
+      }
+      for (const [tx, s] of [[0.12, 1], [0.45, 0.7], [0.9, 1.2]] as const) {
+        const x = w * tx, y = horizonY + h * 0.12, size = 8 * s;
+        g.fillStyle(0x67e8f9, 0.9);
+        g.fillTriangle(x - size, y, x + size, y, x, y - size * 2.2);
+        g.fillStyle(0xcffafe, 0.8);
+        g.fillTriangle(x - size * 0.4, y, x + size * 0.4, y, x, y - size * 1.4);
+      }
+    } else if (deco === "volcano") {
+      g.fillStyle(0x1c1917, 0.9);
+      g.fillTriangle(w * 0.05, horizonY + 4, w * 0.55, horizonY + 4, w * 0.3, horizonY - h * 0.2);
+      g.fillStyle(0xf97316, 0.95);
+      g.fillTriangle(w * 0.27, horizonY - h * 0.14, w * 0.33, horizonY - h * 0.14, w * 0.3, horizonY - h * 0.2);
+      // 지면 용암 균열
+      g.lineStyle(2, 0xfb923c, 0.8);
+      for (const [x1, y1, x2, y2] of [[0.1, 0.6, 0.22, 0.72], [0.6, 0.55, 0.75, 0.6], [0.82, 0.75, 0.95, 0.85]] as const) {
+        g.lineBetween(w * x1, h * y1, w * x2, h * y2);
+      }
+    }
+
+    // 전투 플랫폼(타원 받침) — 적/내 스프라이트 발밑. 포켓몬 배틀 화면의 시그니처 요소.
+    const spriteBottom = (GRID - 1 - CY) * this.cell;
+    g.fillStyle(biome.platform, 0.9);
+    g.fillEllipse(this.enemyCenterX, this.enemyCenterY + spriteBottom + this.cell * 0.8, this.cell * 15, this.cell * 3.6);
+    g.fillEllipse(this.playerCenterX, this.playerCenterY + spriteBottom + this.cell * 0.8, this.cell * 16, this.cell * 4);
+    g.lineStyle(2, biome.platformEdge, 0.55);
+    g.strokeEllipse(this.enemyCenterX, this.enemyCenterY + spriteBottom + this.cell * 0.8, this.cell * 15, this.cell * 3.6);
+    g.strokeEllipse(this.playerCenterX, this.playerCenterY + spriteBottom + this.cell * 0.8, this.cell * 16, this.cell * 4);
+  }
+
+  // 환경 파티클(낙엽/모래/눈/수정 반딧불/불씨) — 바이옴 분위기용 잔잔한 배경 입자.
+  private startAmbient(biome: BiomeDef) {
+    const w = this.scale.width, h = this.scale.height;
+    this.ambient?.destroy();
+    this.ambient = null;
+    if (!biome.particle) return;
+    const p = biome.particle;
+    const falling = p.dir === "fall";
+    this.ambient = this.add.particles(0, 0, "dot", {
+      x: { min: 0, max: w },
+      y: falling ? -6 : h + 6,
+      lifespan: 7000,
+      speedY: falling ? { min: 10, max: 26 } : { min: -22, max: -8 },
+      speedX: { min: -10, max: 10 },
+      scale: { start: 0.55, end: 0.15 },
+      alpha: { start: 0.85, end: 0 },
+      frequency: Math.round(1000 / p.countPerSec),
+      tint: p.color,
+    }).setDepth(1);
+  }
+
+  // ---------- 공용 드로잉 ----------
+
   private cellPx(col: number, row: number) {
     return { x: (col - CX) * this.cell, y: (row - CY) * this.cell };
+  }
+
+  // 크림색 정보 패널 — 어떤 바이옴 배경 위에서도 텍스트가 항상 읽히게 하는 받침 박스.
+  private drawPanel(g: Phaser.GameObjects.Graphics, x: number, y: number, w: number, h: number) {
+    g.fillStyle(0x1c1917, 0.25);
+    g.fillRoundedRect(x + 2, y + 3, w, h, 9); // 떨어진 그림자
+    g.fillStyle(0xfffbeb, 0.96);
+    g.fillRoundedRect(x, y, w, h, 9);
+    g.lineStyle(2, 0x78716c, 1);
+    g.strokeRoundedRect(x, y, w, h, 9);
   }
 
   private drawMonster() {
@@ -282,8 +472,6 @@ export default class CombatScene extends Phaser.Scene {
     const pred = this.squished ? (c: number, r: number) => squish(c, r, basePred) : basePred;
     g.clear();
 
-    // 몸통 판정을 칸마다 한 번만 계산해 캐시해두고(테두리 판정에서 이웃 4칸 재조회 시 재사용),
-    // inBody() 중복 호출을 줄인다.
     const body: boolean[][] = [];
     for (let row = 0; row < GRID; row++) {
       body[row] = [];
@@ -291,25 +479,22 @@ export default class CombatScene extends Phaser.Scene {
     }
     const isBody = (col: number, row: number) => body[row]?.[col] ?? false;
 
-    // 몸통 — 칸마다 실루엣 안쪽인지 검사해 채우고, 바로 바깥 칸이 하나라도 비어 있으면 외곽선색으로.
     for (let row = 0; row < GRID; row++) {
       for (let col = 0; col < GRID; col++) {
         if (!isBody(col, row)) continue;
         const edge = !isBody(col + 1, row) || !isBody(col - 1, row) || !isBody(col, row + 1) || !isBody(col, row - 1);
         const { x, y } = this.cellPx(col, row);
         g.fillStyle(edge ? s.palette.outline : s.palette.body, 1);
-        g.fillRect(x, y, this.cell + 1, this.cell + 1); // +1로 인접 칸 사이 미세한 틈(seam) 방지
+        g.fillRect(x, y, this.cell + 1, this.cell + 1);
       }
     }
 
-    // 광택 — 젤리/매끈한 표면 느낌을 주는 밝은 하이라이트(눈 위쪽, 반투명)
-    {
+    { // 광택
       const p = this.cellPx(CX - 3, species.eyeRow - 2);
       g.fillStyle(s.palette.shine, 0.7);
       g.fillEllipse(p.x, p.y, this.cell * 2.2, this.cell * 1.4);
     }
 
-    // 볼터치
     if (s.hasBlush) {
       g.fillStyle(BLUSH_COLOR, 0.85);
       for (const dir of [-1, 1]) {
@@ -318,9 +503,6 @@ export default class CombatScene extends Phaser.Scene {
       }
     }
 
-    // 눈 — 흰자 없이 동그란 눈동자 하나만 콕 찍어서 "하찮고 멍한" 인상을 줌. 눈동자는 좌우
-    // 대칭 중앙에 고정 — 예전에 바깥쪽으로 쏠려 무섭다는 피드백을 받았던 것과 같은 실수를
-    // 반복하지 않기 위함. 깜빡일 땐 얇은 곡선으로.
     for (const dir of [-1, 1]) {
       const ex = CX + dir * s.eyeGap;
       const p = this.cellPx(ex, species.eyeRow);
@@ -336,7 +518,6 @@ export default class CombatScene extends Phaser.Scene {
       }
     }
 
-    // 입
     if (s.mouth !== "none") {
       const p = this.cellPx(CX, species.mouthRow);
       g.fillStyle(s.palette.outline, 1);
@@ -345,8 +526,6 @@ export default class CombatScene extends Phaser.Scene {
     }
   }
 
-  // 등판 갑옷 광택 하이라이트만 있을 뿐 눈/입은 없음(뒷모습이라 얼굴이 안 보임). 몬스터와 달리
-  // 전투 내내 같은 모양을 유지하므로 idle 애니메이션(숨쉬기/깜빡임) 대상에서도 제외.
   private drawPlayer() {
     const g = this.playerGfx;
     g.clear();
@@ -374,7 +553,7 @@ export default class CombatScene extends Phaser.Scene {
     const pct = maxHp > 0 ? Math.max(0, Math.min(1, hp / maxHp)) : 0;
     const color = pct > 0.5 ? 0x16a34a : pct > 0.2 ? 0xf59e0b : 0xf43f5e;
     gfx.clear();
-    gfx.fillStyle(0x000000, 0.35);
+    gfx.fillStyle(0x44403c, 0.3);
     gfx.fillRoundedRect(x, y, w, HP_BAR_H, HP_BAR_H / 2);
     const fillW = Math.min(w, Math.max(pct > 0 ? HP_BAR_H : 0, w * pct));
     if (fillW > 0) {
@@ -384,30 +563,49 @@ export default class CombatScene extends Phaser.Scene {
     numText.setText(`${Math.max(0, Math.round(hp))}/${Math.round(maxHp)}`);
   }
 
-  // 정예/보스는 상시 배지를 라벨에 붙여 등장 인트로가 사라진 뒤에도 계속 구분되게 함. 새 적이
-  // 나타날 때마다 스프라이트는 페이드+스케일 인, 이름/HP 정보 박스는 왼쪽에서 슬라이드 인
-  // 되는 등장 연출을 재생한다(포켓몬의 "야생의 OO가 나타났다!" 등장 모먼트를 흉내).
-  setEnemy(name: string, hp: number, maxHp: number, encounter: "battle" | "boss" | "elite" = "battle") {
-    const prefix = encounter === "boss" ? "👑 보스 · " : encounter === "elite" ? "🗡️ 정예 · " : "";
+  private redrawEnemyHpBar() {
+    this.drawHpBar(this.enemyHpGfx, this.enemyHpNumText, this.enemyHpBarX, this.enemyHpBarY, this.enemyHpBarW, this.shownEnemyHp.v, this.enemyMaxHpShown);
+  }
+  private redrawPlayerHpBar() {
+    this.drawHpBar(this.playerHpGfx, this.playerHpNumText, this.playerHpBarX, this.playerHpBarY, this.playerHpBarW, this.shownPlayerHp.v, this.playerMaxHpShown);
+  }
+
+  // ---------- 상태 반영 API (React 래퍼가 호출) ----------
+
+  // 새 적 등장 — 스프라이트는 오른쪽 화면 밖에서 미끄러져 들어오고, 정보 패널은 왼쪽에서 슬라이드 인.
+  setEnemy(name: string, hp: number, maxHp: number, encounter: "battle" | "boss" | "elite" = "battle", level?: number) {
+    const prefix = encounter === "boss" ? "👑 " : encounter === "elite" ? "🗡️ " : "";
     const color = encounter === "boss" ? "#d97706" : encounter === "elite" ? "#9333ea" : "#1f2937";
     this.enemyLabel.setText(prefix + name).setColor(color);
+    this.enemyLvText.setText(level ? `Lv.${level}` : "");
+    this.setEnemyStatus(null);
     this.spec = randomMonster();
     this.blinking = false;
     this.squished = false;
     this.drawMonster();
-    this.setEnemyHp(hp, maxHp);
+    this.enemyMaxHpShown = maxHp;
+    this.tweens.killTweensOf(this.shownEnemyHp);
+    this.shownEnemyHp.v = hp;
+    this.redrawEnemyHpBar();
 
     this.tweens.killTweensOf(this.enemyGfx);
-    this.enemyGfx.setAlpha(0).setScale(0.55);
-    this.tweens.add({ targets: this.enemyGfx, alpha: 1, scale: 1, duration: 380, ease: "Back.easeOut" });
+    this.enemyGfx.setPosition(this.enemyCenterX + this.scale.width * 0.35, this.enemyCenterY).setAlpha(0).setScale(1).setAngle(0);
+    this.tweens.add({ targets: this.enemyGfx, x: this.enemyCenterX, alpha: 1, duration: 420, ease: "Back.easeOut" });
+    if (encounter === "boss") this.cameras.main.shake(260, 0.008);
 
     this.tweens.killTweensOf(this.enemyInfoBox);
-    this.enemyInfoBox.setX(this.enemyInfoRestX - 36).setAlpha(0);
-    this.tweens.add({ targets: this.enemyInfoBox, x: this.enemyInfoRestX, alpha: 1, duration: 300, ease: "Cubic.easeOut" });
+    this.enemyInfoBox.setX(-40).setAlpha(0);
+    this.tweens.add({ targets: this.enemyInfoBox, x: 0, alpha: 1, duration: 320, ease: "Cubic.easeOut" });
   }
 
+  // HP는 즉시 꺾지 않고 현재 표시값에서 목표값까지 트윈 — 포켓몬식 "쭉 흘러내리는" HP바.
   setEnemyHp(hp: number, maxHp: number) {
-    this.drawHpBar(this.enemyHpGfx, this.enemyHpNumText, this.enemyHpBarX, this.enemyHpBarY, this.enemyHpBarW, hp, maxHp);
+    this.enemyMaxHpShown = maxHp;
+    this.tweens.killTweensOf(this.shownEnemyHp);
+    this.tweens.add({
+      targets: this.shownEnemyHp, v: hp, duration: 450, ease: "Cubic.easeOut",
+      onUpdate: () => this.redrawEnemyHpBar(),
+    });
   }
 
   setPlayerName(name: string) {
@@ -415,25 +613,49 @@ export default class CombatScene extends Phaser.Scene {
   }
 
   setPlayerHp(hp: number, maxHp: number) {
-    this.drawHpBar(this.playerHpGfx, this.playerHpNumText, this.playerHpBarX, this.playerHpBarY, this.playerHpBarW, hp, maxHp);
+    this.playerMaxHpShown = maxHp;
+    this.tweens.killTweensOf(this.shownPlayerHp);
+    this.tweens.add({
+      targets: this.shownPlayerHp, v: hp, duration: 450, ease: "Cubic.easeOut",
+      onUpdate: () => this.redrawPlayerHpBar(),
+    });
   }
 
-  // 육성(레벨) — 레벨이 오를수록 실루엣이 조금씩 커진다(levelToScale). 실제로 레벨이 바뀔 때만
-  // (최초 마운트 제외) 반짝임 연출을 곁들인다.
   setPlayerLevel(level: number) {
     if (this.playerLevel === level) return;
     const first = this.playerLevel === null;
     this.playerLevel = level;
+    this.playerLvText.setText(`Lv.${level}`);
     const scale = levelToScale(level);
     this.tweens.killTweensOf(this.playerGfx);
+    this.playerGfx.setPosition(this.playerCenterX, this.playerCenterY).setAlpha(1);
     if (first) { this.playerGfx.setScale(scale); return; }
     this.tweens.add({ targets: this.playerGfx, scale, duration: 380, ease: "Back.easeOut" });
-    this.cameras.main.flash(220, 253, 224, 71); // 옅은 금색 플래시로 레벨업 순간 강조
+    this.cameras.main.flash(220, 253, 224, 71);
+    this.burst(this.playerCenterX, this.playerCenterY, 0xfacc15, 18);
   }
 
-  // 살아있는 느낌을 주는 대기 애니메이션 — 위치를 옮기는 트윈 대신 몇 개 픽셀만 주기적으로
-  // 바꿔서 숨쉬듯 눌렸다 펴지는 느낌을 낸다 + 몇 초마다 눈을 잠깐 감는 깜빡임. 둘 다 판정과
-  // 무관한 순수 장식 타이머.
+  // 상태이상 배지 — 정보 패널 위 색깔 칩(화상=주황/독=보라/마비=노랑). null이면 숨김.
+  setEnemyStatus(kind: SceneStatusKind | null) {
+    if (!kind) { this.enemyStatusChip.setVisible(false); return; }
+    const c = STATUS_CHIP[kind];
+    this.enemyStatusChip.setText(c.label).setBackgroundColor(c.bg).setVisible(true);
+    // Lv 표기와 겹치므로 배지가 켜지면 Lv는 잠시 숨긴다(패널이 좁아 우선순위는 상태이상).
+    this.enemyLvText.setVisible(false);
+  }
+  setPlayerStatus(kind: SceneStatusKind | null) {
+    if (!kind) {
+      this.playerStatusChip.setVisible(false);
+      this.playerLabel.setX(this.playerStatusChip.x);
+      return;
+    }
+    const c = STATUS_CHIP[kind];
+    this.playerStatusChip.setText(c.label).setBackgroundColor(c.bg).setVisible(true);
+    this.playerLabel.setX(this.playerStatusChip.x + this.playerStatusChip.width + 4);
+  }
+
+  // ---------- 연출 ----------
+
   private startIdleAnim() {
     this.time.addEvent({
       delay: 550, loop: true,
@@ -449,45 +671,113 @@ export default class CombatScene extends Phaser.Scene {
     });
   }
 
+  // 한 점에서 사방으로 터지는 입자 — 타격/회복/레벨업 등 모든 임팩트의 공용 이펙트.
+  private burst(x: number, y: number, color: number, count = 14) {
+    const e = this.add.particles(x, y, "dot", {
+      speed: { min: 60, max: 170 }, lifespan: 420,
+      scale: { start: 0.9, end: 0 }, tint: color, emitting: false,
+    }).setDepth(7);
+    e.explode(count);
+    this.time.delayedCall(520, () => e.destroy());
+  }
+
+  // 투사체 — 발사 지점에서 목표까지 빛나는 구체가 날아가고 도착 시 콜백(임팩트) 실행.
+  private shoot(fromX: number, fromY: number, toX: number, toY: number, color: number, onHit?: () => void) {
+    const g = this.add.graphics({ x: fromX, y: fromY }).setDepth(7);
+    g.fillStyle(color, 0.35); g.fillCircle(0, 0, 9);
+    g.fillStyle(color, 1); g.fillCircle(0, 0, 5);
+    g.fillStyle(0xffffff, 0.9); g.fillCircle(-1.5, -1.5, 2);
+    this.tweens.add({
+      targets: g, x: toX, y: toY, duration: 230, ease: "Quad.easeIn",
+      onComplete: () => { g.destroy(); onHit?.(); },
+    });
+  }
+
   flashEnemyHit(damage: number) {
-    this.cameras.main.flash(120, 255, 60, 60);
-    this.tweens.add({ targets: this.enemyGfx, scaleX: 0.92, scaleY: 0.92, duration: 80, yoyo: true });
-    this.popText(this.enemyCenterX, this.enemyCenterY - this.cell * CY * 0.6, `-${damage}`, "#f87171");
+    this.tweens.add({ targets: this.enemyGfx, scaleX: 0.9, scaleY: 0.9, duration: 80, yoyo: true });
+    this.burst(this.enemyCenterX, this.enemyCenterY, 0xf87171, 12);
+    this.cameras.main.shake(110, 0.004);
+    this.popText(this.enemyCenterX, this.enemyCenterY - this.cell * CY * 0.6, `-${damage}`, "#ef4444");
   }
 
   flashPlayerBlock(amount: number) {
-    this.popText(this.playerCenterX, this.playerCenterY - this.cell * CY * 0.6, `+${amount} 🛡️`, "#60a5fa");
+    // 육각 방패 팝 — 파란 링 + 파티클
+    this.playPulseRing(0x60a5fa);
+    this.burst(this.playerCenterX, this.playerCenterY - this.cell * 2, 0x93c5fd, 8);
+    this.popText(this.playerCenterX, this.playerCenterY - this.cell * CY * 0.6, `+${amount} 🛡️`, "#2563eb");
   }
 
+  // 적의 공격 — 적이 앞으로 훅 들어왔다 빠지며 투사체를 날리고, 도착하는 순간 피해 숫자/흔들림.
   flashPlayerHit(damage: number) {
     if (damage <= 0) return;
-    this.cameras.main.shake(150, 0.006);
-    this.popText(this.playerCenterX, this.playerCenterY - this.cell * CY * 0.6, `-${damage}`, "#f87171");
+    const dx = (this.playerCenterX - this.enemyCenterX) * 0.14;
+    const dy = (this.playerCenterY - this.enemyCenterY) * 0.14;
+    this.tweens.killTweensOf(this.enemyGfx);
+    this.enemyGfx.setPosition(this.enemyCenterX, this.enemyCenterY);
+    this.tweens.add({ targets: this.enemyGfx, x: this.enemyCenterX + dx, y: this.enemyCenterY + dy, duration: 110, yoyo: true, ease: "Quad.easeOut" });
+    this.shoot(this.enemyCenterX + dx, this.enemyCenterY + dy, this.playerCenterX, this.playerCenterY, 0x818cf8, () => {
+      this.cameras.main.shake(160, 0.007);
+      this.burst(this.playerCenterX, this.playerCenterY, 0xf87171, 12);
+      this.popText(this.playerCenterX, this.playerCenterY - this.cell * CY * 0.6, `-${damage}`, "#ef4444");
+    });
   }
 
   playHeal(amount: number) {
-    this.popText(this.playerCenterX, this.playerCenterY - this.cell * CY * 0.6, `+${amount} ❤️`, "#4ade80");
+    // 초록 반짝임이 아래에서 위로 솟는 회복 연출
+    const e = this.add.particles(this.playerCenterX, this.playerCenterY + this.cell * 3, "dot", {
+      x: { min: -this.cell * 4, max: this.cell * 4 },
+      speedY: { min: -70, max: -30 }, speedX: { min: -8, max: 8 },
+      lifespan: 700, scale: { start: 0.7, end: 0 }, tint: 0x4ade80, emitting: false,
+    }).setDepth(7);
+    e.explode(14);
+    this.time.delayedCall(800, () => e.destroy());
+    this.popText(this.playerCenterX, this.playerCenterY - this.cell * CY * 0.6, `+${amount} ❤️`, "#16a34a");
+  }
+
+  // 기절 — 스프라이트가 옆으로 기울며 가라앉고 사라진다(포켓몬의 "쓰러짐" 모먼트).
+  playEnemyFaint() {
+    this.tweens.killTweensOf(this.enemyGfx);
+    this.tweens.add({
+      targets: this.enemyGfx, y: this.enemyCenterY + this.cell * 5, angle: 24, alpha: 0,
+      duration: 480, ease: "Quad.easeIn",
+    });
+    this.burst(this.enemyCenterX, this.enemyCenterY, 0x94a3b8, 10);
+  }
+  playPlayerFaint() {
+    this.tweens.killTweensOf(this.playerGfx);
+    this.tweens.add({
+      targets: this.playerGfx, y: this.playerCenterY + this.cell * 5, angle: -24, alpha: 0,
+      duration: 480, ease: "Quad.easeIn",
+    });
+  }
+  // 교체 투입 — 왼쪽 화면 밖에서 미끄러져 들어옴(기절 후 다음 몬스터/자발적 교체 공용).
+  playPlayerEnter() {
+    this.tweens.killTweensOf(this.playerGfx);
+    this.playerGfx.setPosition(this.playerCenterX - this.scale.width * 0.3, this.playerCenterY).setAlpha(0).setAngle(0);
+    this.tweens.add({ targets: this.playerGfx, x: this.playerCenterX, alpha: 1, duration: 380, ease: "Back.easeOut" });
   }
 
   showIntro(label: string) {
     this.introText.setText(label).setAlpha(1).setScale(0.6);
-    this.tweens.add({ targets: this.introText, scale: 1, alpha: { from: 1, to: 1 }, duration: 200, ease: "Back.easeOut" });
-    this.time.delayedCall(700, () => this.tweens.add({ targets: this.introText, alpha: 0, duration: 250 }));
+    this.tweens.add({ targets: this.introText, scale: 1, duration: 200, ease: "Back.easeOut" });
+    this.time.delayedCall(800, () => this.tweens.add({ targets: this.introText, alpha: 0, duration: 250 }));
   }
 
-  // 기술을 쓴 순간 재생하는 시전 이펙트 — 결과(피해/블록/회복 숫자)는 이미 HP/블록 변화 감지로
-  // 따로 뜨므로(flashEnemyHit/flashPlayerBlock/playHeal), 여긴 "무엇을 시전했는지"를 즉시
-  // 보여주는 용도. attack은 내 스프라이트가 적 쪽으로 짧게 돌진했다 돌아오는 동작(타격을
-  // 날리는 느낌), shield/heal은 내 스프라이트 둘레로 고리가 번지며 퍼지는 연출.
+  // 기술 시전 — attack은 돌진+투사체+임팩트, shield는 방패 링, heal은 자체 회복 연출과 별개로
+  // 시전 링(HP 변화 감지로 뜨는 playHeal과 겹치지 않게 가볍게만).
   playSkillCast(kind: "attack" | "shield" | "heal") {
     if (kind === "attack") {
-      const dx = (this.enemyCenterX - this.playerCenterX) * 0.12;
-      const dy = (this.enemyCenterY - this.playerCenterY) * 0.12;
+      const dx = (this.enemyCenterX - this.playerCenterX) * 0.14;
+      const dy = (this.enemyCenterY - this.playerCenterY) * 0.14;
       this.tweens.killTweensOf(this.playerGfx);
       const baseScale = this.playerGfx.scaleX;
+      this.playerGfx.setPosition(this.playerCenterX, this.playerCenterY);
       this.tweens.add({
         targets: this.playerGfx, x: this.playerCenterX + dx, y: this.playerCenterY + dy,
-        scaleX: baseScale * 1.08, scaleY: baseScale * 1.08, duration: 90, yoyo: true, ease: "Quad.easeOut",
+        scaleX: baseScale * 1.08, scaleY: baseScale * 1.08, duration: 100, yoyo: true, ease: "Quad.easeOut",
+      });
+      this.shoot(this.playerCenterX + dx, this.playerCenterY + dy, this.enemyCenterX, this.enemyCenterY, 0xf97316, () => {
+        this.burst(this.enemyCenterX, this.enemyCenterY, 0xfb923c, 10);
       });
       return;
     }
@@ -495,7 +785,7 @@ export default class CombatScene extends Phaser.Scene {
   }
 
   private playPulseRing(color: number) {
-    const g = this.add.graphics({ x: this.playerCenterX, y: this.playerCenterY }).setDepth(4);
+    const g = this.add.graphics({ x: this.playerCenterX, y: this.playerCenterY }).setDepth(7);
     g.lineStyle(3, color, 1);
     g.strokeCircle(0, 0, this.cell * 2.5);
     g.setScale(0.4).setAlpha(1);
@@ -506,7 +796,7 @@ export default class CombatScene extends Phaser.Scene {
     const t = this.add.text(x, y, text, {
       fontSize: "16px", color, fontStyle: "bold", resolution: RES,
       stroke: "#ffffff", strokeThickness: 4,
-    }).setOrigin(0.5).setDepth(5);
-    this.tweens.add({ targets: t, y: y - 30, alpha: 0, duration: 600, ease: "Quad.easeOut", onComplete: () => t.destroy() });
+    }).setOrigin(0.5).setDepth(8);
+    this.tweens.add({ targets: t, y: y - 30, alpha: 0, duration: 650, ease: "Quad.easeOut", onComplete: () => t.destroy() });
   }
 }

--- a/cf-idiotquant/components/game/HandView.tsx
+++ b/cf-idiotquant/components/game/HandView.tsx
@@ -187,16 +187,16 @@ function PartyMenu({ party, activeIndex, forced, onSwitch, onBack }: {
 
 // 포켓몬 대각선 배치용 — 적 정보 오버레이(주사위 등)는 좌상단, 내 정보 오버레이는 우하단에
 // 떠서 각자 반대편 코너(적 캐릭터=우상단, 내 캐릭터=좌하단)와 시선이 교차하게 배치. Phaser
-// 캔버스(CombatScene.ts)의 이름표+HP바가 그 좌상단/우하단 자리를 이미 쓰고 있어서, 이 DOM
-// 오버레이는 그 아래/위로 한 칸 밀어(top-[17%]/bottom-[26%]) 겹치지 않게 한다.
+// 캔버스(CombatScene.ts)의 크림색 정보 패널(이름/Lv/HP바)이 그 좌상단/우하단 자리를 이미 쓰고
+// 있어서, 이 DOM 오버레이는 패널 높이만큼 더 밀어(top-[26%]/bottom-[31%]) 겹치지 않게 한다.
 function Battlefield({ children, topLeftOverlay, bottomRightOverlay }: {
   children: React.ReactNode; topLeftOverlay?: React.ReactNode; bottomRightOverlay?: React.ReactNode;
 }) {
   return (
     <div className="relative w-full h-full rounded-xl">
       {children}
-      {topLeftOverlay && <div className="absolute left-1.5 top-[17%] z-10">{topLeftOverlay}</div>}
-      {bottomRightOverlay && <div className="absolute right-1.5 bottom-[26%] z-10">{bottomRightOverlay}</div>}
+      {topLeftOverlay && <div className="absolute left-1.5 top-[26%] z-10">{topLeftOverlay}</div>}
+      {bottomRightOverlay && <div className="absolute right-1.5 bottom-[31%] z-10">{bottomRightOverlay}</div>}
     </div>
   );
 }

--- a/cf-idiotquant/components/game/PhaserCombatCanvas.tsx
+++ b/cf-idiotquant/components/game/PhaserCombatCanvas.tsx
@@ -5,14 +5,16 @@
 // page.tsx에서 dynamic(..., { ssr:false })로 불러와야 함(Phaser가 window/document를 참조).
 
 import { useEffect, useRef } from "react";
-import type { EnemyState, PlayerState, SkillEffectKind } from "@/app/(game)/game/gameTypes";
+import type { EnemyState, PlayerState, SkillEffectKind, StatusKind } from "@/app/(game)/game/gameTypes";
 
-export default function PhaserCombatCanvas({ enemy, player, playerName, introLabel, level, lastSkillCast }: {
+export default function PhaserCombatCanvas({ enemy, player, playerName, introLabel, level, floor, activeStatus, lastSkillCast }: {
   enemy: EnemyState | null;
   player: PlayerState;
   playerName: string; // 좌하단 내 캐릭터 정보 박스에 표시(활성 몬스터 이름)
   introLabel: string | null; // 조우 진입 시 부모가 짧게(한 렌더) 세팅 — 보스/정예만
-  level: number; // 활성 몬스터의 육성 레벨 — 실루엣 크기에 반영
+  level: number; // 활성 몬스터의 육성 레벨 — 실루엣 크기·정보 패널 Lv 표기에 반영
+  floor: number; // 현재 층수 — 5층마다 바이옴 배경이 바뀐다(CombatScene.setFloor)
+  activeStatus?: StatusKind | null; // 활성 몬스터의 상태이상 — 정보 패널 배지
   lastSkillCast?: { kind: SkillEffectKind; seq: number } | null; // 기술 시전 이펙트 트리거(seq가 바뀔 때마다 재생)
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -22,6 +24,7 @@ export default function PhaserCombatCanvas({ enemy, player, playerName, introLab
   const prevEnemyHp = useRef<number>(0);
   const prevPlayerHp = useRef<number>(player.hp);
   const prevPlayerBlock = useRef<number>(player.block);
+  const prevPlayerName = useRef<string | null>(null);
   const latestEnemyRef = useRef(enemy);
   latestEnemyRef.current = enemy;
   const latestPlayerRef = useRef(player);
@@ -30,6 +33,10 @@ export default function PhaserCombatCanvas({ enemy, player, playerName, introLab
   latestPlayerNameRef.current = playerName;
   const latestLevelRef = useRef(level);
   latestLevelRef.current = level;
+  const latestFloorRef = useRef(floor);
+  latestFloorRef.current = floor;
+  const latestActiveStatusRef = useRef(activeStatus ?? null);
+  latestActiveStatusRef.current = activeStatus ?? null;
 
   useEffect(() => {
     let disposed = false;
@@ -53,15 +60,19 @@ export default function PhaserCombatCanvas({ enemy, player, playerName, introLab
         sceneRef.current = scene;
         // 씬이 준비되기 전에 이미 적/플레이어 상태가 정해져 있었을 수 있음(마운트 시점 경쟁) —
         // 놓치지 않게 즉시 반영.
+        scene.setFloor?.(latestFloorRef.current);
         const e = latestEnemyRef.current;
         if (e) {
-          scene.setEnemy?.(String(e.item?.name ?? "몬스터"), e.hp, e.maxHp, e.encounter);
+          scene.setEnemy?.(String(e.item?.name ?? "몬스터"), e.hp, e.maxHp, e.encounter, e.level);
+          scene.setEnemyStatus?.(e.status ?? null);
           prevEnemyTicker.current = e.item?.ticker ?? null;
           prevEnemyHp.current = e.hp;
         }
         scene.setPlayerName?.(latestPlayerNameRef.current);
+        prevPlayerName.current = latestPlayerNameRef.current;
         scene.setPlayerHp?.(latestPlayerRef.current.hp, latestPlayerRef.current.maxHp);
         scene.setPlayerLevel?.(latestLevelRef.current);
+        scene.setPlayerStatus?.(latestActiveStatusRef.current);
       });
       const ro = new ResizeObserver(() => {
         if (!containerRef.current) return;
@@ -79,29 +90,46 @@ export default function PhaserCombatCanvas({ enemy, player, playerName, introLab
     };
   }, []);
 
-  // 적 등장/변경
+  // 층수 변화 → 바이옴 배경(5층마다 실제로 바뀜 — 판단은 씬이 함)
+  useEffect(() => { sceneRef.current?.setFloor?.(floor); }, [floor]);
+
+  // 적 등장/변경/피격/기절
   useEffect(() => {
     const scene = sceneRef.current;
     if (!scene || !enemy) return;
     const id = requestAnimationFrame(() => {
       if (enemy.item?.ticker !== prevEnemyTicker.current) {
         const name = String(enemy.item?.name ?? "몬스터");
-        scene.setEnemy?.(name, enemy.hp, enemy.maxHp, enemy.encounter);
+        scene.setEnemy?.(name, enemy.hp, enemy.maxHp, enemy.encounter, enemy.level);
         // 보스/정예는 부모가 넘겨준 전용 문구, 그 외 모든 조우도 포켓몬처럼 매번 등장 배너를 띄움.
-        scene.showIntro?.(introLabel ?? `${name} 등장!`);
+        scene.showIntro?.(introLabel ?? `야생의 ${name} 등장!`);
         prevEnemyTicker.current = enemy.item?.ticker ?? null;
         prevEnemyHp.current = enemy.hp;
         return;
       }
-      if (enemy.hp < prevEnemyHp.current) scene.flashEnemyHit?.(prevEnemyHp.current - enemy.hp);
+      if (enemy.hp < prevEnemyHp.current) {
+        scene.flashEnemyHit?.(prevEnemyHp.current - enemy.hp);
+        if (enemy.hp <= 0) scene.playEnemyFaint?.();
+      }
       scene.setEnemyHp?.(enemy.hp, enemy.maxHp);
       prevEnemyHp.current = enemy.hp;
     });
     return () => cancelAnimationFrame(id);
   }, [enemy, enemy?.hp, introLabel]);
 
-  // 이름 변경(사실상 초기 1회) — 좌하단 정보 박스 라벨
-  useEffect(() => { sceneRef.current?.setPlayerName?.(playerName); }, [playerName]);
+  // 적 상태이상 배지
+  useEffect(() => { sceneRef.current?.setEnemyStatus?.(enemy?.status ?? null); }, [enemy?.status]);
+  // 내 몬스터 상태이상 배지
+  useEffect(() => { sceneRef.current?.setPlayerStatus?.(activeStatus ?? null); }, [activeStatus]);
+
+  // 이름 변경 = 몬스터 교체 — 왼쪽에서 미끄러져 들어오는 교체 투입 연출(최초 마운트 제외)
+  useEffect(() => {
+    const scene = sceneRef.current;
+    if (!scene) return;
+    scene.setPlayerName?.(playerName);
+    if (prevPlayerName.current !== null && prevPlayerName.current !== playerName) scene.playPlayerEnter?.();
+    prevPlayerName.current = playerName;
+  }, [playerName]);
 
   // 육성 레벨 변화 — 레벨업 시 실루엣 크기 변경 + 플래시(최초 마운트 값 반영 시엔 무연출).
   useEffect(() => { sceneRef.current?.setPlayerLevel?.(level); }, [level]);
@@ -112,12 +140,16 @@ export default function PhaserCombatCanvas({ enemy, player, playerName, introLab
     sceneRef.current?.playSkillCast?.(lastSkillCast.kind);
   }, [lastSkillCast]);
 
-  // 플레이어 HP/블록 변화 → 피격/방어 이펙트 + HP바 갱신
+  // 플레이어 HP/블록 변화 → 피격/방어 이펙트 + HP바 갱신 + 기절 연출
   useEffect(() => {
     const scene = sceneRef.current;
     if (!scene) return;
-    if (player.hp < prevPlayerHp.current) scene.flashPlayerHit?.(prevPlayerHp.current - player.hp);
-    else if (player.hp > prevPlayerHp.current) scene.playHeal?.(player.hp - prevPlayerHp.current);
+    if (player.hp < prevPlayerHp.current) {
+      scene.flashPlayerHit?.(prevPlayerHp.current - player.hp);
+      if (player.hp <= 0) scene.playPlayerFaint?.();
+    } else if (player.hp > prevPlayerHp.current) {
+      scene.playHeal?.(player.hp - prevPlayerHp.current);
+    }
     if (player.block > prevPlayerBlock.current) scene.flashPlayerBlock?.(player.block - prevPlayerBlock.current);
     scene.setPlayerHp?.(player.hp, player.maxHp);
     prevPlayerHp.current = player.hp;

--- a/cf-idiotquant/components/game/biomes.ts
+++ b/cf-idiotquant/components/game/biomes.ts
@@ -1,0 +1,68 @@
+// 던전 바이옴 — 5층마다 배경 테마가 통째로 바뀐다(포켓로그의 바이옴 순환 참고). 이 모듈은
+// Phaser 비의존 순수 데이터라 page.tsx(HUD 바이옴 칩)와 CombatScene.ts(캔버스 렌더링) 양쪽에서
+// 안전하게 임포트할 수 있다 — CombatScene을 직접 임포트하면 Phaser가 페이지 번들에 끌려온다.
+
+export type BiomeDecoKind = "grassland" | "forest" | "desert" | "snow" | "cave" | "volcano";
+
+export interface BiomeDef {
+  id: BiomeDecoKind;
+  name: string;
+  emoji: string;
+  skyTop: number;    // 하늘 그라데이션 위쪽 색
+  skyBottom: number; // 하늘 그라데이션 아래쪽 색
+  ground: number;    // 지면 색
+  groundDark: number; // 지면 하단(그늘) 색
+  platform: number;  // 전투 플랫폼(타원 받침) 색
+  platformEdge: number;
+  // 환경 파티클 — 바이옴 분위기를 살리는 잔잔한 입자(낙엽/눈/불씨 등). null이면 없음.
+  particle: { color: number; dir: "fall" | "rise"; countPerSec: number } | null;
+}
+
+// 진행 순서: 초원 → 숲 → 사막 → 설원 → 동굴 → 화산, 이후 다시 순환. 뒤로 갈수록 험지 느낌.
+export const BIOMES: BiomeDef[] = [
+  {
+    id: "grassland", name: "초원 지대", emoji: "🌿",
+    skyTop: 0x7dd3fc, skyBottom: 0xe0f2fe, ground: 0x4ade80, groundDark: 0x22c55e,
+    platform: 0x86efac, platformEdge: 0x16a34a,
+    particle: { color: 0xa3e635, dir: "fall", countPerSec: 1 },
+  },
+  {
+    id: "forest", name: "깊은 숲", emoji: "🌲",
+    skyTop: 0x65a30d, skyBottom: 0xd9f99d, ground: 0x3f6212, groundDark: 0x1a2e05,
+    platform: 0x84cc16, platformEdge: 0x365314,
+    particle: { color: 0x65a30d, dir: "fall", countPerSec: 2 },
+  },
+  {
+    id: "desert", name: "모래 사막", emoji: "🏜️",
+    skyTop: 0xfbbf24, skyBottom: 0xfef3c7, ground: 0xfcd34d, groundDark: 0xd97706,
+    platform: 0xfde68a, platformEdge: 0xb45309,
+    particle: { color: 0xfcd34d, dir: "rise", countPerSec: 1 },
+  },
+  {
+    id: "snow", name: "눈보라 설원", emoji: "❄️",
+    skyTop: 0x93c5fd, skyBottom: 0xeff6ff, ground: 0xe2e8f0, groundDark: 0x94a3b8,
+    platform: 0xf8fafc, platformEdge: 0x64748b,
+    particle: { color: 0xffffff, dir: "fall", countPerSec: 4 },
+  },
+  {
+    id: "cave", name: "수정 동굴", emoji: "💎",
+    skyTop: 0x334155, skyBottom: 0x64748b, ground: 0x475569, groundDark: 0x1e293b,
+    platform: 0x64748b, platformEdge: 0x0f172a,
+    particle: { color: 0x67e8f9, dir: "rise", countPerSec: 1.5 },
+  },
+  {
+    id: "volcano", name: "용암 화산", emoji: "🌋",
+    skyTop: 0x7f1d1d, skyBottom: 0xf97316, ground: 0x44403c, groundDark: 0x1c1917,
+    platform: 0x57534e, platformEdge: 0x292524,
+    particle: { color: 0xfb923c, dir: "rise", countPerSec: 3 },
+  },
+];
+
+export const BIOME_FLOORS = 5; // 한 바이옴이 이어지는 층수
+
+export function biomeIndexForFloor(floor: number): number {
+  return Math.floor(Math.max(0, floor) / BIOME_FLOORS) % BIOMES.length;
+}
+export function biomeForFloor(floor: number): BiomeDef {
+  return BIOMES[biomeIndexForFloor(floor)];
+}


### PR DESCRIPTION
## Summary
- 전투 화면을 포켓로그 수준으로 전면 개편: 층수에 따라 바뀌는 **바이옴 배경**, 포켓몬식 **전투 플랫폼 + 크림색 정보 패널**, **투사체/파티클 연출**, **상태이상 시스템**(화상/독/마비), **절차 합성 효과음**을 추가했습니다.
- 판정 로직은 기존 combatEngine/useGameRun 구조를 유지하고, Phaser 씬(CombatScene)은 순수 표시 레이어라는 아키텍처는 그대로입니다 — 라이브러리 교체 없이 Phaser 활용도를 대폭 끌어올렸습니다.

## What changed
- **바이옴 시스템** (`components/game/biomes.ts` 신규): 5층마다 배경 테마 순환(초원→숲→사막→설원→동굴→화산). 하늘 그라데이션/지면/원경 장식(나무·선인장·종유석·수정·화산)/환경 파티클(낙엽·눈·불씨·모래)을 전부 절차 드로잉으로 렌더링. HUD에 현재 바이옴 칩(🌿 초원 지대 등) 표시, 바이옴 전환 시 화면 플래시.
- **전투 화면 재구성** (`components/game/CombatScene.ts` 전면 재작성): 적/내 스프라이트 발밑에 타원 전투 플랫폼, 이름/Lv/HP바/상태이상 배지를 담은 크림색 정보 패널(어떤 바이옴 위에서도 항상 가독), HP바는 트윈으로 부드럽게 감소(포켓몬식), 몬스터 종 2종 추가(골렘/새 — 총 6종).
- **연출**: 적 등장 슬라이드 인(+보스 셰이크), 공격 돌진+투사체+임팩트 파티클, 피격 흔들림, 기절 낙하+페이드, 교체 투입 슬라이드, 회복 반짝임 상승, 레벨업 플래시+파티클.
- **상태이상 시스템** (`gameTypes.ts`/`combatEngine.ts`/`useGameRun.ts`): 화상(매 턴 최대 HP 6% 도트)/독(9% 도트)/마비(행동 25% 실패). 강공격(20%)·필살기(30%)가 적에게 화상 부여, 적 공격 적중 시 15% 확률로 내 몬스터에게 독/마비 부여. 도트만으로 처치 가능, 전투 종료(승리·도망 성공) 시 해제, 정보 패널에 색깔 배지 표시.
- **효과음** (`app/(game)/game/sfx.ts` 신규): WebAudio 오실레이터로 합성한 레트로 사운드(타격/크리티컬/방어/회복/피격/기절/상태이상/레벨업/승리/도망) — 외부 에셋 없음. 우측 상단에 음소거 토글 버튼(localStorage 유지).
- 튜토리얼에 상태이상/바이옴 항목 추가, 주사위 오버레이 위치를 새 정보 패널과 안 겹치게 조정.

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 성공
- [x] Playwright(모바일 뷰포트, 프로덕션 빌드): 6개 바이옴 각각 층수 시드 후 배경/플랫폼/패널 렌더링 스크린샷 확인, 상태이상 배지(적 화상/내 몬스터 독) 표시 확인, 전투 흐름 실주행 — 공격 후 적 화상 도트(-4)·적 반격 후 내 몬스터 독 도트(-3) 로그와 HP 계산 정확성 확인, 상태이상이 전투 중 유지되는 것 확인, 기술 시전 연출 재생 시 콘솔 에러 없음


---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_