### PR TITLE
refactor(analyze): 카드·분석 탭을 「지표」 하나로 합치기

### DIFF
--- a/cf-idiotquant/app/(analyze)/analyze/page.tsx
+++ b/cf-idiotquant/app/(analyze)/analyze/page.tsx
@@ -309,8 +309,9 @@ const DEFAULT_XP_PROFILE = { level: 1, xp: 0, maxXp: 100, totalXp: 0, lastGain: 
 // (예전엔 모바일만 탭이고 데스크톱은 네 섹션이 전부 펼쳐져 스크롤이 길었다)
 const DETAIL_TABS = [
   { key: 'strategy', label: '전략' },
-  { key: 'card', label: '카드' },
-  { key: 'analysis', label: '분석' },
+  // 카드(시세·등급·차트)와 상세 지표는 둘 다 "지금 이 종목의 숫자"다. 탭을 갈라 두면
+  // PER·PBR 같은 같은 값을 양쪽에서 다시 보게 되고, 어느 탭을 눌러야 할지 매번 판단해야 한다.
+  { key: 'metrics', label: '지표' },
   { key: 'risk', label: '위험도' },
   { key: 'financials', label: '재무' },
 ] as const;
@@ -838,10 +839,10 @@ function AnalyzeContent() {
                 </div>
               )}
 
-              {/* 종목 카드 — 핵심 지표(NCAV·PBR·PER·ROE)까지 카드가 함께 표시한다.
-                  다른 섹션과 마찬가지로 탭 하나로 다룬다. 항상 펼쳐 두면 어떤 탭을 골라도
-                  카드 높이만큼 스크롤을 먼저 지나야 본문에 닿는다. */}
-              <div className={cn("mb-6", activeTab !== 'card' && 'hidden')}>
+              {/* 지표 탭 (1/2) — 종목 카드. 핵심 지표(NCAV·PBR·PER·ROE)를 카드가 크게 보여주고,
+                  아래 상세 지표 표가 나머지를 잇는다. 결론이 위, 근거가 아래.
+                  카드는 시세만 있으면 그려지므로 재무 로딩(isLoaded) 밖에 둔다. */}
+              <div className={cn("mb-6", activeTab !== 'metrics' && 'hidden')}>
                 <StockCard
                   stock={krOrUs === 'US' ? {
                     code: tickerFromUrl, isUs: true, name: displayName, ticker: name,
@@ -914,8 +915,8 @@ function AnalyzeContent() {
                   />
                 </div>
 
-                {/* 상세 지표 (블러) */}
-                <div className={cn(activeTab !== 'analysis' && 'hidden')}>
+                {/* 지표 탭 (2/2) — 상세 지표 표 (블러). 위 카드와 같은 탭이다. */}
+                <div className={cn(activeTab !== 'metrics' && 'hidden')}>
                   <BlurGate isLoggedIn={isLoggedIn}>
                     <StockMetrics data={data} isUs={krOrUs === 'US'} />
                   </BlurGate>

--- a/cf-idiotquant/app/(search)/search/components/StockMetrics.tsx
+++ b/cf-idiotquant/app/(search)/search/components/StockMetrics.tsx
@@ -96,9 +96,8 @@ export const StockMetrics = ({ data, isUs }: { data: any; isUs: boolean }) => {
         ? (100 * n(detail.tamt) / usMarketCap).toFixed(3)
         : "0";
 
+      // PER·PBR 은 같은 탭 위쪽 종목 카드가 크게 보여준다 — 여기서 또 적으면 같은 숫자가 두 번이다.
       return [
-        { label: "PER",     val: detail.perx ? `${detail.perx}배` : "—", type: "valuation", desc: "주가수익비율. 주가가 1주당 순이익의 몇 배인지 나타냅니다." },
-        { label: "PBR",     val: detail.pbrx ? `${detail.pbrx}배` : "—", type: "valuation", desc: "주가순자산비율. 주가가 1주당 순자산의 몇 배인지 나타냅니다." },
         { label: "EPS",     val: n(detail.epsx) ? `$${n(detail.epsx).toLocaleString()}` : "—", type: "valuation", desc: "주당순이익. 기업이 1주당 얼마의 순이익을 냈는지 보여줍니다." },
         { label: "BPS",     val: n(detail.bpsx) ? `$${n(detail.bpsx).toLocaleString()}` : "—", type: "valuation", desc: "주당순자산. 청산 시 1주당 주주에게 돌아가는 자산 가치입니다." },
         { label: "52주 최고", val: n(detail.h52p) ? `$${Number(detail.h52p).toFixed(2)}` : "—", sub: detail.h52d ? `${detail.h52d.slice(0,4)}-${detail.h52d.slice(4,6)}-${detail.h52d.slice(6,8)}` : "", type: "price", desc: "최근 52주간 가장 높았던 주가입니다." },
@@ -156,9 +155,8 @@ export const StockMetrics = ({ data, isUs }: { data: any; isUs: boolean }) => {
       const finalHigh = w52High > 0 ? { val: w52High, date: p.w52_hgpr_date ?? "" } : fallbackHigh;
       const finalLow  = w52Low  > 0 ? { val: w52Low,  date: p.w52_lwpr_date ?? "" } : fallbackLow;
 
+      // PER·PBR 은 같은 탭 위쪽 종목 카드가 크게 보여준다 — 여기서 또 적으면 같은 숫자가 두 번이다.
       return [
-        { label: "PER",     val: p.per ? `${p.per}배` : "—", type: "valuation", desc: "주가수익비율. 주가가 1주당 순이익의 몇 배인지 나타냅니다." },
-        { label: "PBR",     val: p.pbr ? `${p.pbr}배` : "—", type: "valuation", desc: "주가순자산비율. 주가가 1주당 순자산의 몇 배인지 나타냅니다." },
         { label: "EPS",     val: n(p.eps) ? `${n(p.eps).toLocaleString()}원` : "—", type: "valuation", desc: "주당순이익. 기업이 1주당 얼마의 순이익을 냈는지 보여줍니다." },
         { label: "BPS",     val: n(p.bps) ? `${n(p.bps).toLocaleString()}원` : "—", type: "valuation", desc: "주당순자산. 청산 시 1주당 주주에게 돌아가는 자산 가치입니다." },
         { label: "52주 최고", val: finalHigh.val > 0 ? `${Math.round(finalHigh.val).toLocaleString()}원` : "—", sub: fmt52Date(finalHigh.date), type: "price", desc: "최근 52주간 가장 높았던 주가입니다." },


### PR DESCRIPTION
## 변경 사항

analyze 상세 탭을 **5개 → 4개**로 줄였습니다.

```
전략 / 카드 / 분석 / 위험도 / 재무   →   전략 / 지표 / 위험도 / 재무
```

- `DETAIL_TABS`: `card` + `analysis` → `metrics`
- 종목 카드와 상세 지표 표를 같은 `metrics` 키로 묶음. **카드가 위(결론), 표가 아래(근거)** — 스크롤 순서는 기존과 동일
- `StockMetrics` 에서 **PER·PBR 제거** (KR·US 둘 다)

## 이유

탭이 많아 보이는 원인은 개수가 아니라 **같은 지표가 여러 탭에 흩어져 있는 것**이었습니다.

| 지표 | 전략 | 카드 | 분석 |
|---|---|---|---|
| PER | 모델 입력값 | 지표 4칸 | 밸류에이션 4칸 |
| PBR | — | 지표 4칸 | 밸류에이션 4칸 |
| ROE | S-RIM 입력값 | 지표 4칸 | — |
| NCAV | 모델 카드 | 지표 4칸 | — |

카드와 분석은 둘 다 “지금 이 종목의 숫자”이고 **PER·PBR 은 같은 값이 양쪽에** 나옵니다. 탭을 갈아타며 같은 숫자를 다시 보게 됩니다.

**전략 탭은 합치지 않았습니다** — 원시 지표가 아니라 “그래서 얼마가 적정한가”라는 모델 결과여서 성격이 다릅니다.

## 검증

KIS 응답을 목으로 채워 390px 에서 실제 페이지를 렌더했습니다.

- 탭바: `["전략","지표","위험도","재무"]`
- 지표 탭에 종목 카드 + 상세 지표 표가 함께 표시됨
- 상세 지표 카드 안 항목을 DOM 으로 조회 → `EPS · BPS · 52주 최고 · 52주 최저 · 시가총액 · 상장주식수 · 거래량 · 거래대금 · 대금/시총` 9개. **PER·PBR 이 빠진 것 확인**
- `npx tsc --noEmit` 통과
- `npm run build` 통과

## 알아두실 점

**블러 경계가 탭 안에 생깁니다.** 카드는 비로그인도 보이고 상세 지표는 `BlurGate` 로 가려져 있어서, 합친 탭은 **위는 보이고 아래는 흐린** 모양이 됩니다. 시안 검토 때 언급한 그대로 두었습니다 — 탭 전체를 게이트하는 편이 낫다면 알려주세요.

시안: 대화에서 합의한 제안 A 를 구현한 것입니다. 제안 B(위험도까지 흡수, 3탭)는 하지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_