### PR TITLE
refactor(balance): 사이드바 항목 통합 · 섹션 8→4 · 스위치 이름 정리

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -5,7 +5,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   LayoutDashboard, ChevronRight, MapPin,
   Wallet, Coins, Percent,
-  Database, User, PieChart, BarChart3, ClipboardList, Power, SlidersHorizontal, Activity, KeyRound,
+  Database, User, PieChart, ClipboardList, Power, SlidersHorizontal, Activity, KeyRound,
 } from "lucide-react";
 import TradingAccountPanel from "@/components/balance/tradingAccountPanel";
 import TradingAccountList from "@/components/balance/tradingAccountList";
@@ -433,16 +433,15 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
     return list.find((u: any) => String(u.key) === String(balanceKey)) ?? null;
   })();
 
-  // 섹션 네비게이션 구성
+  // 섹션 네비게이션 — 8개를 4개로 묶는다. "내 돈이 지금 어떤가"(자산)와 "기계가 뭘 하고
+  // 있나"(자동매매)를 가르는 기준이다. 예전엔 이 둘이 8칸에 번갈아 섞여 있어서, 자동매매를
+  // 한 번 손보려면 종목관리 → 조건 → 현황을 오가야 했다.
+  // 각 항목은 묶음의 첫 패널로 스크롤한다(패널 자체의 id 는 그대로라 링크는 살아 있다).
   const navSections: NavSection[] = [
-    { id: "section-kpi", label: "KPI", icon: <Wallet size={13} /> },
-    { id: "section-portfolio", label: "포트폴리오", icon: <PieChart size={13} /> },
-    { id: "section-balance", label: "잔고", icon: <BarChart3 size={13} /> },
-    ...(hasCapital ? [{ id: "section-stocks", label: "종목관리", icon: <Database size={13} /> }] : []),
-    ...(hasCapital ? [{ id: "section-activity", label: "자동매매 현황", icon: <Activity size={13} /> }] : []),
-    ...(hasCapital ? [{ id: "section-conditions", label: "트레이딩 조건", icon: <SlidersHorizontal size={13} /> }] : []),
-    { id: "section-account", label: "계정", icon: <KeyRound size={13} /> },
+    { id: "section-kpi", label: "자산", icon: <Wallet size={13} /> },
+    ...(hasCapital ? [{ id: "section-stocks", label: "자동매매", icon: <Activity size={13} /> }] : []),
     { id: "section-orders", label: "주문내역", icon: <ClipboardList size={13} /> },
+    { id: "section-account", label: "계정", icon: <KeyRound size={13} /> },
   ];
 
   return (
@@ -579,7 +578,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                       valueClass="text-[#16a34a] dark:text-[#16a34a]"
                     />
                     <MetricChip
-                      label="금일 매수 - 매도"
+                      label="금일 순매수"
                       value={`${(thdtBuyAmt - thdtSllAmt) >= 0 ? "+" : ""}${(thdtBuyAmt - thdtSllAmt).toLocaleString()}원`}
                       valueClass={(thdtBuyAmt - thdtSllAmt) >= 0 ? "text-rose-500" : "text-[#16a34a]"}
                     />
@@ -688,29 +687,6 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
           ) : null,
         },
         {
-          id: "section-activity",
-          node: hasCapital ? (
-            <SectionPanel id="section-activity">
-              <SectionHeader
-                icon={<Activity size={16} />}
-                title="자동매매 현황"
-                subtitle="스케줄러(5분마다) 가동 상태 · 토큰 리필 · 최근 자동 체결 내역"
-                badge={
-                  krActivity.state === "pending"
-                    ? <span className="text-[10px] font-mono text-amber-500 bg-amber-50 dark:bg-amber-950/20 px-2 py-0.5 rounded-full border border-amber-200 dark:border-amber-800 animate-pulse">로딩 중</span>
-                    : <span className="text-[10px] font-mono text-neutral-500 dark:text-neutral-400 bg-[#faf9f7] dark:bg-[#242320] px-2 py-0.5 rounded-full">최근 {krActivity.logs.length}건</span>
-                }
-              />
-              <TradingActivityPanel
-                country="KR"
-                capital={krCapital}
-                activity={krActivity}
-                onRefresh={() => dispatch(reqGetKrTradingActivity(balanceKey))}
-              />
-            </SectionPanel>
-          ) : null,
-        },
-        {
           id: "section-conditions",
           node: hasCapital ? (
             <SectionPanel id="section-conditions">
@@ -741,31 +717,27 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
           ) : null,
         },
         {
-          id: "section-account",
-          node: (
-            <SectionPanel id="section-account">
+          id: "section-activity",
+          node: hasCapital ? (
+            <SectionPanel id="section-activity">
               <SectionHeader
-                icon={<KeyRound size={16} />}
-                title="자동매매 계정 관리"
-                subtitle="등록된 계정을 선택해 KIS App Key/Secret·계좌번호·월 예산·ON/OFF 를 관리 (admin 전용)"
+                icon={<Activity size={16} />}
+                title="자동매매 현황"
+                subtitle="스케줄러(5분마다) 가동 상태 · 토큰 리필 · 최근 자동 체결 내역"
+                badge={
+                  krActivity.state === "pending"
+                    ? <span className="text-[10px] font-mono text-amber-500 bg-amber-50 dark:bg-amber-950/20 px-2 py-0.5 rounded-full border border-amber-200 dark:border-amber-800 animate-pulse">로딩 중</span>
+                    : <span className="text-[10px] font-mono text-neutral-500 dark:text-neutral-400 bg-[#faf9f7] dark:bg-[#242320] px-2 py-0.5 rounded-full">최근 {krActivity.logs.length}건</span>
+                }
               />
-              <TradingAccountList
+              <TradingActivityPanel
                 country="KR"
-                balanceKey={balanceKey}
-                onSelect={setBalanceKey}
-                refreshToken={accountListToken}
-              />
-              <TradingAccountPanel
-                country="KR"
-                balanceKey={balanceKey}
-                onChanged={() => {
-                  handleRefresh();
-                  dispatch(reqFetchTradingStatus({ country: "KR", key: balanceKey }));
-                  setAccountListToken(t => t + 1);
-                }}
+                capital={krCapital}
+                activity={krActivity}
+                onRefresh={() => dispatch(reqGetKrTradingActivity(balanceKey))}
               />
             </SectionPanel>
-          ),
+          ) : null,
         },
         {
           id: "section-orders",
@@ -814,6 +786,33 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                   </tbody>
                 </table>
               </div>
+            </SectionPanel>
+          ),
+        },
+        {
+          id: "section-account",
+          node: (
+            <SectionPanel id="section-account">
+              <SectionHeader
+                icon={<KeyRound size={16} />}
+                title="자동매매 계정 관리"
+                subtitle="등록된 계정을 선택해 KIS App Key/Secret·계좌번호·월 예산·ON/OFF 를 관리 (admin 전용)"
+              />
+              <TradingAccountList
+                country="KR"
+                balanceKey={balanceKey}
+                onSelect={setBalanceKey}
+                refreshToken={accountListToken}
+              />
+              <TradingAccountPanel
+                country="KR"
+                balanceKey={balanceKey}
+                onChanged={() => {
+                  handleRefresh();
+                  dispatch(reqFetchTradingStatus({ country: "KR", key: balanceKey }));
+                  setAccountListToken(t => t + 1);
+                }}
+              />
             </SectionPanel>
           ),
         },

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -6,7 +6,7 @@ import {
   Globe, ChevronRight, DollarSign, Building2,
   Wallet, TrendingUp, BarChart3, RefreshCw,
   AlertCircle, Database,
-  ArrowDownRight, PieChart, ClipboardList, TrendingDown, Power, SlidersHorizontal, Activity, KeyRound,
+  PieChart, ClipboardList, TrendingDown, Power, SlidersHorizontal, Activity, KeyRound,
 } from "lucide-react";
 import TradingAccountPanel from "@/components/balance/tradingAccountPanel";
 import TradingAccountList from "@/components/balance/tradingAccountList";
@@ -421,16 +421,13 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
     );
   }
 
-  // 섹션 네비게이션 구성
+  // 섹션 네비게이션 — 8개를 4개로 묶는다(국내 화면과 같은 기준). "내 돈이 지금 어떤가"(자산)와
+  // "기계가 뭘 하고 있나"(자동매매)를 가른다. 각 항목은 묶음의 첫 패널로 스크롤한다.
   const navSections: NavSection[] = [
-    { id: "section-kpi", label: "KPI", icon: <Wallet size={13} /> },
-    { id: "section-portfolio", label: "포트폴리오", icon: <PieChart size={13} /> },
-    { id: "section-balance", label: "잔고", icon: <BarChart3 size={13} /> },
-    ...(hasCapital ? [{ id: "section-stocks", label: "종목관리", icon: <Database size={13} /> }] : []),
-    ...(hasCapital ? [{ id: "section-activity", label: "자동매매 현황", icon: <Activity size={13} /> }] : []),
-    ...(hasCapital ? [{ id: "section-conditions", label: "트레이딩 조건", icon: <SlidersHorizontal size={13} /> }] : []),
-    { id: "section-account", label: "계정", icon: <KeyRound size={13} /> },
+    { id: "section-kpi", label: "자산", icon: <Wallet size={13} /> },
+    ...(hasCapital ? [{ id: "section-stocks", label: "자동매매", icon: <Activity size={13} /> }] : []),
     { id: "section-orders", label: "해외주문", icon: <ClipboardList size={13} /> },
+    { id: "section-account", label: "계정", icon: <KeyRound size={13} /> },
   ];
 
   return (
@@ -511,7 +508,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
           id: "section-kpi",
           node: (
             <>
-              <section id="section-kpi" className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3 animate-in fade-in slide-in-from-bottom-2 duration-400">
+              <section id="section-kpi" className="grid grid-cols-2 lg:grid-cols-4 gap-3 animate-in fade-in slide-in-from-bottom-2 duration-400">
                 <UsdKpiCard
                   label="총 자산 (USD)"
                   mainValue={isLoading ? null : fmtUsd(totalAssetUsd)}
@@ -555,31 +552,21 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
                   accentColor={pnlAccentColor(isPnlPositive)}
                   loading={isLoading}
                 />
-                <UsdKpiCard
-                  label="매입원금 (USD)"
-                  mainValue={isLoading ? null : fmtUsd(pchsAmtUsd)}
-                  subLabel="원화 환산액"
-                  subValue={isLoading ? null : fmtKrw(pchsAmtKrw)}
-                  icon={<DollarSign size={15} />}
-                  iconBg="bg-[#faf9f7] dark:bg-[#242320] text-neutral-500"
-                  accentColor="bg-neutral-400 dark:bg-neutral-600"
-                  loading={isLoading}
-                />
-                <UsdKpiCard
-                  label="출금 가능"
-                  mainValue={isLoading ? null : fmtUsd(wdrwPsblUsd)}
-                  subLabel="원화 환산액"
-                  subValue={isLoading ? null : fmtKrw(wdrwPsblKrw)}
-                  icon={<ArrowDownRight size={15} />}
-                  iconBg="bg-emerald-50 dark:bg-emerald-950/40 text-emerald-500"
-                  accentColor="bg-emerald-400 dark:bg-emerald-600"
-                  loading={isLoading}
-                />
               </section>
 
               {!isLoading && (
                 <div className="overflow-x-auto no-scrollbar mt-3">
                   <div className="flex gap-2 min-w-max pb-0.5">
+                    <MetricChip
+                      label="매입원금 (USD)"
+                      value={fmtUsd(pchsAmtUsd)}
+                      valueClass="text-neutral-700 dark:text-neutral-300"
+                    />
+                    <MetricChip
+                      label="출금 가능 (USD)"
+                      value={fmtUsd(wdrwPsblUsd)}
+                      valueClass="text-emerald-500"
+                    />
                     <MetricChip
                       label="금일 매수 (USD)"
                       value={fmtUsd(frcr_buy_smtl)}
@@ -723,29 +710,6 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
           ) : null,
         },
         {
-          id: "section-activity",
-          node: hasCapital ? (
-            <SectionPanel id="section-activity">
-              <SectionHeader
-                icon={<Activity size={16} />}
-                title="자동매매 현황"
-                subtitle="스케줄러(5분마다) 가동 상태 · 토큰 리필 · 최근 자동 체결 내역"
-                badge={
-                  usActivity.state === "pending"
-                    ? <span className="text-[10px] font-mono text-amber-500 bg-amber-50 dark:bg-amber-950/20 px-2 py-0.5 rounded-full border border-amber-200 dark:border-amber-800 animate-pulse">로딩 중</span>
-                    : <span className="text-[10px] font-mono text-neutral-500 dark:text-neutral-400 bg-[#faf9f7] dark:bg-[#242320] px-2 py-0.5 rounded-full">최근 {usActivity.logs.length}건</span>
-                }
-              />
-              <TradingActivityPanel
-                country="US"
-                capital={usCapital}
-                activity={usActivity}
-                onRefresh={() => dispatch(reqGetUsTradingActivity(balanceKey))}
-              />
-            </SectionPanel>
-          ) : null,
-        },
-        {
           id: "section-conditions",
           node: hasCapital ? (
             <SectionPanel id="section-conditions">
@@ -770,31 +734,27 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
           ) : null,
         },
         {
-          id: "section-account",
-          node: (
-            <SectionPanel id="section-account">
+          id: "section-activity",
+          node: hasCapital ? (
+            <SectionPanel id="section-activity">
               <SectionHeader
-                icon={<KeyRound size={16} />}
-                title="자동매매 계정 관리"
-                subtitle="등록된 계정을 선택해 KIS App Key/Secret·계좌번호·월 예산·ON/OFF 를 관리 (admin 전용)"
+                icon={<Activity size={16} />}
+                title="자동매매 현황"
+                subtitle="스케줄러(5분마다) 가동 상태 · 토큰 리필 · 최근 자동 체결 내역"
+                badge={
+                  usActivity.state === "pending"
+                    ? <span className="text-[10px] font-mono text-amber-500 bg-amber-50 dark:bg-amber-950/20 px-2 py-0.5 rounded-full border border-amber-200 dark:border-amber-800 animate-pulse">로딩 중</span>
+                    : <span className="text-[10px] font-mono text-neutral-500 dark:text-neutral-400 bg-[#faf9f7] dark:bg-[#242320] px-2 py-0.5 rounded-full">최근 {usActivity.logs.length}건</span>
+                }
               />
-              <TradingAccountList
+              <TradingActivityPanel
                 country="US"
-                balanceKey={balanceKey}
-                onSelect={setBalanceKey}
-                refreshToken={accountListToken}
-              />
-              <TradingAccountPanel
-                country="US"
-                balanceKey={balanceKey}
-                onChanged={() => {
-                  fetchAll(balanceKey);
-                  dispatch(reqFetchTradingStatus({ country: "US", key: balanceKey }));
-                  setAccountListToken(t => t + 1);
-                }}
+                capital={usCapital}
+                activity={usActivity}
+                onRefresh={() => dispatch(reqGetUsTradingActivity(balanceKey))}
               />
             </SectionPanel>
-          ),
+          ) : null,
         },
         {
           id: "section-orders",
@@ -849,6 +809,33 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
                   </tbody>
                 </table>
               </div>
+            </SectionPanel>
+          ),
+        },
+        {
+          id: "section-account",
+          node: (
+            <SectionPanel id="section-account">
+              <SectionHeader
+                icon={<KeyRound size={16} />}
+                title="자동매매 계정 관리"
+                subtitle="등록된 계정을 선택해 KIS App Key/Secret·계좌번호·월 예산·ON/OFF 를 관리 (admin 전용)"
+              />
+              <TradingAccountList
+                country="US"
+                balanceKey={balanceKey}
+                onSelect={setBalanceKey}
+                refreshToken={accountListToken}
+              />
+              <TradingAccountPanel
+                country="US"
+                balanceKey={balanceKey}
+                onChanged={() => {
+                  fetchAll(balanceKey);
+                  dispatch(reqFetchTradingStatus({ country: "US", key: balanceKey }));
+                  setAccountListToken(t => t + 1);
+                }}
+              />
             </SectionPanel>
           ),
         },

--- a/cf-idiotquant/components/balance/tradingAccountList.tsx
+++ b/cf-idiotquant/components/balance/tradingAccountList.tsx
@@ -67,7 +67,7 @@ export default function TradingAccountList({ country, balanceKey, onSelect, refr
                     acc.is_active
                       ? "bg-[#f0fdf4] text-[#16a34a] dark:bg-[#14532d]/40"
                       : "bg-neutral-100 text-neutral-500 dark:bg-[#35332e]")}>
-                    <Power className="inline w-3 h-3 -mt-0.5 mr-0.5" />{acc.is_active ? "ON" : "OFF"}
+                    <Power className="inline w-3 h-3 -mt-0.5 mr-0.5" />{acc.is_active ? "대상" : "제외"}
                   </span>
                   <span className="ml-auto text-[11px] text-neutral-400">
                     {acc.account_number || "계좌번호 미등록"} · 월 {won(acc.monthly_budget_krw)}원

--- a/cf-idiotquant/components/balance/tradingAccountPanel.tsx
+++ b/cf-idiotquant/components/balance/tradingAccountPanel.tsx
@@ -85,7 +85,7 @@ export default function TradingAccountPanel({ country, balanceKey, onChanged }: 
           {exists && (
             <span className={cn("ml-1 rounded-full px-2 py-0.5 text-[10px] font-black",
               info?.is_active ? "bg-[#f0fdf4] text-[#16a34a] dark:bg-[#14532d]/30" : "bg-neutral-100 text-neutral-500 dark:bg-[#35332e]")}>
-              <Power className="inline w-3 h-3 -mt-0.5 mr-0.5" />{info?.is_active ? "ON" : "OFF"}
+              <Power className="inline w-3 h-3 -mt-0.5 mr-0.5" />{info?.is_active ? "대상" : "제외"}
             </span>
           )}
         </span>
@@ -119,7 +119,7 @@ export default function TradingAccountPanel({ country, balanceKey, onChanged }: 
         <label className="flex items-center gap-2 text-xs font-bold text-neutral-600 dark:text-neutral-300 cursor-pointer">
           <input type="checkbox" checked={isActive} onChange={e => setIsActive(e.target.checked)}
             className="h-4 w-4 rounded border-neutral-300 text-[#16a34a] focus:ring-[#16a34a]" />
-          자동매매 활성화(ON)
+          자동매매 대상에 포함
         </label>
         {msg && (
           <span className={cn("text-xs font-bold", msg.type === "ok" ? "text-[#16a34a]" : "text-red-500")}>{msg.text}</span>

--- a/cf-idiotquant/components/navigation.tsx
+++ b/cf-idiotquant/components/navigation.tsx
@@ -14,7 +14,6 @@ import {
   LogOut,
   LogIn,
   Eye,
-  DollarSign,
   ShieldCheck,
   History,
   Gamepad2,
@@ -48,9 +47,11 @@ const MORE_NAV: NavItem[] = [
   { label: "수익 계산", href: "/calculator",  icon: Calculator              },
 ];
 
+// 한 화면(/balance)으로 가는 항목이라 하나만 둔다. 국가 선택은 그 화면 안의 🇰🇷/🇺🇸 토글이 맡는다.
+// 예전엔 KR/US 두 항목이 각각 /balance-kr · /balance-us 로 갔다가 클라이언트 리다이렉트로
+// 같은 화면에 도착했다 — 누를 때마다 "이동 중…" 이 한 번 스쳤다.
 const PORTFOLIO_NAV = [
-  { label: "KR 포트폴리오", href: "/balance-kr", icon: Eye         },
-  { label: "US 포트폴리오", href: "/balance-us", icon: DollarSign  },
+  { label: "포트폴리오", href: "/balance", icon: Eye },
 ];
 
 /* ─── HELPERS ─────────────────────────────────────────────────────── */


### PR DESCRIPTION
시안의 **1·2단계**를 구현했습니다. 3단계(KR·US 뷰 통합)는 하지 않았습니다.

---

## 1. 사이드바 KR/US 두 항목 → 「포트폴리오」 하나

```
사이드바 KR 포트폴리오 → /balance-kr → 리다이렉트 → /balance?country=kr
사이드바 US 포트폴리오 → /balance-us → 리다이렉트 → /balance?country=us
```

두 항목이 결국 같은 화면을 가리켰고, 그 화면 안에 이미 🇰🇷/🇺🇸 토글이 있었습니다. 게다가 두 경로 모두 클라이언트 리다이렉트라 **누를 때마다 “이동 중…” 이 한 번 스쳤습니다.**

- `PORTFOLIO_NAV` → `[{ 포트폴리오, /balance }]` 하나
- 레거시 라우트 `/balance-kr` · `/balance-us` 는 북마크용으로 그대로 둡니다

## 2. 섹션 내비 8개 → 4개

```
KPI · 포트폴리오 · 잔고 · 종목관리 · 자동매매 현황 · 트레이딩 조건 · 계정 · 주문내역
                              ↓
              자산 · 자동매매 · 주문내역 · 계정
```

**“내 돈이 지금 어떤가”(자산)** 와 **“기계가 뭘 하고 있나”(자동매매)** 를 가르는 기준입니다. 예전엔 이 둘이 8칸에 번갈아 섞여 있어서, 자동매매를 한 번 손보려면 `종목관리 → 조건 → 현황` 을 오가야 했습니다.

패널 순서도 그 묶음대로 재배치했습니다 — `kpi·포트폴리오·잔고` / `종목·조건·현황` / `주문` / `계정`. **패널 자체의 `id` 는 그대로**라 기존 앵커 링크는 살아 있습니다.

## 3. 미국 KPI 카드 6 → 4

`매입원금 (USD)` · `출금 가능` 을 아래 칩 줄로 내렸습니다. 국내는 **이미 4카드 + 칩 줄** 이라 그대로 두고, 칩 라벨만 `금일 매수 - 매도` → `금일 순매수` 로 미국과 맞췄습니다.

## 4. 계정 단위 스위치 이름 정리

| | before | after |
|---|---|---|
| 계정 패널 체크박스 | `자동매매 활성화(ON)` | `자동매매 대상에 포함` |
| 계정 배지 | `ON` / `OFF` | `대상` / `제외` |

자동매매 섹션 맨 위의 **국가 전체 스위치**와 라벨이 똑같아서, 어느 쪽이 실제로 켜는 것인지 화면만 봐서는 알 수 없었습니다.

---

## 검증

admin 세션을 위조해 실제 페이지를 렌더했습니다.

| 확인 | 결과 |
|---|---|
| 사이드바 링크 | `포트폴리오 → /balance` 하나 (리다이렉트 없음) |
| `/balance` 섹션 내비 | `[자산, 자동매매, 주문내역, 계정]` |
| `/balance?country=us` | `[자산, 자동매매, 해외주문, 계정]` |
| KPI | 두 화면 모두 4카드 + 칩 줄 |

- `npx tsc --noEmit` 통과
- `npm run build` 통과

## 참고 (이번 변경과 무관한 기존 동작)

사이드바의 Portfolio 그룹은 `isMasterUser` 로 가려져 있어 **master 계정에만 보입니다.** `/balance` 자체는 미들웨어에서 `role === "admin"` 이면 열리므로, admin 이지만 master 가 아닌 계정은 링크 없이 URL 로만 들어갈 수 있습니다. 기존 동작이라 손대지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_