### PR TITLE
feat(analyze): 모바일 종합 판단을 한 줄로 축약

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -743,36 +743,54 @@ function AnalyzeContent() {
 
             <div className={cn(!isPriceLoaded ? 'hidden' : 'animate-in fade-in duration-400')}>
 
-              {/* 종합 판단 — 지표 나열보다 먼저 결론을 준다 (판단 → 근거 → 원자료 순서) */}
+              {/* 종합 판단 — 지표 나열보다 먼저 결론을 준다 (판단 → 근거 → 원자료 순서).
+                  모바일은 한 줄(충족 개수 + 결론 문장)만 남긴다. 지표 4개는 세로로 쌓이면서
+                  화면 첫 장을 다 먹었는데, 같은 값이 바로 아래 '카드' 탭에도 있다. */}
               {verdict && (
-                <div className={cn("rounded-2xl border p-5 sm:p-6 mb-5", VERDICT_TONE[verdict.tone].box)}>
-                  <p className={cn("text-[10px] font-extrabold uppercase tracking-[0.1em] mb-2", VERDICT_TONE[verdict.tone].label)}>
-                    종합 판단 · 저평가 기준 4개 중 {verdict.metCount}개 충족
-                  </p>
-                  <p className={cn("text-[14.5px] font-extrabold leading-relaxed break-keep", VERDICT_TONE[verdict.tone].text)}>
-                    {verdict.lead}
-                  </p>
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 mt-3.5">
-                    {verdict.checks.map(c => (
-                      <div key={c.label}
-                        className="flex items-center gap-2.5 px-3 py-2 rounded-xl border border-neutral-200/70 dark:border-[#3a3834]/70 bg-white/70 dark:bg-[#1a1915]/40">
-                        <span className={cn(
-                          "w-4 h-4 rounded-full grid place-items-center text-[9px] font-black text-white shrink-0",
-                          c.ok ? "bg-[#16a34a]" : "bg-neutral-300 dark:bg-[#4a4641]"
-                        )}>
-                          {c.ok ? '✓' : '✕'}
-                        </span>
-                        <span className="text-[11.5px] font-bold text-neutral-600 dark:text-neutral-300 truncate">{c.label}</span>
-                        {/* 기준을 같이 적는다 — 값만 보면 왜 ✓/✕ 인지 알 수 없다 */}
-                        <span className="text-[10px] text-neutral-400 dark:text-neutral-500 truncate hidden sm:inline">{c.criterion}</span>
-                        <span className={cn(
-                          "ml-auto text-[12.5px] font-black font-mono tabular-nums shrink-0",
-                          c.ok ? "text-[#16a34a] dark:text-emerald-400" : "text-neutral-400 dark:text-neutral-500"
-                        )}>
-                          {c.value}
-                        </span>
-                      </div>
-                    ))}
+                <div className={cn("rounded-2xl border p-3 sm:p-6 mb-4 sm:mb-5", VERDICT_TONE[verdict.tone].box)}>
+                  {/* 모바일 — 한 줄. truncate 로 문장이 길어져도 줄바꿈이 생기지 않게 못 박는다.
+                      글자·여백 치수는 가장 긴 문장이 320px 화면에서 잘리지 않게 맞춘 값이다. */}
+                  <div className="flex items-center gap-1.5 sm:hidden">
+                    <span className={cn(
+                      "shrink-0 px-1.5 py-0.5 rounded-full text-[11px] font-black font-mono tabular-nums bg-white/70 dark:bg-[#1a1915]/50",
+                      VERDICT_TONE[verdict.tone].label
+                    )}>
+                      {verdict.metCount}/{verdict.checks.length}
+                    </span>
+                    <p className={cn("text-[12px] font-extrabold truncate", VERDICT_TONE[verdict.tone].text)}>
+                      {verdict.lead}
+                    </p>
+                  </div>
+
+                  <div className="hidden sm:block">
+                    <p className={cn("text-[10px] font-extrabold uppercase tracking-[0.1em] mb-2", VERDICT_TONE[verdict.tone].label)}>
+                      종합 판단 · 저평가 기준 {verdict.checks.length}개 중 {verdict.metCount}개 충족
+                    </p>
+                    <p className={cn("text-[14.5px] font-extrabold leading-relaxed break-keep", VERDICT_TONE[verdict.tone].text)}>
+                      {verdict.lead}
+                    </p>
+                    <div className="grid grid-cols-2 gap-2 mt-3.5">
+                      {verdict.checks.map(c => (
+                        <div key={c.label}
+                          className="flex items-center gap-2.5 px-3 py-2 rounded-xl border border-neutral-200/70 dark:border-[#3a3834]/70 bg-white/70 dark:bg-[#1a1915]/40">
+                          <span className={cn(
+                            "w-4 h-4 rounded-full grid place-items-center text-[9px] font-black text-white shrink-0",
+                            c.ok ? "bg-[#16a34a]" : "bg-neutral-300 dark:bg-[#4a4641]"
+                          )}>
+                            {c.ok ? '✓' : '✕'}
+                          </span>
+                          <span className="text-[11.5px] font-bold text-neutral-600 dark:text-neutral-300 truncate">{c.label}</span>
+                          {/* 기준을 같이 적는다 — 값만 보면 왜 ✓/✕ 인지 알 수 없다 */}
+                          <span className="text-[10px] text-neutral-400 dark:text-neutral-500 truncate">{c.criterion}</span>
+                          <span className={cn(
+                            "ml-auto text-[12.5px] font-black font-mono tabular-nums shrink-0",
+                            c.ok ? "text-[#16a34a] dark:text-emerald-400" : "text-neutral-400 dark:text-neutral-500"
+                          )}>
+                            {c.value}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## 변경 사항

analyze 페이지 상단 **종합 판단** 배너를 모바일(`< sm`)에서 한 줄로 축약했습니다.

- 모바일: `충족 개수 배지(2/4)` + `결론 문장` 한 줄만 표시
- 지표 4개(NCAV·PBR·PER·ROE) 체크 카드는 `sm` 이상에서만 표시
- 박스 패딩 `p-5 sm:p-6` → `p-3 sm:p-6`, 마진 `mb-5` → `mb-4 sm:mb-5`

`sm` 이상 레이아웃은 기존과 동일합니다(라벨 줄 + 결론 문장 + 2열 체크 그리드).

## 이유

지표 4개가 모바일에서 `grid-cols-1` 로 세로로 쌓이면서 배너 하나가 첫 화면을 거의 다 차지했습니다. 같은 값은 바로 아래 `카드` 탭에도 있어서, 모바일에서는 결론만 남기는 편이 스크롤 비용 대비 이득이 큽니다.

## 검증

로컬에 임시 프리뷰 라우트를 만들어 Playwright 로 실측한 뒤 삭제했습니다(커밋에는 포함되지 않음).

| 뷰포트 | 배너 높이 | 결론 문장 줄 수 | 말줄임 발생 |
|---|---|---|---|
| 320px | 47px | 1 | 없음 |
| 375px | 47px | 1 | 없음 |
| 430px | 47px | 1 | 없음 |
| 900px | 192px (기존과 동일) | — | 체크 4개 정상 |

- `truncate`(`white-space: nowrap`)로 어떤 문장이 들어와도 줄바꿈이 불가능하게 고정
- 가장 긴 문장("저평가 신호가 일부에서만 나타납니다.")이 320px 에서 8px 넘쳐 말줄임되던 것을 글자 `12px` + `gap-1.5` + 배지 `px-1.5` 로 맞춰 해소
- `npx tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_