### PR TITLE
feat(nav): 카드 게임을 admin 전용으로 숨기고 랜딩페이지에서 게임 노출 제거

### DIFF
--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -5,7 +5,7 @@ import * as THREE from "three";
 import { RoomEnvironment } from "three/examples/jsm/environments/RoomEnvironment.js";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { Gamepad2, ArrowRight, TrendingUp } from "lucide-react";
+import { Filter, ArrowRight, TrendingUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 // =========================================================================
@@ -201,169 +201,6 @@ function HeroArt() {
   return <div ref={mountRef} className="w-full h-full" aria-hidden="true" />;
 }
 
-// 게임 스텝용 3D — 심플 글로시 돛단배 아이콘 (isolated 스타일 · 소프트 그림자)
-function GameCardArt() {
-  const mountRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const mount = mountRef.current;
-    if (!mount) return;
-    const reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-
-    const scene = new THREE.Scene();
-    const camera = new THREE.PerspectiveCamera(36, 1, 0.1, 100);
-    camera.position.set(0.2, 1.35, 8.9);
-    camera.lookAt(0, 0.75, 0);
-
-    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
-    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-    renderer.toneMapping = THREE.ACESFilmicToneMapping;
-    renderer.toneMappingExposure = 1.1;
-    renderer.outputColorSpace = THREE.SRGBColorSpace;
-    const canvas = renderer.domElement;
-    canvas.style.width = "100%";
-    canvas.style.height = "100%";
-    canvas.style.display = "block";
-    mount.appendChild(canvas);
-
-    const disposables: { dispose: () => void }[] = [];
-    const pmrem = new THREE.PMREMGenerator(renderer);
-    const envRT = pmrem.fromScene(new RoomEnvironment(), 0.04);
-    scene.environment = envRT.texture;
-    pmrem.dispose();
-    disposables.push(envRT.texture);
-
-    scene.add(new THREE.HemisphereLight(0xffffff, 0xdfe6ee, 0.65));
-    const sun = new THREE.DirectionalLight(0xfff2dc, 2.4);
-    sun.position.set(-4, 6, 5);
-    scene.add(sun);
-    const fillL = new THREE.DirectionalLight(0xdfeeff, 0.7);
-    fillL.position.set(5, 2, 3);
-    scene.add(fillL);
-
-    // ── 소프트 그림자 (바닥 대신 · isolated 느낌) ──
-    const shadowTex = makeRadialTexture("rgba(16,60,40,0.55)");
-    const shadowMat = new THREE.SpriteMaterial({ map: shadowTex, transparent: true, depthWrite: false, opacity: 0.5 });
-    disposables.push(shadowTex, shadowMat);
-    const shadow = new THREE.Sprite(shadowMat);
-    shadow.scale.set(5.6, 1.6, 1);
-    shadow.position.set(0, -1.05, -0.3);
-    scene.add(shadow);
-
-    // ── 심플 글로시 돛단배 ──
-    const boat = new THREE.Group();
-    const gloss = (color: number, extra: THREE.MeshPhysicalMaterialParameters = {}) => {
-      const m = new THREE.MeshPhysicalMaterial({ color, roughness: 0.32, clearcoat: 1, clearcoatRoughness: 0.18, ...extra });
-      disposables.push(m); return m;
-    };
-
-    // 선체 (둥근 플라스틱)
-    const hullShape = new THREE.Shape();
-    hullShape.moveTo(1.85, 0.42);
-    hullShape.lineTo(-1.7, 0.42);
-    hullShape.lineTo(-1.5, 0.05);
-    hullShape.quadraticCurveTo(0, -0.72, 1.5, 0.05);
-    hullShape.lineTo(1.85, 0.42);
-    const hullGeo = new THREE.ExtrudeGeometry(hullShape, { depth: 1.15, bevelEnabled: true, bevelThickness: 0.14, bevelSize: 0.14, bevelSegments: 4, steps: 1, curveSegments: 20 });
-    hullGeo.translate(0, 0, -0.575);
-    hullGeo.computeVertexNormals();
-    disposables.push(hullGeo);
-    boat.add(new THREE.Mesh(hullGeo, gloss(0xe0492c, { roughness: 0.28 })));
-
-    // 흰색 갑판 트림
-    const trimGeo = roundedBoxGeometry(3.4, 0.16, 1.34, 0.07);
-    disposables.push(trimGeo);
-    const trim = new THREE.Mesh(trimGeo, gloss(0xfff6ec, { clearcoatRoughness: 0.1 }));
-    trim.position.set(0.05, 0.42, 0);
-    boat.add(trim);
-
-    // 돛대
-    const mastMat = gloss(0xdcbf94, { roughness: 0.5, clearcoat: 0.5 });
-    const mastGeo = new THREE.CylinderGeometry(0.06, 0.075, 2.5, 14);
-    disposables.push(mastGeo);
-    const mast = new THREE.Mesh(mastGeo, mastMat);
-    mast.position.set(0.1, 1.6, 0);
-    boat.add(mast);
-
-    // 삼각돛 2개 (솔리드 3D 패널)
-    const sailMat = gloss(0xfdf1da, { roughness: 0.55, clearcoat: 0.4, side: THREE.DoubleSide });
-    const jibMat = gloss(0xffd7c2, { roughness: 0.55, clearcoat: 0.4, side: THREE.DoubleSide });
-    const mkSail = (pts: [number, number][], mat: THREE.Material, depth = 0.08) => {
-      const s = new THREE.Shape();
-      s.moveTo(pts[0][0], pts[0][1]); s.lineTo(pts[1][0], pts[1][1]); s.lineTo(pts[2][0], pts[2][1]); s.lineTo(pts[0][0], pts[0][1]);
-      const g = new THREE.ExtrudeGeometry(s, { depth, bevelEnabled: true, bevelThickness: 0.03, bevelSize: 0.03, bevelSegments: 1, steps: 1 });
-      g.translate(0, 0, -depth / 2);
-      disposables.push(g);
-      const m = new THREE.Mesh(g, mat); m.position.set(0.1, 0, 0);
-      boat.add(m);
-    };
-    mkSail([[0, 0.2], [0, 2.65], [-1.4, 0.25]], sailMat);   // 메인 돛 (뒤)
-    mkSail([[0, 0.4], [0, 2.45], [1.3, 0.35]], jibMat);     // 지브 (앞)
-
-    // 깃발
-    const flagGeo = new THREE.ConeGeometry(0.13, 0.52, 3);
-    disposables.push(flagGeo);
-    const flag = new THREE.Mesh(flagGeo, gloss(0x16a34a, { roughness: 0.45 }));
-    flag.rotation.z = -Math.PI / 2; flag.position.set(0.35, 2.8, 0);
-    boat.add(flag);
-
-    boat.position.set(0, -0.15, 0);
-    scene.add(boat);
-
-    // ── 물결 컬 (심플 흰 포말) ──
-    const foamTex = makeRadialTexture("rgba(255,255,255,0.9)");
-    const foamMat = new THREE.SpriteMaterial({ map: foamTex, transparent: true, depthWrite: false, opacity: 0.85 });
-    disposables.push(foamTex, foamMat);
-    const foams: { s: THREE.Sprite; by: number; sc: number; ph: number }[] = [];
-    ([[1.85, -0.32, 0.66], [-1.75, -0.34, 0.6], [2.2, -0.14, 0.42], [-2.15, -0.18, 0.4]] as [number, number, number][]).forEach(([x, y, sc], i) => {
-      const s = new THREE.Sprite(foamMat); s.scale.set(sc, sc * 0.6, 1); s.position.set(x, y, 0.15);
-      scene.add(s); foams.push({ s, by: y, sc, ph: i * 1.3 });
-    });
-
-    const resize = () => {
-      const w = mount.clientWidth || 1, h = mount.clientHeight || 1;
-      renderer.setSize(w, h, false);
-      camera.aspect = w / h;
-      camera.updateProjectionMatrix();
-    };
-    resize();
-    const ro = new ResizeObserver(resize);
-    ro.observe(mount);
-
-    const clock = new THREE.Clock();
-    let raf = 0;
-    const render = () => {
-      const t = clock.getElapsedTime();
-      boat.position.y = -0.15 + Math.sin(t * 1.4) * 0.08;
-      boat.rotation.z = Math.sin(t * 1.1) * 0.05;
-      boat.rotation.y = Math.sin(t * 0.35) * 0.16;
-      foams.forEach(({ s, by, sc, ph }) => {
-        const p = (Math.sin(t * 2.6 + ph) + 1) / 2;
-        s.position.y = by + Math.sin(t * 2.0 + ph) * 0.04;
-        s.scale.set(sc * (0.85 + p * 0.3), sc * 0.6 * (0.85 + p * 0.3), 1);
-      });
-      renderer.render(scene, camera);
-      raf = requestAnimationFrame(render);
-    };
-    if (reduce) {
-      boat.rotation.y = 0.1;
-      renderer.render(scene, camera);
-    } else {
-      raf = requestAnimationFrame(render);
-    }
-
-    return () => {
-      cancelAnimationFrame(raf);
-      ro.disconnect();
-      disposables.forEach(d => d.dispose());
-      renderer.dispose();
-      if (canvas.parentNode) canvas.parentNode.removeChild(canvas);
-    };
-  }, []);
-
-  return <div ref={mountRef} className="w-full h-full" aria-hidden="true" />;
-}
-
 // 온보딩 스텝용 3D — 회전하는 글로시 오브젝트 (coin: 금화 / gem: 에메랄드 젬)
 function SpinArt({ kind }: { kind: "coin" | "gem" }) {
   const mountRef = useRef<HTMLDivElement>(null);
@@ -506,25 +343,19 @@ function StatsBand() {
   );
 }
 
-// 순차 온보딩 3단계 — 각 단계는 3D 이미지 + 한 줄 설명 + 단일 CTA
+// 순차 온보딩 2단계 — 각 단계는 3D 이미지 + 한 줄 설명 + 단일 CTA
 const STEPS: {
   n: string; tag: string; title: string; desc: string; cta: string; href: string;
   art: React.ReactNode; tint: string;
 }[] = [
   {
-    n: "01", tag: "PLAY", title: "카드 게임으로 시작",
-    desc: "두 종목을 비교하는 카드 게임으로 가치투자 감각을 놀이처럼 익혀요. 회원가입 없이 바로 시작합니다.",
-    cta: "게임 시작하기", href: "/game", art: <GameCardArt />,
-    tint: "from-[#eaf5ee] to-white dark:from-[#0e2019] dark:to-[#161511]",
-  },
-  {
-    n: "02", tag: "DISCOVER", title: "저평가 종목 발굴",
-    desc: "게임으로 익힌 감각을 실제 시장에. 검증된 퀀트 전략으로 숨어 있는 저평가 종목을 스캔해요.",
+    n: "01", tag: "DISCOVER", title: "저평가 종목 발굴",
+    desc: "검증된 퀀트 전략으로 숨어 있는 저평가 종목을 스캔해요. 회원가입 없이 바로 시작합니다.",
     cta: "종목 발굴하기", href: "/screener?mincap=500", art: <SpinArt kind="coin" />,
     tint: "from-[#fdf6e9] to-white dark:from-[#241d0e] dark:to-[#161511]",
   },
   {
-    n: "03", tag: "ANALYZE", title: "적정주가 분석",
+    n: "02", tag: "ANALYZE", title: "적정주가 분석",
     desc: "관심 종목의 내재가치를 재무 데이터로 직접 계산해, 지금 가격이 싼지 비싼지 판단해요.",
     cta: "종목 분석하기", href: "/analyze", art: <SpinArt kind="gem" />,
     tint: "from-[#eafaf0] to-white dark:from-[#0e2016] dark:to-[#161511]",
@@ -555,25 +386,25 @@ export default function HomePage() {
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75" />
               <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-emerald-500" />
             </span>
-            게임으로 배우는 주식·경제
+            데이터로 배우는 주식·경제
           </div>
 
           <h1 className="text-[2.3rem] sm:text-[3.2rem] md:text-[4rem] font-black leading-[1.06] tracking-tight mb-4 text-neutral-900 dark:text-neutral-50">
-            주식이 게임처럼,<br />
+            주식 분석이,<br />
             <span className="bg-gradient-to-r from-[#16a34a] to-emerald-500 dark:from-[#22c55e] dark:to-emerald-400 bg-clip-text text-transparent">쉽고 재미있게.</span>
           </h1>
 
           <p className="text-sm sm:text-base text-neutral-600 dark:text-neutral-300 font-medium break-keep max-w-md">
-            종목 카드 게임으로 시작해, 실제 시장 데이터로 주식·경제 감각을 키웁니다.
+            검증된 퀀트 전략과 실제 시장 데이터로 주식·경제 감각을 키웁니다.
           </p>
 
           <div className="mt-8">
             <Link
-              href="/game"
+              href="/screener?mincap=500"
               className="group inline-flex items-center gap-2 px-7 py-4 rounded-2xl bg-[#16a34a] hover:bg-[#15803d] active:bg-[#166534] text-white font-bold text-base shadow-lg shadow-[#16a34a]/25 transition-all hover:-translate-y-0.5"
             >
-              <Gamepad2 size={18} strokeWidth={2.5} />
-              게임으로 무료 시작
+              <Filter size={18} strokeWidth={2.5} />
+              종목 발굴 무료 시작
               <ArrowRight size={16} className="group-hover:translate-x-0.5 transition-transform" />
             </Link>
           </div>
@@ -638,11 +469,11 @@ export default function HomePage() {
           </div>
           <div className="max-w-md mx-auto text-center relative">
             <h2 className="text-2xl font-black text-neutral-900 dark:text-neutral-50 mb-3 tracking-tight leading-tight">
-              발굴한 카드를 모으려면?
+              발굴한 종목을 모으려면?
             </h2>
             <ul className="space-y-2.5 mb-6 text-left inline-block">
               {[
-                "게임에서 발굴한 종목 카드 영구 보관",
+                "관심 종목 영구 보관 및 분석 이력 저장",
                 "스크리너 즐겨찾기 및 포트폴리오 저장",
                 "신규 저평가 종목 알림 수신",
               ].map(item => (
@@ -675,7 +506,6 @@ export default function HomePage() {
           </div>
           <div className="flex items-center gap-4">
             {[
-              { label: "게임", href: "/game" },
               { label: "발굴", href: "/screener" },
               { label: "분석", href: "/analyze" },
               { label: "계산기", href: "/calculator" },

--- a/cf-idiotquant/components/navigation.tsx
+++ b/cf-idiotquant/components/navigation.tsx
@@ -34,10 +34,10 @@ type NavItem = {
   adminOnly?: boolean;
 };
 
-// 순서·아이콘을 홈 온보딩 설명 순서에 맞춤: 게임(⛵) → 발굴(🥇) → 분석(💎)
+// 순서·아이콘을 홈 온보딩 설명 순서에 맞춤: 발굴(🥇) → 분석(💎). 게임(⛵)은 admin 전용.
 const MAIN_NAV: NavItem[] = [
   { label: "홈",        href: "/",           icon: Home,       exact: true  },
-  { label: "카드 게임", href: "/game",        icon: Gamepad2,   emoji: "⛵", badge: "New" },
+  { label: "카드 게임", href: "/game",        icon: Gamepad2,   emoji: "⛵", badge: "New", adminOnly: true },
   { label: "종목 발굴", href: "/screener",    icon: Filter,     emoji: "🥇", badge: "Pro" },
   { label: "전략 히스토리", href: "/backtest", icon: History, adminOnly: true },
   { label: "적정 주가", href: "/analyze",     icon: Search,     emoji: "💎"   },
@@ -370,12 +370,13 @@ export function NavbarWithSimpleLinks() {
       {/* ══ MOBILE BOTTOM TAB BAR ════════════════════════════════════ */}
       <nav className="md:hidden fixed bottom-0 left-0 right-0 h-[64px] z-40 bg-white/95 dark:bg-[#1f1e1b]/95 backdrop-blur-xl border-t border-neutral-200/70 dark:border-[#3a3834] flex items-center px-3">
         <TabItem href="/"           label="홈"     icon={Home}       isActive={pathname === "/"} />
-        {/* 게임 화면에선 게임 탭이 '내 덱'으로 전환 — 게임 페이지 상단 바 제거분을 통합. 덱 닫기는 덱 화면의 '게임으로' 버튼 */}
-        {pathname.startsWith("/game") ? (
+        {/* 게임은 admin 전용 — 사이드바(MAIN_NAV의 adminOnly)와 같은 기준. 게임 화면에선 게임
+            탭이 '내 덱'으로 전환된다(게임 페이지 상단 바 제거분 통합, 덱 닫기는 덱 화면의 '게임으로' 버튼) */}
+        {isAdmin && (pathname.startsWith("/game") ? (
           <TabItem href="/game?deck=1" label="내 덱" icon={Layers} isActive={true} />
         ) : (
           <TabItem href="/game"       label="게임"   icon={Gamepad2}   emoji="⛵" isActive={false} />
-        )}
+        ))}
         <TabItem href="/screener"   label="발굴"   icon={Filter}     emoji="🥇" isActive={pathname.startsWith("/screener")} />
         {isAdmin && (
           <TabItem href="/backtest"   label="히스토리" icon={History}  isActive={pathname.startsWith("/backtest")} />


### PR DESCRIPTION
## Summary
- 카드 게임을 **admin 로그인 시에만** 네비게이션에 노출되도록 변경했습니다(데스크톱 사이드바 + 모바일 하단탭 양쪽).
- **랜딩페이지에서 게임 노출을 전부 제거**했습니다 — 온보딩 스텝, 히어로 CTA, 전환 CTA 문구, 푸터 링크.
- `/game` 라우트 자체는 그대로 접근 가능합니다. 이번 변경은 **노출 경로만** 제거하며, 미들웨어의 public 경로 설정도 건드리지 않았습니다.

## What changed

**`components/navigation.tsx`**
- `MAIN_NAV`의 "카드 게임" 항목에 `adminOnly: true` 추가 — 사이드바는 기존 `MAIN_NAV.filter(item => !item.adminOnly || isAdmin)`가 그대로 처리하므로 별도 분기 불필요. 게임이 필터링되면 그 하위의 "내 덱" 서브링크도 함께 사라집니다.
- 모바일 하단탭의 게임/내 덱 탭을 `isAdmin &&`로 감싸 사이드바와 동일 기준 적용.

**`app/(home)/page.tsx`**
- 온보딩 스텝에서 게임 단계(`01 PLAY 카드 게임으로 시작`) 제거 → **01 DISCOVER 발굴 · 02 ANALYZE 분석**으로 재정렬.
- 히어로: 배지 `게임으로 배우는` → `데이터로 배우는`, H1 `주식이 게임처럼` → `주식 분석이`, 서브카피에서 카드 게임 언급 제거, CTA `게임으로 무료 시작`(→`/game`) → `종목 발굴 무료 시작`(→`/screener?mincap=500`).
- 전환 CTA: `발굴한 카드를 모으려면?` → `발굴한 종목을 모으려면?`, `게임에서 발굴한 종목 카드 영구 보관` → `관심 종목 영구 보관 및 분석 이력 저장`.
- 푸터에서 `게임` 링크 제거.
- 위 변경으로 orphan이 된 `GameCardArt`(3D 돛단배 three.js 컴포넌트, 163줄)와 `Gamepad2` import 정리, CTA 아이콘용 `Filter` import 추가.

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 성공
- [x] Playwright로 **비로그인 / 일반유저 / admin × 데스크톱 / 모바일** 6개 조합 검증 (next-auth 세션 엔드포인트 목킹):

  | 뷰포트 | 세션 | nav 내 `/game` 링크 | 페이지 전체 `/game` 링크 |
  |---|---|---|---|
  | desktop | 비로그인 | 0 | 0 |
  | desktop | 일반유저 | 0 | 0 |
  | desktop | admin | 2 | 2 |
  | mobile | 비로그인 | 0 | 0 |
  | mobile | 일반유저 | 0 | 0 |
  | mobile | admin | 2 | 2 |

  (admin의 2건 = 데스크톱 사이드바 항목 + 모바일 하단탭 항목. 반대 뷰포트의 것은 CSS로 숨겨져 있을 뿐 DOM에는 존재.)
- [x] 랜딩페이지 소스에 `게임`/`/game` 문자열 잔여 0건 확인
- [x] 온보딩 스텝 렌더링 확인 — 태그 순서 `DISCOVER → ANALYZE`, `03` 잔여 없음, 좌우 교차 레이아웃 정상


---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_