### PR TITLE
feat(analyze): 재무제표를 가로 막대 뷰로 (막대 기본 + 표 토글)

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -22,6 +22,7 @@ import {
   Search, Heart, X, TrendingUp, ChevronLeft, ChevronDown, Lock, ArrowRight,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { buildKrBars, buildUsBars } from '@/app/(search)/search/components/financialBars';
 
 // =========================================================================
 // Dynamic imports
@@ -58,6 +59,11 @@ const FinancialTables = dynamic(
 
 const FinnhubTable = dynamic(
   () => import('@/app/(search)/search/components/FinnhubTable'),
+  { ssr: false }
+);
+
+const FinancialBars = dynamic(
+  () => import('@/app/(search)/search/components/FinancialBars').then(mod => ({ default: mod.FinancialBars })),
   { ssr: false }
 );
 
@@ -410,6 +416,8 @@ function AnalyzeContent() {
   const [activeTab, setActiveTab] = useState<DetailTab>('strategy');
   // 모바일 종합 판단 — 한 줄 요약을 눌러 지표 4개(기준·값·충족 여부)를 펼친다
   const [verdictOpen, setVerdictOpen] = useState(false);
+  // 재무 탭 — 막대가 기본, 원본 숫자표는 토글로 남긴다
+  const [financeView, setFinanceView] = useState<'bars' | 'table'>('bars');
   // 결과를 보는 중에는 검색줄을 접어 헤더가 종목 정보를 대신 보여준다
   const [searchOpen, setSearchOpen] = useState(false);
 
@@ -927,22 +935,48 @@ function AnalyzeContent() {
                   )}
                 </div>
 
-                {/* 재무제표 (블러) */}
+                {/* 재무제표 (블러) — 막대가 기본, 원본 숫자표는 토글로 남긴다.
+                    막대에도 값을 함께 적지만 정렬·복사에는 표가 낫다. */}
                 <div className={cn(activeTab !== 'financials' && 'hidden')}>
                   <BlurGate isLoggedIn={isLoggedIn} loginHref={loginHref}>
-                    <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] shadow-sm overflow-hidden">
-                      <div className="px-5 py-4 border-b border-neutral-100 dark:border-[#35332e]">
-                        <h3 className="text-sm font-extrabold text-neutral-800 dark:text-neutral-200">재무제표</h3>
-                        <p className="text-[10px] text-neutral-400 mt-0.5">
-                          {krOrUs === 'KR' ? 'DART 공시 기준 (억 원)' : 'US-GAAP 기준 (USD)'}
+                    <div className="flex flex-col gap-4">
+                      <div className="flex items-center gap-2">
+                        <p className="text-[10.5px] text-neutral-400">
+                          {krOrUs === 'KR' ? 'DART 공시 기준 · 억 원' : 'US-GAAP 기준 · USD'}
                         </p>
+                        <div className="ml-auto shrink-0 flex items-center gap-0.5 p-0.5 rounded-[10px] bg-[#f2f0ec] dark:bg-[#2c2b27]">
+                          {([['bars', '막대'], ['table', '표']] as const).map(([mode, label]) => (
+                            <button
+                              key={mode}
+                              onClick={() => setFinanceView(mode)}
+                              aria-pressed={financeView === mode}
+                              className={cn(
+                                "px-2.5 py-1 rounded-lg text-[11px] transition-colors",
+                                financeView === mode
+                                  ? "bg-white dark:bg-[#1f1e1b] font-extrabold text-neutral-900 dark:text-white shadow-sm"
+                                  : "font-bold text-neutral-500 dark:text-neutral-400"
+                              )}
+                            >
+                              {label}
+                            </button>
+                          ))}
+                        </div>
                       </div>
-                      <div className="overflow-x-auto">
-                        {krOrUs === 'KR'
-                          ? <FinancialTables kiBS={data.kiBS} kiIS={data.kiIS} />
-                          : <FinnhubTable data={data.finnhubData.data} />
-                        }
-                      </div>
+
+                      {financeView === 'bars' ? (
+                        krOrUs === 'KR'
+                          ? <FinancialBars {...buildKrBars(data.kiBS, data.kiIS)} unit="eok" />
+                          : <FinancialBars {...buildUsBars(data.finnhubData?.data ?? [])} unit="usd" />
+                      ) : (
+                        <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] shadow-sm overflow-hidden">
+                          <div className="overflow-x-auto">
+                            {krOrUs === 'KR'
+                              ? <FinancialTables kiBS={data.kiBS} kiIS={data.kiIS} />
+                              : <FinnhubTable data={data.finnhubData.data} />
+                            }
+                          </div>
+                        </div>
+                      )}
                     </div>
                   </BlurGate>
                 </div>

--- a/cf-idiotquant/app/(search)/search/components/FinancialBars.tsx
+++ b/cf-idiotquant/app/(search)/search/components/FinancialBars.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import {
+    barGeometry, periodDelta, fmtEok, usdBlockFormatter,
+    type BarModel, type BarItem, type StackRow, type Tone,
+} from "./financialBars";
+
+// 토큰 하나에서 막대·점·스택 색이 전부 나온다 — 항목마다 색 클래스를 따로 붙이면
+// 다크 모드 대응이 두 배가 되고 색이 어긋나기 시작한다.
+const TONE_BG: Record<Tone, string> = {
+    green: "bg-[#16a34a]",
+    rose: "bg-[#d4525c]",
+    emerald: "bg-emerald-500",
+    indigo: "bg-indigo-500",
+    violet: "bg-violet-500",
+    teal: "bg-teal-500",
+    amber: "bg-amber-500",
+};
+
+type Unit = "eok" | "usd";
+const blockFormatter = (unit: Unit, values: (number | null)[]) =>
+    unit === "eok" ? fmtEok : usdBlockFormatter(values);
+
+// ── 구성 스택 ────────────────────────────────────────────────────────────
+function Stack({ row }: { row: StackRow }) {
+    return (
+        <div className="flex flex-col gap-1.5">
+            <p className="text-[12.5px] font-bold text-neutral-800 dark:text-neutral-100">
+                {row.title}
+                {row.note && <span className="ml-1.5 text-[11px] font-semibold text-neutral-400">{row.note}</span>}
+            </p>
+            <div className="flex h-7 rounded-lg overflow-hidden bg-neutral-100 dark:bg-[#322f2a]">
+                {row.segs.map(seg => (
+                    <div
+                        key={seg.label}
+                        title={`${seg.label} ${seg.pct.toFixed(1)}%`}
+                        style={{ width: `${seg.pct}%` }}
+                        className={cn(
+                            "grid place-items-center min-w-0 overflow-hidden whitespace-nowrap font-mono text-[10.5px] font-black",
+                            TONE_BG[seg.tone],
+                            seg.pale ? "opacity-45 text-neutral-900 dark:text-white" : "text-white"
+                        )}
+                    >
+                        {seg.pct >= 12 ? `${seg.label} ${Math.round(seg.pct)}%` : seg.pct >= 6 ? `${Math.round(seg.pct)}%` : ""}
+                    </div>
+                ))}
+            </div>
+            {row.legend && (
+                <div className="flex flex-wrap gap-x-3.5 gap-y-1 text-[11px] text-neutral-500 dark:text-neutral-400">
+                    {row.legend.map(l => (
+                        <span key={l.label} className="inline-flex items-center gap-1.5">
+                            <i className={cn("w-2 h-2 rounded-[2px] shrink-0", TONE_BG[l.tone])} />
+                            {l.label}
+                        </span>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+// ── 증감 배지 ────────────────────────────────────────────────────────────
+function DeltaBadge({ item }: { item: BarItem }) {
+    const d = periodDelta(item.values);
+    if (d.turnedLoss) return <span className="font-mono text-[10.5px] font-bold text-rose-500 dark:text-rose-400">적자전환</span>;
+
+    // 현금흐름처럼 음수가 정상인 항목은 변화율이 오해를 부른다 — 유출이 −4,200 → −5,900 으로
+    // 커진 것을 "−40.5%" 로 적으면 줄어든 것처럼 읽힌다. 규모의 방향으로 바꿔 말한다.
+    if (item.neutral) {
+        const latest = item.values.find(v => v !== null) ?? null;
+        const oldest = [...item.values].reverse().find(v => v !== null) ?? null;
+        if (latest !== null && oldest !== null && latest < 0 && oldest < 0) {
+            return (
+                <span className="font-mono text-[10.5px] font-bold text-neutral-400">
+                    유출 {Math.abs(latest) >= Math.abs(oldest) ? "확대" : "축소"}
+                </span>
+            );
+        }
+    }
+
+    if (d.pct === null) return null;
+    // 방향이 아니라 좋고/나쁨으로 칠한다 — 부채·비용은 늘면 나쁘다.
+    const good = item.costLike ? d.pct < 0 : d.pct > 0;
+    const flat = Math.abs(d.pct) < 0.05;
+    return (
+        <span className={cn(
+            "font-mono text-[10.5px] font-bold tabular-nums",
+            item.neutral || flat ? "text-neutral-400"
+                : good ? "text-[#16a34a] dark:text-emerald-400" : "text-rose-500 dark:text-rose-400"
+        )}>
+            {d.spanCount}기 {flat ? "±0.0%" : `${d.pct > 0 ? "+" : "−"}${Math.abs(d.pct).toFixed(1)}%`}
+        </span>
+    );
+}
+
+// ── 항목 하나(최근 → 과거) ───────────────────────────────────────────────
+function TrendBlock({ item, periods, unit }: { item: BarItem; periods: string[]; unit: Unit }) {
+    const geo = barGeometry(item.values);
+    const f = blockFormatter(unit, item.values);
+    const latest = item.values.find(v => v !== null) ?? null;
+
+    return (
+        <div className="flex flex-col gap-1">
+            <div className="flex items-baseline gap-1.5">
+                <span className={cn(
+                    "text-[12.5px] font-bold flex items-center gap-1.5",
+                    item.isTotal ? "text-neutral-900 dark:text-white" : "text-neutral-700 dark:text-neutral-300"
+                )}>
+                    {item.isTotal && <i className={cn("w-[3px] h-3 rounded-full shrink-0", TONE_BG[item.tone])} />}
+                    {item.label}
+                </span>
+                <DeltaBadge item={item} />
+                <span className={cn(
+                    "ml-auto font-mono text-[12.5px] font-black tabular-nums",
+                    latest !== null && latest < 0 ? "text-rose-500 dark:text-rose-400" : "text-neutral-900 dark:text-white"
+                )}>
+                    {f(latest)}
+                </span>
+            </div>
+
+            {item.values.map((v, i) => {
+                const bar = geo.bars[i];
+                const isLatest = i === 0;
+                return (
+                    <div key={periods[i] ?? i} className="grid grid-cols-[1.9rem_1fr_3.6rem] items-center gap-1.5">
+                        <span className={cn(
+                            "font-mono text-[10px] tabular-nums",
+                            isLatest ? "font-bold text-neutral-700 dark:text-neutral-200" : "text-neutral-400 dark:text-neutral-500"
+                        )}>
+                            {(periods[i] ?? "").replace(/^(\d{2})(\d{2})\./, "$2.").replace(/^FY\d{2}/, m => `'${m.slice(4)}`)}
+                        </span>
+
+                        <div className={cn(
+                            "relative rounded bg-neutral-100 dark:bg-[#322f2a]",
+                            isLatest ? "h-3" : "h-2"
+                        )}>
+                            {geo.zeroPct > 0 && (
+                                <span className="absolute -inset-y-0.5 w-px bg-neutral-400/50 dark:bg-neutral-500/50" style={{ left: `${geo.zeroPct}%` }} />
+                            )}
+                            {!bar.empty && bar.pct > 0 && (
+                                <span
+                                    className={cn(
+                                        "absolute inset-y-0 rounded",
+                                        bar.negative ? "bg-[#d4525c]" : TONE_BG[item.tone],
+                                        isLatest ? "opacity-100" : "opacity-40"
+                                    )}
+                                    style={bar.negative
+                                        ? { right: `${100 - geo.zeroPct}%`, width: `${bar.pct}%` }
+                                        : { left: `${geo.zeroPct}%`, width: `${bar.pct}%` }}
+                                />
+                            )}
+                        </div>
+
+                        <span className={cn(
+                            "text-right font-mono tabular-nums",
+                            isLatest ? "text-[11px] font-bold text-neutral-800 dark:text-neutral-100" : "text-[10px] text-neutral-400 dark:text-neutral-500",
+                            v !== null && v < 0 && "text-rose-500 dark:text-rose-400"
+                        )}>
+                            {f(v)}
+                        </span>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}
+
+// ── 명세서 한 장 ─────────────────────────────────────────────────────────
+function StatementCard({ model, unit }: { model: BarModel; unit: Unit }) {
+    return (
+        <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] overflow-hidden">
+            <div className="px-5 py-3.5 border-b border-neutral-100 dark:border-[#35332e] flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <h4 className="text-sm font-extrabold text-neutral-800 dark:text-neutral-100">{model.title}</h4>
+                <span className="font-mono text-[10px] text-neutral-400">
+                    {model.periods[0]} → {model.periods[model.periods.length - 1]}
+                    {unit === "eok" ? " · 억 원" : " · USD"}
+                </span>
+            </div>
+
+            {model.stacks.length > 0 && (
+                <div className="px-5 py-4 bg-[#faf9f7] dark:bg-[#1f1e1b] border-b border-neutral-100 dark:border-[#35332e] flex flex-col gap-3.5">
+                    <span className="font-mono text-[9.5px] font-bold uppercase tracking-[0.16em] text-neutral-400">
+                        한눈에 · {model.periods[0]}
+                    </span>
+                    {model.stacks.map(s => <Stack key={s.title} row={s} />)}
+                </div>
+            )}
+
+            <div className="px-5 pb-5">
+                {model.groups.map(g => (
+                    <div key={g.labelEn}>
+                        <div className="flex items-center gap-1.5 mt-5 mb-2 font-mono text-[9.5px] font-bold uppercase tracking-[0.16em] text-neutral-400">
+                            <i className={cn("w-[7px] h-[7px] rounded-full shrink-0", TONE_BG[g.tone])} />
+                            {g.labelEn}
+                        </div>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-4">
+                            {g.items.map(item => (
+                                <TrendBlock key={item.label} item={item} periods={model.periods} unit={unit} />
+                            ))}
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export function FinancialBars({ bs, is, unit }: { bs: BarModel | null; is: BarModel | null; unit: Unit }) {
+    if (!bs && !is) return null;
+    return (
+        <div className="flex flex-col gap-4">
+            {bs && <StatementCard model={bs} unit={unit} />}
+            {is && <StatementCard model={is} unit={unit} />}
+            <p className="text-[10.5px] leading-relaxed text-neutral-400 dark:text-neutral-500 break-keep px-1">
+                막대 길이는 <span className="font-bold">항목별</span>로 자기 기간 최댓값을 100% 로 잡은 것입니다 —
+                같은 항목의 세로 비교용이며, 항목끼리의 길이 비교는 의미가 없습니다.
+                맨 위 구성 막대만 한 줄 합계가 100% 입니다.
+            </p>
+        </div>
+    );
+}

--- a/cf-idiotquant/app/(search)/search/components/financialBars.ts
+++ b/cf-idiotquant/app/(search)/search/components/financialBars.ts
@@ -1,0 +1,345 @@
+// 재무제표 막대 뷰의 계산 — React 비의존. 표현은 FinancialBars.tsx 가 맡는다.
+//
+// 두 가지 축 규칙이 섞여 있어서 헷갈리기 쉬운데, 의도된 것이다.
+//  · 추이 막대(BarItem)는 "그 항목의 최댓값"이 100% — 항목끼리 길이를 비교하면 안 된다.
+//    매출액(4,180)과 영업이익(310)을 같은 축에 두면 영업이익이 보이지 않기 때문이다.
+//  · 구성 스택(StackRow)은 한 줄 합계가 100% — 이쪽은 가로 비교가 목적이다.
+
+export type Tone = "green" | "rose" | "emerald" | "indigo" | "violet" | "teal" | "amber";
+
+export interface BarItem {
+    label: string;
+    /** 합계 행 — 이름 앞에 색 막대를 붙이고 굵게 */
+    isTotal?: boolean;
+    /** 최근 → 과거 순. 값이 없으면 null (0 과 구분해야 한다) */
+    values: (number | null)[];
+    tone: Tone;
+    /** 늘면 나쁜 항목(부채·비용) — 증감 배지 색을 뒤집는다 */
+    costLike?: boolean;
+    /** 좋고 나쁨을 단정할 수 없는 항목(현금흐름) — 배지를 중립으로 */
+    neutral?: boolean;
+}
+
+export interface BarGroup { labelEn: string; tone: Tone; items: BarItem[] }
+export interface StackSeg { label: string; pct: number; tone: Tone; pale?: boolean }
+export interface StackRow { title: string; note?: string; segs: StackSeg[]; legend?: { label: string; tone: Tone }[] }
+
+export interface BarModel {
+    title: string;
+    /** 최근 → 과거 순 라벨 (예: "2025.12", "FY2025") */
+    periods: string[];
+    groups: BarGroup[];
+    stacks: StackRow[];
+}
+
+const num = (v: unknown): number | null => {
+    if (v === null || v === undefined || v === "") return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+};
+
+// ── 막대 기하 ────────────────────────────────────────────────────────────
+export interface BarGeometry {
+    /** 0 선의 가로 위치(%) — 음수가 없으면 0 */
+    zeroPct: number;
+    bars: { pct: number; negative: boolean; empty: boolean }[];
+}
+
+/**
+ * 0 선 위치를 데이터가 정한다: 음수최대 ÷ (음수최대 + 양수최대).
+ * 손실이 클수록 0 선이 오른쪽으로 밀려 손실 폭이 길이로 드러나고,
+ * 값이 전부 음수면 0 선이 오른쪽 끝에 서서 막대가 왼쪽으로만 자란다.
+ */
+export function barGeometry(values: (number | null)[]): BarGeometry {
+    const nums = values.filter((v): v is number => v !== null);
+    const maxPos = nums.reduce((m, v) => (v > m ? v : m), 0);
+    const maxNeg = nums.reduce((m, v) => (-v > m ? -v : m), 0);
+    const span = maxPos + maxNeg;
+    if (span <= 0) {
+        return { zeroPct: 0, bars: values.map(v => ({ pct: 0, negative: false, empty: v === null })) };
+    }
+    return {
+        zeroPct: (maxNeg / span) * 100,
+        bars: values.map(v =>
+            v === null
+                ? { pct: 0, negative: false, empty: true }
+                : { pct: (Math.abs(v) / span) * 100, negative: v < 0, empty: false }
+        ),
+    };
+}
+
+// ── 기간 증감 ────────────────────────────────────────────────────────────
+export interface PeriodDelta { pct: number | null; turnedLoss: boolean; spanCount: number }
+
+/** values 는 최근 → 과거 순. 가장 오래된 값 대비 최근 값의 변화. */
+export function periodDelta(values: (number | null)[]): PeriodDelta {
+    const idxLatest = values.findIndex(v => v !== null);
+    let idxOldest = -1;
+    for (let i = values.length - 1; i >= 0; i--) { if (values[i] !== null) { idxOldest = i; break; } }
+    if (idxLatest < 0 || idxOldest <= idxLatest) return { pct: null, turnedLoss: false, spanCount: 0 };
+
+    const latest = values[idxLatest] as number;
+    const oldest = values[idxOldest] as number;
+    const spanCount = idxOldest - idxLatest + 1;
+    if (latest < 0 && oldest >= 0) return { pct: null, turnedLoss: true, spanCount };
+    if (oldest === 0) return { pct: null, turnedLoss: false, spanCount };
+    return { pct: ((latest - oldest) / Math.abs(oldest)) * 100, turnedLoss: false, spanCount };
+}
+
+// ── 값 표기 ──────────────────────────────────────────────────────────────
+/** 국내: 원본이 억 원 단위 */
+export const fmtEok = (v: number | null): string =>
+    v === null ? "—" : `${Math.round(v).toLocaleString()}`;
+
+/** 미국: 원본이 USD */
+export function fmtUsd(v: number | null): string {
+    if (v === null) return "—";
+    const abs = Math.abs(v);
+    const sign = v < 0 ? "−" : "";
+    if (abs >= 1e12) return `${sign}${(abs / 1e12).toFixed(2)}T`;
+    if (abs >= 1e9) return `${sign}${(abs / 1e9).toFixed(2)}B`;
+    if (abs >= 1e6) return `${sign}${(abs / 1e6).toFixed(0)}M`;
+    return `${sign}${Math.round(abs).toLocaleString()}`;
+}
+
+/**
+ * 한 블록 안에서는 단위를 하나로 고정한다. 값마다 B/M 을 갈아 쓰면
+ * (−1.85B 옆에 −900M) 길이는 비슷한데 숫자는 두 배 넘게 차이 나 보인다.
+ */
+export function usdBlockFormatter(values: (number | null)[]): (v: number | null) => string {
+    const max = values.reduce<number>((m, v) => (v === null ? m : Math.max(m, Math.abs(v))), 0);
+    const [div, suffix] = max >= 1e12 ? [1e12, "T"] : max >= 1e9 ? [1e9, "B"] : max >= 1e6 ? [1e6, "M"] : [1, ""];
+    return v => {
+        if (v === null) return "—";
+        const scaled = Math.abs(v) / div;
+        return `${v < 0 ? "−" : ""}${div === 1 ? Math.round(scaled).toLocaleString() : scaled.toFixed(2)}${suffix}`;
+    };
+}
+
+// ── 구성 스택 ────────────────────────────────────────────────────────────
+/** 합계가 0 이하이거나 조각이 비면 스택을 만들지 않는다(빈 막대는 오해를 부른다) */
+function makeStack(
+    title: string,
+    total: number | null,
+    parts: { label: string; value: number | null; tone: Tone; pale?: boolean }[],
+    legend?: { label: string; tone: Tone }[],
+    note?: string,
+): StackRow | null {
+    if (total === null || total <= 0) return null;
+    const segs: StackSeg[] = [];
+    for (const p of parts) {
+        if (p.value === null || p.value < 0) return null;
+        segs.push({ label: p.label, pct: (p.value / total) * 100, tone: p.tone, pale: p.pale });
+    }
+    return { title, note, segs, legend };
+}
+
+// ── 국내 (KIS) ───────────────────────────────────────────────────────────
+const KR_BS_GROUPS: { labelEn: string; tone: Tone; rows: [string, string, boolean?][] }[] = [
+    { labelEn: "자산 ASSETS", tone: "green", rows: [["유동자산", "cras"], ["고정자산", "fxas"], ["자산총계", "total_aset", true]] },
+    { labelEn: "부채 LIABILITIES", tone: "rose", rows: [["유동부채", "flow_lblt"], ["고정부채", "fix_lblt"], ["부채총계", "total_lblt", true]] },
+    { labelEn: "자본 EQUITY", tone: "emerald", rows: [["자본금", "cpfn"], ["이익잉여금", "prfi_surp"], ["자본총계", "total_cptl", true]] },
+];
+
+const KR_IS_GROUPS: { labelEn: string; tone: Tone; rows: [string, string, boolean?][] }[] = [
+    { labelEn: "수익 REVENUE", tone: "indigo", rows: [["매출액", "sale_account", true], ["매출원가", "sale_cost"], ["매출총이익", "sale_totl_prfi"]] },
+    { labelEn: "영업 OPERATING", tone: "violet", rows: [["판관비", "sell_mang"], ["영업이익", "bsop_prti", true]] },
+    { labelEn: "순이익 NET INCOME", tone: "teal", rows: [["당기순이익", "thtr_ntin", true]] },
+];
+
+const KR_COST_KEYS = new Set(["flow_lblt", "fix_lblt", "total_lblt", "sale_cost", "sell_mang"]);
+
+const krPeriodLabel = (raw: unknown): string =>
+    String(raw ?? "").replace(/^(\d{4})(\d{2})$/, "$1.$2") || "—";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function krValues(periods: any[], key: string): (number | null)[] {
+    return periods.map(p => num(p?.[key]));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function buildKrBars(kiBS: any, kiIS: any): { bs: BarModel | null; is: BarModel | null } {
+    const bsRows: any[] = (kiBS?.output ?? []).slice(0, 5);
+    const isRows: any[] = (kiIS?.output ?? []).slice(0, 5);
+
+    const toGroups = (defs: typeof KR_BS_GROUPS, rows: any[]): BarGroup[] =>
+        defs.map(g => ({
+            labelEn: g.labelEn,
+            tone: g.tone,
+            items: g.rows.map(([label, key, isTotal]) => ({
+                label,
+                isTotal,
+                tone: g.tone,
+                costLike: KR_COST_KEYS.has(key),
+                values: krValues(rows, key),
+            })),
+        }));
+
+    const bs: BarModel | null = bsRows.length ? (() => {
+        const at = (key: string) => num(bsRows[0]?.[key]);
+        const asset = at("total_aset");
+        const stacks = [
+            makeStack("자산은 무엇으로 이루어져 있나", asset, [
+                { label: "유동자산", value: at("cras"), tone: "green" },
+                { label: "고정자산", value: at("fxas"), tone: "green", pale: true },
+            ], undefined, asset === null ? undefined : `총 ${fmtEok(asset)}억`),
+            makeStack("그 자산은 누구 돈인가", asset, [
+                { label: "부채", value: at("total_lblt"), tone: "rose" },
+                { label: "자본", value: at("total_cptl"), tone: "emerald" },
+            ], [
+                { label: `갚아야 할 돈 ${fmtEok(at("total_lblt"))}억`, tone: "rose" },
+                { label: `주주 몫 ${fmtEok(at("total_cptl"))}억`, tone: "emerald" },
+            ]),
+        ].filter((s): s is StackRow => s !== null);
+        return { title: "재무상태표", periods: bsRows.map(r => krPeriodLabel(r?.stac_yymm)), groups: toGroups(KR_BS_GROUPS, bsRows), stacks };
+    })() : null;
+
+    const is: BarModel | null = isRows.length ? (() => {
+        const at = (key: string) => num(isRows[0]?.[key]);
+        const sale = at("sale_account");
+        const op = at("bsop_prti");
+        const stacks = [
+            makeStack("매출 100원이 어디로 갔나", sale, [
+                { label: "매출원가", value: at("sale_cost"), tone: "indigo", pale: true },
+                { label: "판관비", value: at("sell_mang"), tone: "violet", pale: true },
+                { label: "영업이익", value: op, tone: "violet" },
+            ], op !== null && sale ? [{ label: `영업이익 ${fmtEok(op)}억 · 영업이익률 ${((op / sale) * 100).toFixed(1)}%`, tone: "violet" }] : undefined,
+                sale === null ? undefined : `매출액 ${fmtEok(sale)}억`),
+        ].filter((s): s is StackRow => s !== null);
+        return { title: "손익계산서", periods: isRows.map(r => krPeriodLabel(r?.stac_yymm)), groups: toGroups(KR_IS_GROUPS, isRows), stacks };
+    })() : null;
+
+    return { bs, is };
+}
+
+// ── 미국 (Finnhub) ───────────────────────────────────────────────────────
+const US_CONCEPTS = {
+    cash: ["us-gaap_CashAndCashEquivalentsAtCarryingValue", "CashAndCashEquivalentsAtCarryingValue"],
+    ar: ["us-gaap_AccountsReceivableNetCurrent", "AccountsReceivableNetCurrent"],
+    inventory: ["us-gaap_InventoryNet", "InventoryNet"],
+    currentAssets: ["us-gaap_AssetsCurrent", "AssetsCurrent"],
+    assets: ["us-gaap_Assets", "Assets"],
+    liabilities: ["us-gaap_Liabilities", "Liabilities", "us-gaap_LiabilitiesAndStockholdersEquity"],
+    equity: ["us-gaap_StockholdersEquity", "StockholdersEquity", "us-gaap_StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest"],
+    revenue: [
+        "us-gaap_RevenueFromContractWithCustomerExcludingAssessedTax",
+        "RevenueFromContractWithCustomerExcludingAssessedTax",
+        "us-gaap_Revenues", "Revenues", "us-gaap_SalesRevenueNet", "SalesRevenueNet",
+    ],
+    operating: ["us-gaap_OperatingIncomeLoss", "OperatingIncomeLoss"],
+    netIncome: ["us-gaap_NetIncomeLoss", "NetIncomeLoss"],
+    cfo: ["us-gaap_NetCashProvidedByUsedInOperatingActivities", "NetCashProvidedByUsedInOperatingActivities"],
+    cfi: ["us-gaap_NetCashProvidedByUsedInInvestingActivities", "NetCashProvidedByUsedInInvestingActivities"],
+    cff: ["us-gaap_NetCashProvidedByUsedInFinancingActivities", "NetCashProvidedByUsedInFinancingActivities"],
+} as const;
+
+type UsKey = keyof typeof US_CONCEPTS;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function usColumns(reports: any[]): { label: string; map: Map<string, number | null> }[] {
+    return (Array.isArray(reports) ? reports : []).slice(0, 5).map(r => {
+        const dateStr = String(r?.endDate || r?.filedDate || r?.acceptedDate || "").split(" ")[0];
+        const map = new Map<string, number | null>();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const merge = (arr: any[] = []) => arr.forEach(item => {
+            const concept = item?.concept || item?.label || "";
+            if (concept) map.set(concept, num(item?.value ?? item?.val ?? item?.amount));
+        });
+        merge(r?.report?.bs);
+        merge(r?.report?.ic);
+        merge(r?.report?.cf);
+        return { label: dateStr ? dateStr.slice(0, 4) : "—", map };
+    });
+}
+
+const pick = (map: Map<string, number | null>, key: UsKey): number | null => {
+    for (const c of US_CONCEPTS[key]) {
+        const v = map.get(c);
+        if (v !== undefined) return v;
+    }
+    return null;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function buildUsBars(reports: any[]): { bs: BarModel | null; is: BarModel | null } {
+    const cols = usColumns(reports);
+    if (!cols.length) return { bs: null, is: null };
+
+    const series = (key: UsKey) => cols.map(c => pick(c.map, key));
+    const periods = cols.map(c => `FY${c.label}`);
+    const latest = (key: UsKey) => pick(cols[0].map, key);
+
+    const assets = latest("assets");
+    const currentAssets = latest("currentAssets");
+    const bsStacks = [
+        makeStack("자산은 무엇으로 이루어져 있나", assets, [
+            { label: "유동자산", value: currentAssets, tone: "green" },
+            { label: "비유동", value: assets !== null && currentAssets !== null ? assets - currentAssets : null, tone: "green", pale: true },
+        ], undefined, assets === null ? undefined : `총 ${fmtUsd(assets)}`),
+        makeStack("그 자산은 누구 돈인가", assets, [
+            { label: "부채", value: latest("liabilities"), tone: "rose" },
+            { label: "자본", value: latest("equity"), tone: "emerald" },
+        ], [
+            { label: `갚아야 할 돈 ${fmtUsd(latest("liabilities"))}`, tone: "rose" },
+            { label: `주주 몫 ${fmtUsd(latest("equity"))}`, tone: "emerald" },
+        ]),
+    ].filter((s): s is StackRow => s !== null);
+
+    const bs: BarModel = {
+        title: "재무상태표",
+        periods,
+        stacks: bsStacks,
+        groups: [
+            {
+                labelEn: "자산 ASSETS", tone: "green", items: [
+                    { label: "현금성 자산", tone: "green", values: series("cash") },
+                    { label: "매출채권", tone: "green", values: series("ar") },
+                    { label: "재고자산", tone: "green", values: series("inventory") },
+                    { label: "유동자산 합계", tone: "green", isTotal: true, values: series("currentAssets") },
+                    { label: "자산 총계", tone: "green", isTotal: true, values: series("assets") },
+                ],
+            },
+            {
+                labelEn: "부채 및 자본 LIAB & EQUITY", tone: "rose", items: [
+                    { label: "부채 총계", tone: "rose", isTotal: true, costLike: true, values: series("liabilities") },
+                    { label: "자본 총계", tone: "emerald", isTotal: true, values: series("equity") },
+                ],
+            },
+        ],
+    };
+
+    const revenue = latest("revenue");
+    const operating = latest("operating");
+    const isStacks = [
+        makeStack("매출 $100 이 어디로 갔나", revenue, [
+            { label: "비용", value: revenue !== null && operating !== null ? revenue - operating : null, tone: "indigo", pale: true },
+            { label: "영업이익", value: operating, tone: "violet" },
+        ], operating !== null && revenue ? [{ label: `영업이익 ${fmtUsd(operating)} · 영업이익률 ${((operating / revenue) * 100).toFixed(1)}%`, tone: "violet" }] : undefined,
+            revenue === null ? undefined : `매출액 ${fmtUsd(revenue)}`),
+    ].filter((s): s is StackRow => s !== null);
+
+    const is: BarModel = {
+        title: "손익계산서 · 현금흐름",
+        periods,
+        stacks: isStacks,
+        groups: [
+            {
+                labelEn: "수익 · 이익 REVENUE & PROFIT", tone: "indigo", items: [
+                    { label: "매출액", tone: "indigo", isTotal: true, values: series("revenue") },
+                    { label: "영업이익", tone: "violet", isTotal: true, values: series("operating") },
+                    { label: "순이익", tone: "teal", isTotal: true, values: series("netIncome") },
+                ],
+            },
+            {
+                labelEn: "현금흐름 CASH FLOW", tone: "amber", items: [
+                    { label: "영업활동", tone: "amber", values: series("cfo") },
+                    // 유출이 늘어난 게 좋은지 나쁜지는 단정할 수 없다(설비투자일 수도, 자사주 매입일 수도)
+                    { label: "투자활동", tone: "amber", neutral: true, values: series("cfi") },
+                    { label: "재무활동", tone: "amber", neutral: true, values: series("cff") },
+                ],
+            },
+        ],
+    };
+
+    return { bs, is };
+}


### PR DESCRIPTION
## 변경 사항

analyze 재무 탭을 **가로 막대 뷰**로 바꿨습니다. 국내(KIS)·미국(Finnhub) 둘 다 적용됩니다.

- `financialBars.ts` — 순수 계산 (축 기하 · 기간 증감 · 구성 스택 · 시장별 계정과목 매핑)
- `FinancialBars.tsx` — 표현
- 재무 탭: **막대가 기본**, 헤더의 `막대 / 표` 토글로 기존 숫자표도 그대로 볼 수 있음

각 명세서 카드는 두 층입니다.

1. **한눈에** — 구성 100% 스택 (`자산은 무엇으로` · `그 자산은 누구 돈인가` · `매출 100원이 어디로`)
2. **계정과목별 추이** — 최근 결산이 **맨 위**, 과거는 아래로. 최근 행만 진하고 두껍게

## 축 규칙이 두 가지인데 의도된 것입니다

- **추이 막대**는 “그 항목의 최댓값”이 100%. 매출액(4,180)과 영업이익(310)을 같은 축에 두면 영업이익 막대가 보이지 않습니다. **항목끼리 길이 비교는 의미가 없고**, 같은 항목의 세로 비교용입니다.
- **구성 스택**은 한 줄 합계가 100%. 이쪽은 가로 비교가 목적입니다.

컴포넌트 하단에 이 내용을 한 줄로 적어 뒀습니다.

## 0 선 위치는 데이터가 정합니다

`음수최대 ÷ (음수최대 + 양수최대)`

손실이 클수록 0 선이 오른쪽으로 밀려 **손실 폭이 레이아웃으로 드러납니다.** 미국 투자·재무활동 현금흐름처럼 값이 전부 음수면 0 선이 오른쪽 끝에 서고 막대가 왼쪽으로만 자랍니다.

## 색·표기 규칙

- **증감 배지는 방향이 아니라 좋고/나쁨**으로 칠합니다 — 고정부채 `−5.9%` 는 초록, 판관비 `+33.3%` 는 빨강.
- **현금흐름은 중립**입니다. 좋고 나쁨을 단정할 수 없어(설비투자일 수도, 자사주 매입일 수도) 회색 + `유출 확대/축소` 로 적습니다. 유출이 `−4,200 → −5,900` 인 것을 `−40.5%` 로 적으면 줄어든 것처럼 읽히기 때문입니다.
- **미국 금액은 블록 안에서 단위를 하나로 고정**합니다. `−1.85B` 옆에 `−900M` 이 오면 길이는 비슷한데 숫자는 두 배 넘게 차이 나 보입니다.
- **값이 없으면 0 으로 그리지 않습니다.** 트랙을 비운 채 `—` 만 남깁니다 — 0 과 구분되어야 합니다.

## 시장별 차이

| | 국내 (KIS) | 미국 (Finnhub) |
|---|---|---|
| 단위 | 억 원 | USD |
| 자산 | 유동 · 고정 · 총계 | 현금성 · 매출채권 · 재고 · 유동합계 · 총계 |
| 부채 · 자본 | 각각 하위 항목 + 총계 | 총계만 |
| 손익 | 6개 (매출원가 · 판관비 포함) | 3개 |
| 현금흐름 | 없음 | 영업 · 투자 · 재무 |

미국은 매출원가·판관비가 없어 매출 구성 스택이 `비용 / 영업이익` 두 칸입니다(국내는 세 칸).

## 검증

KR·US 예시 데이터로 임시 라우트를 띄워 390px·900px 렌더를 확인한 뒤 삭제했습니다(커밋 미포함). 음수 막대·0 선 위치·단위 고정·증감 배지 색을 눈으로 확인했습니다.

- `npx tsc --noEmit` 통과
- `npm run build` 통과

시안: 이 PR 은 대화에서 합의한 B(기간 추이) + C(구성 스택) 조합을 구현한 것입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_