### PR TITLE
fix(balance): 재조회 때마다 화면이 초기화되던 문제

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -410,6 +410,11 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
   const pnlRate = pchs > 0 ? (totalPnl / pchs) * 100 : Number(summary.asst_icdc_erng_rt || 0);
   const isPnlPositive = totalPnl >= 0;
   const isLoading = kiBalance.state === "pending";
+  // 재조회(30초 자동새로고침·수동 새로고침) 중에도 직전 데이터는 슬라이스에 그대로 남아 있다.
+  // 그런데 isLoading 만 보고 스켈레톤으로 되돌리면, 가진 데이터를 버리고 화면을 처음부터 다시
+  // 그리는 꼴이라 매번 페이지가 새로고침되는 것처럼 보인다. 표시할 게 아무것도 없는 첫 로딩에만
+  // 스켈레톤을 쓰고, 재조회는 헤더 새로고침 버튼의 스피너로만 알린다.
+  const isFirstLoad = isLoading && !summary.tot_evlu_amt;
   const hasCapital = krCapital.state === "fulfilled" || krCapital.state === "pending";
 
   // 추가 지표
@@ -525,24 +530,24 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
               <section id="section-kpi" className="grid grid-cols-2 lg:grid-cols-4 gap-3 animate-in fade-in slide-in-from-bottom-2 duration-400">
                 <KpiCard
                   label="총 평가 금액"
-                  value={isLoading ? null : `${totalEvalAmt.toLocaleString()}원`}
-                  sub={isLoading ? "" : `주식 ${sctsEvluAmt.toLocaleString()}원 · CMA ${cmaEvluAmt.toLocaleString()}원`}
+                  value={isFirstLoad ? null : `${totalEvalAmt.toLocaleString()}원`}
+                  sub={isFirstLoad ? "" : `주식 ${sctsEvluAmt.toLocaleString()}원 · CMA ${cmaEvluAmt.toLocaleString()}원`}
                   icon={<Wallet size={15} />}
                   iconBg="bg-[#f0fdf4] dark:bg-[#052e16]/40 text-[#16a34a]"
                   accentColor="bg-[#16a34a] dark:bg-[#16a34a]"
                 />
                 <KpiCard
                   label="예수금 (D+2)"
-                  value={isLoading ? null : `${d2Deposit.toLocaleString()}원`}
-                  sub={isLoading ? "" : `순자산 ${nassAmt.toLocaleString()}원`}
+                  value={isFirstLoad ? null : `${d2Deposit.toLocaleString()}원`}
+                  sub={isFirstLoad ? "" : `순자산 ${nassAmt.toLocaleString()}원`}
                   icon={<Coins size={15} />}
                   iconBg="bg-amber-50 dark:bg-amber-950/40 text-amber-500"
                   accentColor="bg-amber-400 dark:bg-amber-600"
                 />
                 <KpiCard
                   label="평가손익 합계"
-                  value={isLoading ? null : `${isPnlPositive ? "▲ +" : "▼ "}${totalPnl.toLocaleString()}원`}
-                  sub={isLoading ? "" : `매입원금 ${pchs.toLocaleString()}원`}
+                  value={isFirstLoad ? null : `${isPnlPositive ? "▲ +" : "▼ "}${totalPnl.toLocaleString()}원`}
+                  sub={isFirstLoad ? "" : `매입원금 ${pchs.toLocaleString()}원`}
                   icon={<PnlIcon positive={isPnlPositive} />}
                   iconBg={pnlIconBg(isPnlPositive)}
                   valueColor={pnlValueColor(isPnlPositive)}
@@ -550,8 +555,8 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                 />
                 <KpiCard
                   label="자산 수익률"
-                  value={isLoading ? null : `${isPnlPositive ? "▲ +" : "▼ "}${pnlRate.toFixed(2)}%`}
-                  sub={isLoading ? "" : `당일 증감 ${isDailyPositive ? "+" : ""}${asstIcdcErngRt.toFixed(2)}%`}
+                  value={isFirstLoad ? null : `${isPnlPositive ? "▲ +" : "▼ "}${pnlRate.toFixed(2)}%`}
+                  sub={isFirstLoad ? "" : `당일 증감 ${isDailyPositive ? "+" : ""}${asstIcdcErngRt.toFixed(2)}%`}
                   icon={<Percent size={15} />}
                   iconBg="bg-[#faf9f7] dark:bg-[#242320] text-neutral-500"
                   valueColor={pnlValueColor(isPnlPositive)}
@@ -559,7 +564,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
                 />
               </section>
 
-              {!isLoading && (
+              {!isFirstLoad && (
                 <div className="overflow-x-auto no-scrollbar mt-3">
                   <div className="flex gap-2 min-w-max pb-0.5">
                     <MetricChip
@@ -607,7 +612,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
               <PortfolioChartSection
                 output1={kiBalance.output1 || []}
                 isUs={false}
-                isLoading={isLoading}
+                isLoading={isFirstLoad}
               />
             </SectionPanel>
           ),

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -385,6 +385,11 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
   const totalPnlRate = Number(out3?.evlu_erng_rt1 || 0);
   const isPnlPositive = totalPnlKrw >= 0;
   const isLoading = kiBalance.state === "pending";
+  // 재조회(30초 자동새로고침·수동 새로고침) 중에도 직전 데이터는 슬라이스에 그대로 남아 있다.
+  // 그런데 isLoading 만 보고 스켈레톤으로 되돌리면, 가진 데이터를 버리고 화면을 처음부터 다시
+  // 그리는 꼴이라 매번 페이지가 새로고침되는 것처럼 보인다. 표시할 게 아무것도 없는 첫 로딩에만
+  // 스켈레톤을 쓰고, 재조회는 헤더 새로고침 버튼의 스피너로만 알린다.
+  const isFirstLoad = isLoading && !out3?.tot_asst_amt;
   const hasCapital = usCapital.state === "fulfilled" || usCapital.state === "pending";
 
   // 추가 지표
@@ -511,50 +516,50 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
               <section id="section-kpi" className="grid grid-cols-2 lg:grid-cols-4 gap-3 animate-in fade-in slide-in-from-bottom-2 duration-400">
                 <UsdKpiCard
                   label="총 자산 (USD)"
-                  mainValue={isLoading ? null : fmtUsd(totalAssetUsd)}
+                  mainValue={isFirstLoad ? null : fmtUsd(totalAssetUsd)}
                   mainColor="text-[#16a34a] dark:text-[#16a34a]"
                   subLabel="원화 평가액"
-                  subValue={isLoading ? null : fmtKrw(totalAssetKrw)}
+                  subValue={isFirstLoad ? null : fmtKrw(totalAssetKrw)}
                   icon={<BarChart3 size={15} />}
                   iconBg="bg-[#f0fdf4] dark:bg-[#052e16]/40 text-[#16a34a]"
                   accentColor="bg-[#16a34a] dark:bg-[#16a34a]"
-                  loading={isLoading}
+                  loading={isFirstLoad}
                 />
                 <UsdKpiCard
                   label="외화 예수금 (USD)"
-                  mainValue={isLoading ? null : fmtUsd(depositUsd)}
+                  mainValue={isFirstLoad ? null : fmtUsd(depositUsd)}
                   subLabel="익일 출금 가능"
-                  subValue={isLoading ? null : fmtUsd(nxdyFrcrDrwg)}
+                  subValue={isFirstLoad ? null : fmtUsd(nxdyFrcrDrwg)}
                   icon={<Wallet size={15} />}
                   iconBg="bg-amber-50 dark:bg-amber-950/40 text-amber-500"
                   accentColor="bg-amber-400 dark:bg-amber-600"
-                  loading={isLoading}
+                  loading={isFirstLoad}
                 />
                 <UsdKpiCard
                   label="주식 평가총액"
-                  mainValue={isLoading ? null : fmtUsd(stockEvalUsd)}
+                  mainValue={isFirstLoad ? null : fmtUsd(stockEvalUsd)}
                   subLabel="원화 환산액"
-                  subValue={isLoading ? null : fmtKrw(stockEvalKrw)}
+                  subValue={isFirstLoad ? null : fmtKrw(stockEvalKrw)}
                   icon={<TrendingUp size={15} />}
                   iconBg="bg-indigo-50 dark:bg-indigo-950/40 text-indigo-500"
                   accentColor="bg-indigo-400 dark:bg-indigo-600"
-                  loading={isLoading}
+                  loading={isFirstLoad}
                 />
                 <UsdKpiCard
                   label="총 수익률"
-                  mainValue={isLoading ? null : `${isPnlPositive ? "▲ +" : "▼ "}${totalPnlRate.toFixed(2)}%`}
+                  mainValue={isFirstLoad ? null : `${isPnlPositive ? "▲ +" : "▼ "}${totalPnlRate.toFixed(2)}%`}
                   mainColor={pnlValueColor(isPnlPositive)}
                   subLabel="손익 합계"
-                  subValue={isLoading ? null : fmtKrw(totalPnlKrw)}
+                  subValue={isFirstLoad ? null : fmtKrw(totalPnlKrw)}
                   subColor={pnlValueColor(isPnlPositive)}
                   icon={<PnlIcon positive={isPnlPositive} />}
                   iconBg={pnlIconBg(isPnlPositive)}
                   accentColor={pnlAccentColor(isPnlPositive)}
-                  loading={isLoading}
+                  loading={isFirstLoad}
                 />
               </section>
 
-              {!isLoading && (
+              {!isFirstLoad && (
                 <div className="overflow-x-auto no-scrollbar mt-3">
                   <div className="flex gap-2 min-w-max pb-0.5">
                     <MetricChip
@@ -628,7 +633,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
               <PortfolioChartSection
                 output1={kiBalance.output1 || []}
                 isUs={true}
-                isLoading={isLoading}
+                isLoading={isFirstLoad}
               />
             </SectionPanel>
           ),

--- a/cf-idiotquant/components/balance/tradingActivityPanel.tsx
+++ b/cf-idiotquant/components/balance/tradingActivityPanel.tsx
@@ -217,7 +217,7 @@ export default function TradingActivityPanel({
             </tr>
           </thead>
           <tbody className="divide-y divide-neutral-50 dark:divide-[#35332e]/40">
-            {loading ? (
+            {loading && logs.length === 0 ? (
               <tr><td colSpan={5} className="px-3 py-8 text-center text-xs text-neutral-400">불러오는 중…</td></tr>
             ) : logs.length === 0 ? (
               <tr><td colSpan={5} className="px-3 py-8 text-center text-xs text-neutral-400">아직 자동 체결 내역이 없습니다.</td></tr>


### PR DESCRIPTION
## 원인

`balance` 페이지는 30초마다 자동으로 잔고를 재조회한다. 그런데 화면이 `kiBalance.state === "pending"` 하나만 보고 표시를 결정하고 있었다.

```
const isLoading = kiBalance.state === "pending";
value={isLoading ? null : ...}   // KpiCard 는 value===null 이면 스켈레톤
{!isLoading && ( ...지표 칩 행... )}
<PortfolioChartSection isLoading={isLoading} />   // isLoading 이면 ChartSectionSkeleton
```

슬라이스의 `pending` 리듀서는 `state` 필드만 바꾸고 `output1`/`output2`/`output3` 은 그대로 둔다. 즉 **데이터는 계속 손에 있는데 UI 만 스스로 버리고** 스켈레톤으로 되돌아갔다. 30초마다 KPI 숫자가 사라지고, 지표 칩 행이 통째로 언마운트되어 레이아웃 높이가 줄었다 늘고, 차트가 스켈레톤을 거쳐 `animate-in fade-in` 으로 다시 등장했다. 이게 "데이터 로딩될 때마다 새로고침되는" 정체다.

부수적으로 `PortfolioChartSection` 이 언마운트되면서 내부 `activeTab` state 도 날아갔다 — 「수익률」 탭을 골라 둬도 30초 뒤 「자산 구성」으로 되돌아갔다.

## 변경

판단 기준을 "요청이 진행 중인가"에서 **"보여줄 데이터가 아직 없는가"** 로 바꾼다.

```
const isFirstLoad = isLoading && !summary.tot_evlu_amt;   // US 는 !out3?.tot_asst_amt
```

- KPI 카드 · 지표 칩 행 · 포트폴리오 차트가 `isFirstLoad` 를 쓴다 → 첫 로딩에만 스켈레톤, 재조회 중에는 직전 값을 그대로 유지.
- 헤더의 `isLoading={isLoading}` 은 그대로 둔다. 재조회 중이라는 사실은 새로고침 버튼 스피너로만 알리면 충분하다.
- `tradingActivityPanel` 의 자동 체결 내역 표도 같은 이유로 재조회 때 행이 "불러오는 중…" 으로 사라졌다 → `loading && logs.length === 0` 일 때만 표시.

KR·US 두 뷰에 동일하게 적용.

## 검증

Playwright 로 관리자 세션을 만들어 `/balance`, `/balance?country=us` 를 띄우고, 첫 로딩 완료 후 잔고 응답을 2.5초 지연시킨 채 새로고침을 눌러 pending 한가운데를 관찰했다.

| | 수정 전 | 수정 후 |
|---|---|---|
| 재조회 중 KPI 텍스트 | (빈 문자열) | `총 평가 금액 3,200,000원 …` 유지 |
| 재조회 중 지표 칩 행 | 사라짐 | 유지 |
| KPI 영역 스켈레톤 개수 | 20 | 0 |

같은 스크립트를 수정 전 코드에 돌려 FAIL 이 나는 것까지 확인해, 테스트가 실제로 이 동작을 가려낸다는 걸 검증했다. `npx tsc --noEmit` · `npm run build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_