### PR TITLE
fix(balance): 탭을 묶으면서 사라진 패널 4개 복구

### DIFF
--- a/cf-idiotquant/components/balance/balanceKrView.tsx
+++ b/cf-idiotquant/components/balance/balanceKrView.tsx
@@ -614,6 +614,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
         },
         {
           id: "section-portfolio",
+          tab: "section-kpi",
           node: (
             <SectionPanel id="section-portfolio">
               <SectionHeader
@@ -631,6 +632,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
         },
         {
           id: "section-balance",
+          tab: "section-kpi",
           node: (
             <SectionPanel id="section-balance">
               <InquireBalanceResult
@@ -705,6 +707,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
         },
         {
           id: "section-conditions",
+          tab: "section-stocks",
           node: hasCapital ? (
             <SectionPanel id="section-conditions">
               <SectionHeader
@@ -735,6 +738,7 @@ export function BalanceKrView({ countryToggle }: { countryToggle?: React.ReactNo
         },
         {
           id: "section-activity",
+          tab: "section-stocks",
           node: hasCapital ? (
             <SectionPanel id="section-activity">
               <SectionHeader

--- a/cf-idiotquant/components/balance/balanceShell.tsx
+++ b/cf-idiotquant/components/balance/balanceShell.tsx
@@ -15,6 +15,9 @@ import {
 
 export interface BalanceSection {
   id: string;
+  // 이 패널이 속한 탭(navSections 의 id). 탭 하나가 패널 여러 개를 묶으므로 id 와 다를 수 있다.
+  // 생략하면 자기 id 를 탭으로 쓴다(패널 하나가 곧 탭인 경우).
+  tab?: string;
   node: React.ReactNode;
 }
 
@@ -89,9 +92,10 @@ export function BalanceShell({
         {/* 섹션 네비게이션 */}
         <SectionNav sections={navSections} mobileTab={mobileTab} onMobileTabChange={onMobileTabChange} />
 
-        {/* 섹션 본문 (데스크탑·모바일 모두 탭 단위로 활성 섹션만 표시) */}
+        {/* 섹션 본문 — 활성 탭에 속한 패널을 모두 표시한다.
+            탭 id 와 패널 id 를 1:1 로 보면, 탭을 묶는 순간 짝 없는 패널이 조용히 사라진다. */}
         {sections.map(s => (
-          <div key={s.id} className={cn(mobileTab !== s.id && "hidden")}>
+          <div key={s.id} className={cn(mobileTab !== (s.tab ?? s.id) && "hidden")}>
             {s.node}
           </div>
         ))}

--- a/cf-idiotquant/components/balance/balanceUsView.tsx
+++ b/cf-idiotquant/components/balance/balanceUsView.tsx
@@ -633,6 +633,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
         },
         {
           id: "section-portfolio",
+          tab: "section-kpi",
           node: (
             <SectionPanel id="section-portfolio">
               <SectionHeader
@@ -650,6 +651,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
         },
         {
           id: "section-balance",
+          tab: "section-kpi",
           node: (
             <SectionPanel id="section-balance">
               <InquireBalanceResult
@@ -726,6 +728,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
         },
         {
           id: "section-conditions",
+          tab: "section-stocks",
           node: hasCapital ? (
             <SectionPanel id="section-conditions">
               <SectionHeader
@@ -750,6 +753,7 @@ export function BalanceUsView({ countryToggle }: { countryToggle?: React.ReactNo
         },
         {
           id: "section-activity",
+          tab: "section-stocks",
           node: hasCapital ? (
             <SectionPanel id="section-activity">
               <SectionHeader


### PR DESCRIPTION
## 회귀

#672 에서 섹션 탭을 8개 → 4개로 묶었다. 그런데 셸은 패널을 이렇게 렌더한다.

```jsx
{sections.map(s => (
  <div className={cn(mobileTab !== s.id && "hidden")}>   // 탭 id === 패널 id 가정
```

패널 id 는 그대로 뒀으므로, 탭과 짝이 없어진 패널 4개가 **어느 탭에서도 열리지 않게** 됐다. 당시 코드에 "각 항목은 묶음의 첫 패널로 스크롤한다(패널 자체의 id 는 그대로라 링크는 살아 있다)"고 주석까지 달았지만, 셸은 스크롤이 아니라 나머지를 숨기는 구조였다. 확인하지 않은 게 원인이다.

브라우저에서 각 탭을 눌러 보이는 패널을 나열한 결과(수정 전):

```
=== KR · 탭 ["자산","자동매매","주문내역","계정"] ===
  [자산]     → section-kpi
  [자동매매] → section-stocks
  [주문내역] → section-orders
  [계정]     → section-account
  어느 탭에서도 볼 수 없는 패널:
    section-portfolio, section-balance, section-conditions, section-activity
```

US 도 동일. 사라진 것은 **포트폴리오 자산 구성 · 잔고 표 · 트레이딩 조건 · 자동매매 현황**이다.

## 변경

`BalanceSection` 에 소속 탭을 두고, 셸이 활성 탭에 속한 패널을 **모두** 표시한다. 탭 id 와 패널 id 를 1:1 로 본 게 원인이라, 그 가정을 타입 수준에서 끊는다.

```diff
 export interface BalanceSection {
   id: string;
+  // 이 패널이 속한 탭(navSections 의 id). 탭 하나가 패널 여러 개를 묶으므로 id 와 다를 수 있다.
+  tab?: string;
   node: React.ReactNode;
 }
-<div className={cn(mobileTab !== s.id && "hidden")}>
+<div className={cn(mobileTab !== (s.tab ?? s.id) && "hidden")}>
```

| 탭 | 묶이는 패널 |
|---|---|
| 자산 | kpi · portfolio · balance |
| 자동매매 | stocks · conditions · activity |
| 주문내역(해외주문) | orders |
| 계정 | account |

## 검증

같은 스크립트 재실행(수정 후):

```
[자산]     → section-kpi, section-portfolio, section-balance
[자동매매] → section-stocks, section-conditions, section-activity
[주문내역] → section-orders
[계정]     → section-account
어느 탭에서도 볼 수 없는 패널: 없음
```

KR·US 모두 누락 0. 「자동매매 현황」 패널이 체결 이력 표까지 렌더되는 것을 스크린샷으로 확인했다. `npx tsc --noEmit` · `npm run build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_