### PR TITLE
fix(mobile): 종합 판단 펼치기 + 배경 씬 높이 고정 + 캔들 배치

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -19,7 +19,7 @@ import { useStockSearch } from '@/app/(search)/search/hooks/useStockSearch';
 import { selectKrMarketHistory } from '@/lib/features/searchHistory/searchHistorySlice';
 import {
   AlertCircle, Loader2, Flame, Share2, Check, CheckCircle,
-  Search, Heart, X, TrendingUp, ChevronLeft, Lock, ArrowRight,
+  Search, Heart, X, TrendingUp, ChevronLeft, ChevronDown, Lock, ArrowRight,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -408,6 +408,8 @@ function AnalyzeContent() {
   const [staticStockData, setStaticStockData] = useState<StaticStockData>({ allTickers: [], corpCodeJson: {} });
   const [shareStatus, setShareStatus] = useState<'idle' | 'copied' | 'error'>('idle');
   const [activeTab, setActiveTab] = useState<DetailTab>('strategy');
+  // 모바일 종합 판단 — 한 줄 요약을 눌러 지표 4개(기준·값·충족 여부)를 펼친다
+  const [verdictOpen, setVerdictOpen] = useState(false);
   // 결과를 보는 중에는 검색줄을 접어 헤더가 종목 정보를 대신 보여준다
   const [searchOpen, setSearchOpen] = useState(false);
 
@@ -748,19 +750,52 @@ function AnalyzeContent() {
                   화면 첫 장을 다 먹었는데, 같은 값이 바로 아래 '카드' 탭에도 있다. */}
               {verdict && (
                 <div className={cn("rounded-2xl border p-3 sm:p-6 mb-4 sm:mb-5", VERDICT_TONE[verdict.tone].box)}>
-                  {/* 모바일 — 한 줄. truncate 로 문장이 길어져도 줄바꿈이 생기지 않게 못 박는다.
-                      글자·여백 치수는 가장 긴 문장이 320px 화면에서 잘리지 않게 맞춘 값이다. */}
-                  <div className="flex items-center gap-1.5 sm:hidden">
+                  {/* 모바일 — 한 줄 요약. 눌러서 지표 4개를 펼친다(접힌 상태가 기본).
+                      truncate 로 문장이 길어져도 줄바꿈이 생기지 않게 못 박는다. */}
+                  <button
+                    type="button"
+                    onClick={() => setVerdictOpen(o => !o)}
+                    aria-expanded={verdictOpen}
+                    className="w-full flex items-center gap-1 sm:hidden text-left"
+                  >
                     <span className={cn(
                       "shrink-0 px-1.5 py-0.5 rounded-full text-[11px] font-black font-mono tabular-nums bg-white/70 dark:bg-[#1a1915]/50",
                       VERDICT_TONE[verdict.tone].label
                     )}>
                       {verdict.metCount}/{verdict.checks.length}
                     </span>
-                    <p className={cn("text-[12px] font-extrabold truncate", VERDICT_TONE[verdict.tone].text)}>
+                    <span className={cn("min-w-0 flex-1 text-[11.5px] font-extrabold truncate", VERDICT_TONE[verdict.tone].text)}>
                       {verdict.lead}
-                    </p>
-                  </div>
+                    </span>
+                    <ChevronDown
+                      size={11}
+                      className={cn("shrink-0 transition-transform", VERDICT_TONE[verdict.tone].label, verdictOpen && "rotate-180")}
+                    />
+                  </button>
+
+                  {/* 펼친 내용 — 좁은 폭이라 한 줄에 하나씩. 기준을 같이 적어야 왜 ✓/✕ 인지 읽힌다 */}
+                  {verdictOpen && (
+                    <div className="mt-2.5 pt-2.5 border-t border-neutral-200/70 dark:border-[#3a3834]/70 flex flex-col gap-1.5 sm:hidden">
+                      {verdict.checks.map(c => (
+                        <div key={c.label} className="flex items-center gap-2">
+                          <span className={cn(
+                            "w-4 h-4 rounded-full grid place-items-center text-[9px] font-black text-white shrink-0",
+                            c.ok ? "bg-[#16a34a]" : "bg-neutral-300 dark:bg-[#4a4641]"
+                          )}>
+                            {c.ok ? '✓' : '✕'}
+                          </span>
+                          <span className="text-[11.5px] font-bold text-neutral-600 dark:text-neutral-300 shrink-0">{c.label}</span>
+                          <span className="text-[10px] text-neutral-400 dark:text-neutral-500 truncate">{c.criterion}</span>
+                          <span className={cn(
+                            "ml-auto text-[12px] font-black font-mono tabular-nums shrink-0",
+                            c.ok ? "text-[#16a34a] dark:text-emerald-400" : "text-neutral-400 dark:text-neutral-500"
+                          )}>
+                            {c.value}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
 
                   <div className="hidden sm:block">
                     <p className={cn("text-[10px] font-extrabold uppercase tracking-[0.1em] mb-2", VERDICT_TONE[verdict.tone].label)}>

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -179,7 +179,8 @@ function HeroArt() {
     const CANDLE_SERIES = [0.7, 0.95, 0.85, 1.2, 1.45, 1.28, 1.65, 1.95, 1.75, 2.15, 2.45, 2.28, 2.7, 2.95, 3.2];
     // 좁은 화면에 15개를 다 밀어 넣으면 몸통이 성냥개비처럼 얇아지고 양끝이 잘린다 → 최근 구간만
     // 잘라 보여준다(상승 흐름은 그대로 읽히고 캔들 두께도 지킬 수 있다).
-    const CANDLE_H = narrowVp ? CANDLE_SERIES.slice(4) : CANDLE_SERIES;
+    // 개수를 더 줄인 이유는 아래 CANDLE_GAP 주석 참고 — 같은 폭에 띄엄띄엄 세우기 위해서다.
+    const CANDLE_H = narrowVp ? CANDLE_SERIES.slice(6) : CANDLE_SERIES;
     const N = CANDLE_H.length;
     // 가장 앞(오른쪽 끝) 캔들의 깊이 — 바닥 금화 더미보다는 뒤에 둔다.
     // 좁은 화면에선 한 겹 더 뒤로 민다. 프레임이 좁아 캔들이 금화·헤드라인과 같은 평면에 선 것처럼
@@ -187,7 +188,12 @@ function HeroArt() {
     // 글씨 뒤로 떨어지는 금화가 z −3.6~−2.6 을 쓰므로, 캔들 뒤끝(CANDLE_Z − CANDLE_ARC)이
     // 그 구간에 닿으면 금화가 캔들 몸통을 파고들어 박힌 것처럼 보인다.
     const CANDLE_Z = narrowVp ? -1.5 : -0.6;
-    const CANDLE_GAP = narrowVp ? 0.56 : 1.05;
+    // 좁은 화면에서는 캔들을 띄엄띄엄 세운다. 개수를 11 → 9로 줄이고 간격을 그만큼 넓혀
+    // 전체 폭(약 6.3)은 그대로 두면서 몸통 사이 빈 자리만 벌린다. 예전엔 몸통끼리 거의 붙어
+    // 초록·빨강 벽처럼 보였고, 배경으로 물러나야 할 차트가 헤드라인과 경쟁했다.
+    const CANDLE_GAP = narrowVp ? 0.70 : 1.05;
+    // 몸통 폭은 간격에 비례 — 좁은 화면은 비율을 낮춰 빈 자리를 몸통만큼 확보한다
+    const CANDLE_BODY_RATIO = narrowVp ? 0.5 : 0.66;
     const CANDLE_HS = narrowVp ? 0.7 : 1; // 화면이 좁으면 높이도 낮춰 가로:세로 비율을 유지
     const CANDLE_ARC = narrowVp ? 1.0 : 1.7;   // 왼쪽 끝이 뒤로 물러나는 거리
     // 어두운 무대에서는 짙은 그림자가 배경과 구분되지 않는다 → 아주 옅게만 깔아 캔들 밑동만 눌러준다
@@ -209,7 +215,7 @@ function HeroArt() {
       const h = CANDLE_H[i] * CANDLE_HS;
       const up = h >= prev; prev = h;
       const mat = up ? upMat : dnMat;
-      const bw = CANDLE_GAP * 0.66; // 몸통 폭은 간격에 비례 — 겹치지도, 성기지도 않게
+      const bw = CANDLE_GAP * CANDLE_BODY_RATIO;
       const geo = new THREE.BoxGeometry(bw, h, bw);
       const wickGeo = new THREE.BoxGeometry(bw * 0.24, h * 0.28, bw * 0.24); // 짧고 도톰한 심지
       disposables.push(geo, wickGeo);

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -382,10 +382,9 @@ function HeroArt() {
       camera.updateProjectionMatrix();
     };
     resize();
-    // 모바일 스크롤 중엔 주소창이 접히며 min-h-[88dvh] 컨테이너 높이가 계속 미세하게 바뀌어
-    // ResizeObserver가 연속 발화한다. 그때마다 renderer.setSize()(프레임버퍼 재할당, 비용 큼)를
-    // 동기 호출하면 스크롤이 끊겨 보인다. 캔버스는 이미 CSS로 100% 채워지므로, 실제 렌더 해상도
-    // 갱신은 리사이즈가 잦아든 뒤 한 번만 하도록 디바운스한다.
+    // 컨테이너 높이는 100vh 로 고정돼 있어(마운트하는 쪽 주석 참고) 스크롤만으로는 리사이즈가
+    // 일어나지 않는다. 남는 경우는 화면 회전·창 크기 변경뿐인데, renderer.setSize()는
+    // 프레임버퍼를 다시 잡는 비싼 호출이라 연속 발화하면 끊겨 보인다 → 잦아든 뒤 한 번만.
     let resizeTimer: ReturnType<typeof setTimeout> | undefined;
     const ro = new ResizeObserver(() => {
       clearTimeout(resizeTimer);
@@ -780,9 +779,14 @@ export default function HomePage() {
       {/* ── 페이지 전체 배경 ────────────────────────────────────────
           3D 씬을 히어로 안이 아니라 뷰포트에 고정해 둔다. 그래야 스크롤을 내려도 금화가
           계속 떨어지며 아래 섹션의 배경이 된다(히어로 안에 두면 히어로를 벗어나는 순간 잘린다).
-          그라디언트 → 금화 → 콘텐츠 순으로 겹친다. */}
-      <div className="fixed inset-0 z-0 pointer-events-none bg-[radial-gradient(130%_90%_at_74%_-10%,#143725_0%,#0a1b12_46%,#050d09_100%)]" />
-      <div className="fixed inset-0 z-[1] pointer-events-none">
+          그라디언트 → 금화 → 콘텐츠 순으로 겹친다.
+
+          높이는 inset-0 대신 h-screen(100vh)으로 고정한다. 모바일에서 fixed inset-0 은
+          주소창이 접혔다 펴질 때마다 따라 늘었다 줄고, 그때마다 캔버스가 리사이즈되면서
+          스크롤 중에 배경이 커졌다 작아졌다 한다. 100vh 는 모바일에서 "주소창이 접힌
+          상태"의 큰 뷰포트에 고정된 값이라 스크롤 내내 변하지 않는다. */}
+      <div className="fixed inset-x-0 top-0 h-screen z-0 pointer-events-none bg-[radial-gradient(130%_90%_at_74%_-10%,#143725_0%,#0a1b12_46%,#050d09_100%)]" />
+      <div className="fixed inset-x-0 top-0 h-screen z-[1] pointer-events-none">
         <HeroArt />
       </div>
 

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -228,7 +228,17 @@ function HeroArt() {
       shadow.scale.set(bw * 2.6, bw * 2.6, 1);
       g.add(shadow, body, wick);
       const u = i / (N - 1);
-      g.position.set((i - (N - 1) / 2) * CANDLE_GAP - CANDLE_GAP * 0.4, BASE, CANDLE_Z - (1 - u) * CANDLE_ARC);
+      // 좁은 화면 — 균일 간격으로 세우면 아무리 벌려도 "막대그래프 한 줄"로 읽힌다.
+      // 자리마다 좌우로 흔들어 듬성듬성 흩어 세운다. 흔들 폭을 (간격 − 몸통 폭) 이내로 잡아야
+      // 이웃과 몸통이 겹치지 않는다. 깊이는 앞쪽으로만 흔든다 — 뒤로 밀면 글씨 뒤로 떨어지는
+      // 금화 구간(z −3.6~−2.6)에 닿아 금화가 캔들에 박힌 것처럼 보인다.
+      const jitterX = narrowVp ? (Math.random() - 0.5) * (CANDLE_GAP - bw) : 0;
+      const jitterZ = narrowVp ? Math.random() * 0.35 : 0;
+      g.position.set(
+        (i - (N - 1) / 2) * CANDLE_GAP - CANDLE_GAP * 0.4 + jitterX,
+        BASE,
+        CANDLE_Z - (1 - u) * CANDLE_ARC + jitterZ,
+      );
       candleGroup.add(g);
     }
 

--- a/cf-idiotquant/app/(home)/page.tsx
+++ b/cf-idiotquant/app/(home)/page.tsx
@@ -192,9 +192,12 @@ function HeroArt() {
     // 전체 폭(약 6.3)은 그대로 두면서 몸통 사이 빈 자리만 벌린다. 예전엔 몸통끼리 거의 붙어
     // 초록·빨강 벽처럼 보였고, 배경으로 물러나야 할 차트가 헤드라인과 경쟁했다.
     const CANDLE_GAP = narrowVp ? 0.70 : 1.05;
-    // 몸통 폭은 간격에 비례 — 좁은 화면은 비율을 낮춰 빈 자리를 몸통만큼 확보한다
-    const CANDLE_BODY_RATIO = narrowVp ? 0.5 : 0.66;
-    const CANDLE_HS = narrowVp ? 0.7 : 1; // 화면이 좁으면 높이도 낮춰 가로:세로 비율을 유지
+    // 몸통 폭은 간격에 비례 — 좁은 화면은 비율을 낮춰 빈 자리를 넓힌다. 몸통이 얇을수록
+    // 아래 jitterX 의 허용 범위(간격 − 몸통 폭)가 넓어져 더 제멋대로 흩어 세울 수 있다.
+    const CANDLE_BODY_RATIO = narrowVp ? 0.44 : 0.66;
+    // 좁은 화면에선 키를 확 낮춰 아기자기한 크기로 둔다. 배경 장식이라 키가 크면 헤드라인
+    // 옆에서 존재감을 다투는데, 낮추면 바닥에 오밀조밀 늘어선 소품처럼 읽힌다.
+    const CANDLE_HS = narrowVp ? 0.42 : 1;
     const CANDLE_ARC = narrowVp ? 1.0 : 1.7;   // 왼쪽 끝이 뒤로 물러나는 거리
     // 어두운 무대에서는 짙은 그림자가 배경과 구분되지 않는다 → 아주 옅게만 깔아 캔들 밑동만 눌러준다
     const shadowTex = makeRadialTexture("rgba(0,0,0,.45)");
@@ -212,7 +215,9 @@ function HeroArt() {
     upMat.opacity = dnMat.opacity = CANDLE_BASE_OPACITY;
     let prev = CANDLE_H[0] * CANDLE_HS;
     for (let i = 0; i < N; i++) {
-      const h = CANDLE_H[i] * CANDLE_HS;
+      // 키도 자리처럼 흔든다 — 시퀀스대로만 세우면 계단처럼 반듯해서 "가지런한 막대"로 읽힌다.
+      // ±30% 안에서만 흔들어 우상향 흐름 자체는 남긴다.
+      const h = CANDLE_H[i] * CANDLE_HS * (narrowVp ? 0.7 + Math.random() * 0.6 : 1);
       const up = h >= prev; prev = h;
       const mat = up ? upMat : dnMat;
       const bw = CANDLE_GAP * CANDLE_BODY_RATIO;
@@ -230,10 +235,10 @@ function HeroArt() {
       const u = i / (N - 1);
       // 좁은 화면 — 균일 간격으로 세우면 아무리 벌려도 "막대그래프 한 줄"로 읽힌다.
       // 자리마다 좌우로 흔들어 듬성듬성 흩어 세운다. 흔들 폭을 (간격 − 몸통 폭) 이내로 잡아야
-      // 이웃과 몸통이 겹치지 않는다. 깊이는 앞쪽으로만 흔든다 — 뒤로 밀면 글씨 뒤로 떨어지는
-      // 금화 구간(z −3.6~−2.6)에 닿아 금화가 캔들에 박힌 것처럼 보인다.
+      // 이웃과 몸통이 겹치지 않는다. 깊이는 앞뒤 양쪽이 다 막혀 있어 조금만 흔든다 — 뒤로는
+      // 글씨 뒤 낙하 금화 구간(z −3.6~−2.6), 앞으로는 바닥 금화 더미(z −1.5~1.5)에 닿는다.
       const jitterX = narrowVp ? (Math.random() - 0.5) * (CANDLE_GAP - bw) : 0;
-      const jitterZ = narrowVp ? Math.random() * 0.35 : 0;
+      const jitterZ = narrowVp ? Math.random() * 0.2 : 0;
       g.position.set(
         (i - (N - 1) / 2) * CANDLE_GAP - CANDLE_GAP * 0.4 + jitterX,
         BASE,


### PR DESCRIPTION
모바일 관련 수정 5건입니다.

---

## 1. analyze — 종합 판단을 눌러 지표 4개 펼치기

한 줄 요약을 **누르면** 저평가 기준 4개(NCAV·PBR·PER·ROE)가 펼쳐집니다.

- 요약 줄을 `button` 으로 (`aria-expanded`), 오른쪽에 방향 셰브론
- 펼친 내용은 한 줄에 하나씩 — `✓/✕` · 지표명 · 기준 · 값
- 기본은 접힌 상태, `sm` 이상은 기존 2열 그리드 그대로

**폭 재조정** — 셰브론이 들어간 만큼 320px 에서 가장 긴 문장이 넘쳐, `gap-1.5→1` · 셰브론 `13→11px` · 문장 `12→11.5px` 로 맞췄습니다.

| 뷰포트 | 말줄임 | 접힘 | 펼침 |
|---|---|---|---|
| 320px | 없음 (세 톤 전부) | 47px | 158px |
| 390px | 없음 (세 톤 전부) | 47px | 158px |

---

## 2. home — 배경 3D 씬 높이를 100vh 로 고정

스크롤 중 배경이 커졌다 작아졌다 하던 문제입니다. 배경 컨테이너가 `fixed inset-0` 이라 주소창이 접혔다 펴질 때마다 높이가 따라 움직이고, `ResizeObserver → renderer.setSize()` 로 캔버스가 다시 잡히면서 씬이 리스케일됐습니다.

- `inset-0` → `inset-x-0 top-0 h-screen` (`100vh` 는 스크롤 중 변하지 않음)
- 리사이즈는 화면 회전·창 크기 변경 때만 발생

**검증** — 390px 에서 `y = 0 / 200 / 600 / 1200` 스크롤 중 컨테이너 높이(780px)와 캔버스 버퍼(585×1170)가 고정됨을 확인.

> 헤드리스 브라우저에는 주소창이 없어 URL 바 접힘 자체는 재현할 수 없었습니다. 위 수정은 그 동작을 유발하던 경로(동적 뷰포트 추적)를 제거하는 방식입니다.

---

## 3~5. home — 모바일 캔들 배치 (간격 → 랜덤 → 크기)

세 번에 걸쳐 다듬은 결과입니다. **전부 좁은 화면에서만** 적용되고 데스크톱 값은 그대로입니다.

| 항목 | before | after |
|---|---|---|
| 캔들 개수 | 11 (`slice(4)`) | 9 (`slice(6)`) |
| 간격 | 0.56 | 0.70 |
| 몸통 폭 비율 | 0.66 | 0.44 |
| 높이 스케일 | 0.7 | **0.42** |
| 가장 큰 캔들 높이 | 2.24 | **1.34** |
| 위치 | 균일 | `jitterX ±(간격−몸통)/2`, `jitterZ 0~0.2` |
| 키 | 시퀀스 그대로 | 캔들마다 **±30%** |

**왜 이렇게 잡았나**

- **`jitterX` 상한이 `(간격 − 몸통 폭)/2` 인 이유** — 이 값을 넘기면 이웃과 몸통이 실제로 겹칩니다. 겹치지 않는 최대치를 그대로 상한으로 썼고, 몸통 폭 비율을 낮춘 것도 이 여유를 벌기 위해서입니다.
- **`jitterZ` 가 0~0.2 로 좁은 이유** — 앞뒤가 다 막혀 있습니다. 뒤로는 글씨 뒤 낙하 금화 구간(`z −3.6~−2.6`), 앞으로는 바닥 금화 더미(`z −1.5~1.5`)에 닿습니다. 캔들은 더미 뒤에 있어야 합니다.
- **키 랜덤이 ±30% 인 이유** — 시퀀스대로만 세우면 계단처럼 반듯해 "가지런한 막대"로 읽힙니다. 흐름(우상향)은 남기면서 계단 모양만 깨는 정도입니다.

**검증** — 390px 을 두 번씩 로드해 배치·키가 매번 다르고 몸통 겹침이 없음을 확인했습니다.

---

## 공통 검증

- `npx tsc --noEmit` 통과
- `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P