### PR TITLE
feat(analyze): 종목 카드를 탭 바 선택지로 편입

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -303,6 +303,7 @@ const DEFAULT_XP_PROFILE = { level: 1, xp: 0, maxXp: 100, totalXp: 0, lastGain: 
 // (예전엔 모바일만 탭이고 데스크톱은 네 섹션이 전부 펼쳐져 스크롤이 길었다)
 const DETAIL_TABS = [
   { key: 'strategy', label: '전략' },
+  { key: 'card', label: '카드' },
   { key: 'analysis', label: '분석' },
   { key: 'risk', label: '위험도' },
   { key: 'financials', label: '재무' },
@@ -776,8 +777,10 @@ function AnalyzeContent() {
                 </div>
               )}
 
-              {/* 종목 카드 — 핵심 지표(NCAV·PBR·PER·ROE)까지 카드가 함께 표시한다 */}
-              <div className="mb-6">
+              {/* 종목 카드 — 핵심 지표(NCAV·PBR·PER·ROE)까지 카드가 함께 표시한다.
+                  다른 섹션과 마찬가지로 탭 하나로 다룬다. 항상 펼쳐 두면 어떤 탭을 골라도
+                  카드 높이만큼 스크롤을 먼저 지나야 본문에 닿는다. */}
+              <div className={cn("mb-6", activeTab !== 'card' && 'hidden')}>
                 <StockCard
                   stock={krOrUs === 'US' ? {
                     code: tickerFromUrl, isUs: true, name: displayName, ticker: name,


### PR DESCRIPTION
## 변경 사항

analyze 페이지 상단 탭 바에 **`카드`** 탭을 추가하고, 그동안 탭과 무관하게 항상 펼쳐져 있던 종목 카드(StockCard)를 이 탭의 콘텐츠로 옮겼습니다.

- `DETAIL_TABS` — `전략 / 카드 / 분석 / 위험도 / 재무` (전략은 첫 번째 유지)
- 종목 카드 블록을 다른 섹션과 동일한 방식(`activeTab !== 'card' && 'hidden'`)으로 처리

## 이유

카드가 항상 렌더링돼 있어서 어떤 탭을 골라도 카드 높이만큼 스크롤을 먼저 지나야 해당 탭 본문에 닿았습니다. 카드도 하나의 뷰로 다루면 탭 선택이 곧 화면 내용이 됩니다.

## 유지한 것

- 기본 탭은 기존과 같이 `전략`
- 상단 **종합 판단** 배너는 결론 요약이라 탭과 무관하게 계속 노출

## 검증

- `npx tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_