### PR TITLE
feat(screener/analyze): 개선 제안 4건 적용 + 적정주가 축 끝값 라벨 제거

### DIFF
--- a/cf-idiotquant/app/(screener)/screener/components/LiquidityBadge.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/LiquidityBadge.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+// 유동성·거래정지 표시.
+// 스크리너는 종목을 네 가지 뷰(비율·카드·데스크탑 표·모바일 표)로 그리는데, 어느 뷰로 보든
+// "이 종목을 실제로 담을 수 있는가"는 같은 자리에 같은 모양으로 서야 한다 → 여기 한 곳에 둔다.
+// 판정에 쓰는 값(trAmtEok·isHalted)도 같이 두어 필터와 배지가 다른 기준을 쓰는 일이 없게 한다.
+
+/** 누적 거래대금(원) → 억원. 값이 없으면 null — "거래대금 0원"과 "아직 수집 안 됨"은 다르다. */
+export function trAmtEok(i: any): number | null {
+    const v = i?.acml_tr_pbmn;
+    if (v === null || v === undefined || v === "") return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n / 1e8 : null;
+}
+
+export function isHalted(i: any): boolean {
+    return String(i?.temp_stop_yn ?? "").toUpperCase() === "Y";
+}
+
+/** 하루 거래대금이 이보다 적으면 원하는 수량을 한 번에 담기 어렵다 */
+export const LOW_TR_AMT_EOK = 3;
+
+// 정상 종목에는 아무것도 붙이지 않는다 — 모든 행에 배지가 달리면 신호가 아니라 잡음이 된다.
+// 표에 열을 새로 만들지 않은 이유: 데스크탑 표는 이미 7열 고정폭이라 한 열을 더하면 좁은
+// 노트북에서 눌리고, 카드 뷰에는 그 열이 아예 없어 같은 정보가 한쪽에만 생긴다.
+export function LiquidityBadge({ item }: { item: any }) {
+    if (isHalted(item)) {
+        return (
+            <span className="px-1.5 py-0.5 rounded text-[9.5px] font-black bg-rose-50 text-rose-600 dark:bg-rose-950/30 dark:text-rose-400 whitespace-nowrap">
+                거래정지
+            </span>
+        );
+    }
+    const v = trAmtEok(item);
+    if (v === null || v >= LOW_TR_AMT_EOK) return null;
+    return (
+        <span
+            title={`하루 거래대금 약 ${v.toFixed(1)}억원 — 원하는 수량을 한 번에 담기 어렵습니다`}
+            className="px-1.5 py-0.5 rounded text-[9.5px] font-black bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400 whitespace-nowrap"
+        >
+            거래 {v.toFixed(1)}억
+        </span>
+    );
+}

--- a/cf-idiotquant/app/(screener)/screener/components/StockGridCard.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/StockGridCard.tsx
@@ -2,6 +2,7 @@
 
 import { Heart, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { LiquidityBadge } from "./LiquidityBadge";
 import { ValueMedal } from "@/components/valueMedal";
 import { STRATEGY_LABEL, STRATEGY_BADGE, STRATEGY_HEX, STRATEGY_PRESETS_CLIENT } from "@/lib/constants/strategies";
 import SectorSprite, { SECTOR_COLOR } from "./SectorSprite";
@@ -85,7 +86,10 @@ export function StockGridCard({ item, onClick, isLiked, onToggleLike }: {
                     <ValueMedal item={item} />
                     <div className="min-w-0 flex-1">
                         <p className="text-sm font-extrabold text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
-                        <p className="text-[10.5px] font-mono tracking-[0.05em] text-neutral-400 mt-0.5">{item.ticker}</p>
+                        <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
+                            <span className="text-[10.5px] font-mono tracking-[0.05em] text-neutral-400">{item.ticker}</span>
+                            <LiquidityBadge item={item} />
+                        </div>
                     </div>
                     <button
                         onClick={e => { e.stopPropagation(); onToggleLike(item.ticker, item.name); }}

--- a/cf-idiotquant/app/(screener)/screener/components/StockRatioRow.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/StockRatioRow.tsx
@@ -2,6 +2,7 @@
 
 import { Heart } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { LiquidityBadge } from "./LiquidityBadge";
 import { ValueMedal } from "@/components/valueMedal";
 import { ratioMetrics, barPct } from "./ratioMetrics";
 
@@ -62,7 +63,10 @@ export function StockRatioRow({ item, onClick, isLiked, onToggleLike }: {
                 <ValueMedal item={item} />
                 <div className="min-w-0 flex-1">
                     <p className="text-sm font-extrabold text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
-                    <p className="text-[10.5px] font-mono tracking-[0.05em] text-neutral-400 mt-0.5">{item.ticker}</p>
+                    <div className="flex items-center gap-1.5 mt-0.5 min-w-0">
+                        <span className="text-[10.5px] font-mono tracking-[0.05em] text-neutral-400 shrink-0">{item.ticker}</span>
+                        <LiquidityBadge item={item} />
+                    </div>
                 </div>
                 <button
                     onClick={e => { e.stopPropagation(); onToggleLike(item.ticker, item.name); }}

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -24,6 +24,7 @@ import { buildGroups, defaultOpenGroups, GroupedResults, type GroupMode } from "
 import { ResultSummary, TermStrip } from "./components/ResultSummary";
 import { StockGridCard } from "./components/StockGridCard";
 import { StockRatioRow } from "./components/StockRatioRow";
+import { LiquidityBadge, trAmtEok, isHalted } from "./components/LiquidityBadge";
 import { STRATEGY_LABEL, STRATEGY_BADGE, STRATEGY_PRESETS_CLIENT as STRATEGY_PRESETS, MKTCAP_PRESETS, STRATEGY_ACTIVE_CLS } from "@/lib/constants/strategies";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -55,14 +56,7 @@ const TR_AMT_PRESETS = [1, 3, 10, 50];
 
 // 업종명 — 워커는 sector 로 저장한다(inquire-price 의 bstp_kor_isnm). 예전 응답 호환으로 industry 도 본다.
 const sectorOf = (i: any): string => String(i?.sector ?? i?.industry ?? "").trim();
-// 누적 거래대금(원) → 억원. 값이 없으면 null — "거래대금 0원"과 "아직 수집 안 됨"은 다르다.
-const trAmtEok = (i: any): number | null => {
-    const v = i?.acml_tr_pbmn;
-    if (v === null || v === undefined || v === "") return null;
-    const n = Number(v);
-    return Number.isFinite(n) ? n / 1e8 : null;
-};
-const isHalted = (i: any): boolean => String(i?.temp_stop_yn ?? "").toUpperCase() === "Y";
+// 거래대금·거래정지 판정은 배지와 같은 기준을 써야 하므로 LiquidityBadge 모듈에서 가져온다.
 
 
 // 백엔드 strategies + 프론트엔드 clientFilter 병합 (백엔드 미분류 종목도 표시)
@@ -280,7 +274,10 @@ const TableRow = memo(function TableRow({ item, onClick, isLiked, onToggleLike, 
                 <ValueMedal item={item} />
                 <div className="min-w-0">
                     <p className="font-bold text-sm text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
-                    <p className="text-[11px] text-neutral-400 font-mono mt-0.5 tracking-wider">{item.ticker}</p>
+                    <div className="flex items-center gap-1.5 mt-0.5 min-w-0">
+                        <span className="text-[11px] text-neutral-400 font-mono tracking-wider shrink-0">{item.ticker}</span>
+                        <LiquidityBadge item={item} />
+                    </div>
                 </div>
             </div>
 
@@ -381,7 +378,10 @@ const StockRowCard = memo(function StockRowCard({ item, onClick, isLiked, onTogg
                         <ValueMedal item={item} size="lg" />
                     </div>
                     <p className="font-bold text-base text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
-                    <p className="text-[11px] text-neutral-400 font-mono tracking-wider mt-0.5">{item.ticker}</p>
+                    <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
+                        <span className="text-[11px] text-neutral-400 font-mono tracking-wider">{item.ticker}</span>
+                        <LiquidityBadge item={item} />
+                    </div>
                 </div>
                 <div className="flex items-center gap-1.5 shrink-0">
                     <button

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -46,6 +46,20 @@ const NCAV_MIN_PRESETS = [0.7, 1.0, 1.5];   // NCAV 비율 이상
 // 우선주: 종목명이 '우' / '우B' / '우C' 등으로 끝남
 const isPreferredStock = (name: string): boolean => /\d*우[A-C]?$/.test((name ?? "").trim());
 
+// 일 거래대금 하한 프리셋 (단위: 억원, 0 = 미적용)
+const TR_AMT_PRESETS = [1, 3, 10, 50];
+
+// 업종명 — 워커는 sector 로 저장한다(inquire-price 의 bstp_kor_isnm). 예전 응답 호환으로 industry 도 본다.
+const sectorOf = (i: any): string => String(i?.sector ?? i?.industry ?? "").trim();
+// 누적 거래대금(원) → 억원. 값이 없으면 null — "거래대금 0원"과 "아직 수집 안 됨"은 다르다.
+const trAmtEok = (i: any): number | null => {
+    const v = i?.acml_tr_pbmn;
+    if (v === null || v === undefined || v === "") return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n / 1e8 : null;
+};
+const isHalted = (i: any): boolean => String(i?.temp_stop_yn ?? "").toUpperCase() === "Y";
+
 
 // 백엔드 strategies + 프론트엔드 clientFilter 병합 (백엔드 미분류 종목도 표시)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -108,6 +122,9 @@ interface ScreenerFilters {
     excludeHoldings: boolean;
     excludeDeficit: boolean;
     excludePreferred: boolean;
+    excludeHalted: boolean;
+    sectors: Set<string>;
+    minTrAmt: number;
     minMarketCap: number;
     maxPbr: number;
     maxPer: number;
@@ -116,15 +133,17 @@ interface ScreenerFilters {
 }
 
 // 필터 그룹 — 서랍 카드 순서와 1:1. 누적 카운트(→N)는 이 순서대로 쌓아 계산한다.
-type FilterGroupKey = "mktcap" | "pbr" | "per" | "ncav" | "profit" | "exclude";
-const FILTER_GROUP_ORDER: FilterGroupKey[] = ["mktcap", "pbr", "per", "ncav", "profit", "exclude"];
+type FilterGroupKey = "mktcap" | "pbr" | "per" | "ncav" | "profit" | "sector" | "liquidity" | "exclude";
+const FILTER_GROUP_ORDER: FilterGroupKey[] = ["mktcap", "pbr", "per", "ncav", "profit", "sector", "liquidity", "exclude"];
 const GROUP_DEFAULTS: Record<FilterGroupKey, Partial<ScreenerFilters>> = {
     mktcap:  { minMarketCap: 0 },
     pbr:     { maxPbr: 0 },
     per:     { maxPer: 0 },
     ncav:    { minNcav: 0 },
     profit:  { minRoe: 0, excludeDeficit: false },
-    exclude: { excludeHoldings: false, excludePreferred: false },
+    sector:    { sectors: new Set<string>() },
+    liquidity: { minTrAmt: 0 },
+    exclude:   { excludeHoldings: false, excludePreferred: false, excludeHalted: false },
 };
 
 function applyFilters(list: Record<string, any>[], f: ScreenerFilters): Record<string, any>[] {
@@ -157,6 +176,13 @@ function applyFilters(list: Record<string, any>[], f: ScreenerFilters): Record<s
     if (f.maxPer > 0)  out = out.filter(item => safeNum(item.per) > 0 && safeNum(item.per) <= f.maxPer);
     if (f.minNcav > 0) out = out.filter(item => safeNum(item.ncav_ratio) >= f.minNcav);
     if (f.minRoe > 0)  out = out.filter(item => roeOf(item) >= f.minRoe);
+
+    if (f.sectors.size > 0) out = out.filter(item => f.sectors.has(sectorOf(item)));
+    // 값이 아직 없는 종목은 통과시킨다. 배포 직후처럼 일부만 채워진 구간에서 "모르는 것"을
+    // "조건 위반"으로 취급하면 목록이 통째로 비어 고장난 것처럼 보인다.
+    // (아래 두 서랍 카드는 애초에 데이터가 있을 때만 뜨므로 정상 상태에서는 이 경로가 드물다.)
+    if (f.minTrAmt > 0) out = out.filter(item => { const v = trAmtEok(item); return v === null || v >= f.minTrAmt; });
+    if (f.excludeHalted) out = out.filter(item => !isHalted(item));
 
     return out;
 }
@@ -561,6 +587,15 @@ function ScreenerContent() {
     const [excludeHoldings, setExcludeHoldings] = useState(() => initExclude('holdings'));
     const [excludeDeficit, setExcludeDeficit] = useState(() => initExclude('deficit'));
     const [excludePreferred, setExcludePreferred] = useState(() => initExclude('preferred'));
+    const [excludeHalted, setExcludeHalted] = useState(() => initExclude('halted'));
+    // 업종 다중 선택 (URL param: sectors, 쉼표 구분)
+    const [sectors, setSectors] = useState<Set<string>>(() => {
+        const urlS = searchParams.get('sectors');
+        const src = urlS ?? (Array.isArray(saved.sectors) ? saved.sectors.join(',') : '');
+        return new Set((src || '').split(',').map(v => v.trim()).filter(Boolean));
+    });
+    // 일 거래대금 하한 (단위: 억원, URL param: mintr)
+    const [minTrAmt, setMinTrAmt] = useState<number>(() => initNum('mintr', 'mintr', TR_AMT_PRESETS));
     const [filterOpen, setFilterOpen] = useState(false);
     const [showLikedOnly, setShowLikedOnly] = useState(() =>
         (searchParams.get('filter') ?? saved.filter) === 'liked'
@@ -630,8 +665,11 @@ function ScreenerContent() {
             excludeHoldings ? 'holdings' : null,
             excludeDeficit ? 'deficit' : null,
             excludePreferred ? 'preferred' : null,
+            excludeHalted ? 'halted' : null,
         ].filter(Boolean).join(',');
         if (excludeList) params.set('exclude', excludeList);
+        if (sectors.size > 0) params.set('sectors', Array.from(sectors).join(','));
+        if (minTrAmt > 0) params.set('mintr', String(minTrAmt));
         if (minMarketCap > 0) params.set('mincap', String(minMarketCap));
         if (maxPbr > 0) params.set('maxpbr', String(maxPbr));
         if (maxPer > 0) params.set('maxper', String(maxPer));
@@ -642,7 +680,7 @@ function ScreenerContent() {
         if (groupMode !== 'none') params.set('group', groupMode);
         if (viewMode !== DEFAULT_VIEW) params.set('view', viewMode);
         return params.toString();
-    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode]);
+    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode]);
 
     // 필터 상태 → URL 동기화 + localStorage 저장 (페이지 이동 후 재진입 시에도 전체 필터 유지)
     useEffect(() => {
@@ -660,8 +698,11 @@ function ScreenerContent() {
             excludeHoldings ? 'holdings' : null,
             excludeDeficit ? 'deficit' : null,
             excludePreferred ? 'preferred' : null,
+            excludeHalted ? 'halted' : null,
         ].filter(Boolean);
         if (excludeArr.length) snapshot.exclude = excludeArr;
+        if (sectors.size > 0) snapshot.sectors = Array.from(sectors);
+        if (minTrAmt > 0) snapshot.mintr = minTrAmt;
         if (minMarketCap > 0) snapshot.mincap = minMarketCap;
         if (maxPbr > 0) snapshot.maxpbr = maxPbr;
         if (maxPer > 0) snapshot.maxper = maxPer;
@@ -681,7 +722,7 @@ function ScreenerContent() {
         localStorage.removeItem('screener:filterMode');
         }, 300);
         return () => clearTimeout(debounce);
-    }, [queryString, activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode, router]);
+    }, [queryString, activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode, router]);
 
     // 현재 필터링 결과 링크 공유 (모바일: 네이티브 공유 시트 / 데스크탑: 클립보드 복사)
     const handleShare = useCallback(async () => {
@@ -782,9 +823,10 @@ function ScreenerContent() {
         strategies: activeStrategyIds,
         mode: filterMode,
         q: searchQuery,
-        excludeHoldings, excludeDeficit, excludePreferred,
+        excludeHoldings, excludeDeficit, excludePreferred, excludeHalted,
+        sectors, minTrAmt,
         minMarketCap, maxPbr, maxPer, minRoe, minNcav,
-    }), [activeStrategyIds, filterMode, searchQuery, excludeHoldings, excludeDeficit, excludePreferred, minMarketCap, maxPbr, maxPer, minRoe, minNcav]);
+    }), [activeStrategyIds, filterMode, searchQuery, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav]);
 
     const baseList = useMemo(
         () => (showLikedOnly ? normalizedLikedList : ncavDailyList.list) as Record<string, any>[],
@@ -848,7 +890,8 @@ function ScreenerContent() {
     const funnel = useMemo(() => {
         const none: ScreenerFilters = {
             strategies: new Set(), mode: 'OR', q: '',
-            excludeHoldings: false, excludeDeficit: false, excludePreferred: false,
+            excludeHoldings: false, excludeDeficit: false, excludePreferred: false, excludeHalted: false,
+            sectors: new Set<string>(), minTrAmt: 0,
             minMarketCap: 0, maxPbr: 0, maxPer: 0, minRoe: 0, minNcav: 0,
         };
         const steps: { label: string; patch: Partial<ScreenerFilters> }[] = [
@@ -857,6 +900,7 @@ function ScreenerContent() {
             { label: '검색',      patch: { q: filters.q } },
             { label: '가치 지표', patch: { minMarketCap: filters.minMarketCap, maxPbr: filters.maxPbr, maxPer: filters.maxPer, minNcav: filters.minNcav } },
             { label: '수익·제외', patch: { minRoe: filters.minRoe, excludeDeficit: filters.excludeDeficit, excludeHoldings: filters.excludeHoldings, excludePreferred: filters.excludePreferred } },
+            { label: '업종·유동성', patch: { sectors: filters.sectors, minTrAmt: filters.minTrAmt, excludeHalted: filters.excludeHalted } },
         ];
         let acc = { ...none };
         return steps.map(s => {
@@ -901,12 +945,25 @@ function ScreenerContent() {
         : null;
     const scanningInProgress = ncavDailyList.scanningInProgress;
 
-    const activeFilterCount = [excludeHoldings, excludeDeficit, excludePreferred, minMarketCap > 0, maxPbr > 0, maxPer > 0, minRoe > 0, minNcav > 0].filter(Boolean).length;
+    const activeFilterCount = [excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, sectors.size > 0, minTrAmt > 0, minMarketCap > 0, maxPbr > 0, maxPer > 0, minRoe > 0, minNcav > 0].filter(Boolean).length;
     const isAllActive = activeStrategyIds.size === 0;
-    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || excludePreferred || minMarketCap > 0 || maxPbr > 0 || maxPer > 0 || minRoe > 0 || minNcav > 0 || sortKey !== 'value_score' || sortOrder !== 'desc' || showLikedOnly;
+    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || excludePreferred || excludeHalted || sectors.size > 0 || minTrAmt > 0 || minMarketCap > 0 || maxPbr > 0 || maxPer > 0 || minRoe > 0 || minNcav > 0 || sortKey !== 'value_score' || sortOrder !== 'desc' || showLikedOnly;
     const isFiltered = !showLikedOnly && filteredList.length !== ncavDailyList.list.length;
     // 업종 묶기는 응답에 sector/industry 가 있을 때만. 없으면 세그먼트에서 비활성.
     const hasSectorData = ncavDailyList.list.some((i: any) => i.sector ?? i.industry);
+    // 워커가 아직 이 값을 채우기 전(migration 0013 배포 전)에는 해당 서랍 카드를 아예 띄우지
+    // 않는다. 조작해도 아무 일이 없는 손잡이를 두는 것보다 없는 편이 낫다.
+    const hasTrAmtData = useMemo(() => baseList.some(i => trAmtEok(i) !== null), [baseList]);
+    const hasHaltData = useMemo(() => baseList.some(i => i.temp_stop_yn != null), [baseList]);
+    // 업종 선택지 — 지금 목록에 실제로 있는 업종만, 종목이 많은 순으로.
+    const sectorOptions = useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const i of baseList) {
+            const sec = sectorOf(i);
+            if (sec) counts.set(sec, (counts.get(sec) ?? 0) + 1);
+        }
+        return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+    }, [baseList]);
 
     // 단일 전략 선택 시에만 기준 배너를 띄운다 — 여러 전략을 겹치면 "이 값이 왜 초록인지"를
     // 한 줄로 설명할 수 없어 오히려 오해를 만든다.
@@ -934,8 +991,11 @@ function ScreenerContent() {
         excludeDeficit   && { label: '적자 기업 제외',           override: { excludeDeficit: false } as Partial<ScreenerFilters>,   clear: () => setExcludeDeficit(false) },
         excludeHoldings  && { label: '홀딩스 제외',              override: { excludeHoldings: false } as Partial<ScreenerFilters>,  clear: () => setExcludeHoldings(false) },
         excludePreferred && { label: '우선주 제외',              override: { excludePreferred: false } as Partial<ScreenerFilters>, clear: () => setExcludePreferred(false) },
+        excludeHalted    && { label: '거래정지 제외',             override: { excludeHalted: false } as Partial<ScreenerFilters>,    clear: () => setExcludeHalted(false) },
+        minTrAmt > 0     && { label: `거래대금 ${minTrAmt}억+`,   override: { minTrAmt: 0 } as Partial<ScreenerFilters>,             clear: () => setMinTrAmt(0) },
+        sectors.size > 0 && { label: `업종 ${sectors.size}개`,    override: { sectors: new Set<string>() } as Partial<ScreenerFilters>, clear: () => setSectors(new Set()) },
     ].filter(Boolean) as { label: string; override: Partial<ScreenerFilters>; clear: () => void }[]),
-    [minMarketCap, maxPbr, maxPer, minNcav, minRoe, excludeDeficit, excludeHoldings, excludePreferred]);
+    [minMarketCap, maxPbr, maxPer, minNcav, minRoe, excludeDeficit, excludeHoldings, excludePreferred, excludeHalted, minTrAmt, sectors]);
 
     // 결과가 0개일 때 — "무엇을 풀면 몇 개가 돌아오는지"를 짚어준다. 그냥 "없습니다"로 끝내면
     // 어떤 조건이 결과를 죽였는지 사용자가 하나씩 꺼보며 찾아야 한다.
@@ -951,6 +1011,7 @@ function ScreenerContent() {
     const clearDetailFilters = useCallback(() => {
         setMinMarketCap(0); setMaxPbr(0); setMaxPer(0); setMinRoe(0); setMinNcav(0);
         setExcludeHoldings(false); setExcludeDeficit(false); setExcludePreferred(false);
+        setExcludeHalted(false); setSectors(new Set()); setMinTrAmt(0);
         setDisplayCount(DAILY_PAGE_SIZE);
     }, []);
 
@@ -1254,6 +1315,9 @@ function ScreenerContent() {
                         if (excludeHoldings) chips.push({ key: 'hold', label: '홀딩스 제외', clear: () => setExcludeHoldings(false) });
                         if (excludeDeficit)  chips.push({ key: 'def',  label: '적자 제외',  clear: () => setExcludeDeficit(false) });
                         if (excludePreferred) chips.push({ key: 'pref', label: '우선주 제외', clear: () => setExcludePreferred(false) });
+                        if (excludeHalted)   chips.push({ key: 'halt', label: '거래정지 제외', clear: () => setExcludeHalted(false) });
+                        if (minTrAmt > 0)    chips.push({ key: 'tr',   label: `거래대금 ${minTrAmt}억+`, clear: () => { setMinTrAmt(0); setDisplayCount(DAILY_PAGE_SIZE); } });
+                        if (sectors.size > 0) chips.push({ key: 'sec', label: `업종 ${sectors.size}개`, clear: () => { setSectors(new Set()); setDisplayCount(DAILY_PAGE_SIZE); } });
                         // 칩이 없어도 걸린 조건(정렬·관심·전략)이 있으면 초기화 경로는 남겨야 한다.
                         if (chips.length === 0 && !hasActiveFilters) return null;
                         return (
@@ -1412,6 +1476,51 @@ function ScreenerContent() {
                                 />
                             </DrawerCard>
 
+                            {/* 업종 — 저PBR·NCAV 결과는 한 업종에 몰리기 쉽다. 골라서 좁히거나 덜어낸다. */}
+                            {hasSectorData && sectorOptions.length > 0 && (
+                                <DrawerCard label="업종" remain={cumulativeCounts.sector} span2>
+                                    <div className="flex items-center gap-1.5 flex-wrap max-h-28 overflow-y-auto -mr-1 pr-1">
+                                        {sectorOptions.map(([sec, n]) => (
+                                            <DrawerChip
+                                                key={sec}
+                                                active={sectors.has(sec)}
+                                                onClick={() => {
+                                                    setSectors(prev => {
+                                                        const next = new Set(prev);
+                                                        if (next.has(sec)) next.delete(sec); else next.add(sec);
+                                                        return next;
+                                                    });
+                                                    setDisplayCount(DAILY_PAGE_SIZE);
+                                                }}
+                                            >
+                                                {sec} <span className="opacity-60 font-mono">{n}</span>
+                                            </DrawerChip>
+                                        ))}
+                                    </div>
+                                    {sectors.size > 0 && (
+                                        <button
+                                            onClick={() => { setSectors(new Set()); setDisplayCount(DAILY_PAGE_SIZE); }}
+                                            className="mt-2 text-[11px] font-bold text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300"
+                                        >
+                                            업종 선택 해제
+                                        </button>
+                                    )}
+                                </DrawerCard>
+                            )}
+
+                            {/* 유동성 — 지표가 아무리 좋아도 하루 거래대금이 적으면 원하는 수량을 담을 수 없다. */}
+                            {hasTrAmtData && (
+                                <DrawerCard label="일 거래대금" remain={cumulativeCounts.liquidity}>
+                                    <div className="flex items-center gap-1.5 flex-wrap">
+                                        {TR_AMT_PRESETS.map(v => (
+                                            <DrawerChip key={v} active={minTrAmt === v} onClick={() => { setMinTrAmt(minTrAmt === v ? 0 : v); setDisplayCount(DAILY_PAGE_SIZE); }}>
+                                                {v}억 이상
+                                            </DrawerChip>
+                                        ))}
+                                    </div>
+                                </DrawerCard>
+                            )}
+
                             {/* 제외 조건 */}
                             <DrawerCard label="제외" remain={cumulativeCounts.exclude}>
                                 <div className="flex flex-col gap-1">
@@ -1431,6 +1540,16 @@ function ScreenerContent() {
                                             ? countWith({ excludePreferred: false }) - filteredList.length
                                             : filteredList.length - countWith({ excludePreferred: true })}
                                     />
+                                    {hasHaltData && (
+                                        <DrawerCheck
+                                            checked={excludeHalted}
+                                            onChange={v => { setExcludeHalted(v); setDisplayCount(DAILY_PAGE_SIZE); }}
+                                            label="거래정지 제외"
+                                            delta={excludeHalted
+                                                ? countWith({ excludeHalted: false }) - filteredList.length
+                                                : filteredList.length - countWith({ excludeHalted: true })}
+                                        />
+                                    )}
                                 </div>
                             </DrawerCard>
 

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -46,6 +46,10 @@ const NCAV_MIN_PRESETS = [0.7, 1.0, 1.5];   // NCAV 비율 이상
 // 우선주: 종목명이 '우' / '우B' / '우C' 등으로 끝남
 const isPreferredStock = (name: string): boolean => /\d*우[A-C]?$/.test((name ?? "").trim());
 
+// 업종 분포 띠 색 — 앱 강조색(초록)에서 단계적으로 옅어지고, 마지막은 "그 외"용 중립색.
+// 두 테마 모두 같은 값을 쓴다: 채도가 있는 면 위에 흰 글씨라 바탕색이 바뀌어도 대비가 유지된다.
+const MIX_COLORS = ['#15803d', '#16a34a', '#3faf6d', '#6ec492', '#93a89b', '#a8a29e'];
+
 // 일 거래대금 하한 프리셋 (단위: 억원, 0 = 미적용)
 const TR_AMT_PRESETS = [1, 3, 10, 50];
 
@@ -886,6 +890,29 @@ function ScreenerContent() {
     const visibleList = filteredList.slice(0, displayCount);
     const hasMore = !groups && filteredList.length > displayCount;
 
+    // 업종 분포 — 지금 화면에 있는 목록 기준. 저PBR·NCAV 결과는 업황이 꺾인 산업 하나로
+    // 뒤덮이기 쉬운데, 표를 위에서부터 읽으면 그게 "싼 회사가 많다"로 보인다.
+    const sectorMix = useMemo(() => {
+        if (filteredList.length < 4) return null;
+        const counts = new Map<string, number>();
+        let known = 0;
+        for (const i of filteredList) {
+            const sec = sectorOf(i);
+            if (!sec) continue;
+            counts.set(sec, (counts.get(sec) ?? 0) + 1);
+            known++;
+        }
+        if (known < 4 || counts.size < 2) return null;
+        const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+        const head = sorted.slice(0, 5);
+        const restCount = sorted.slice(5).reduce((acc, [, n]) => acc + n, 0);
+        const segs = head.map(([name, n], idx) => ({ name, n, pct: (n / known) * 100, color: MIX_COLORS[idx] }));
+        if (restCount > 0) segs.push({ name: '그 외', n: restCount, pct: (restCount / known) * 100, color: MIX_COLORS[5] });
+        const top3 = sorted.slice(0, 3).reduce((acc, [, n]) => acc + n, 0);
+        return { segs, known, top3Pct: (top3 / known) * 100, topNames: sorted.slice(0, 3).map(([nm]) => nm) };
+        // 업종이 하나도 없는 응답이면 known 이 0 이라 위에서 null 로 빠진다 — 별도 플래그 불필요.
+    }, [filteredList]);
+
     // 조건 깔때기 — 어느 단계에서 결과가 확 줄었는지 보여준다
     const funnel = useMemo(() => {
         const none: ScreenerFilters = {
@@ -1709,6 +1736,47 @@ function ScreenerContent() {
 
                 {!isLoading && filteredList.length > 0 && (
                     <>
+                        {/* 업종 분포 — 목록을 늘어놓기 전에 "무엇을 받았는지"를 먼저 보여준다.
+                            좁은 화면에서는 띠 안에 이름을 넣을 자리가 없으므로 이름은 항상 아래
+                            범례가 맡고, 띠 안에는 넉넉한 조각에만 퍼센트를 얹는다. */}
+                        {sectorMix && (
+                            <div className="mb-3 rounded-xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] px-3.5 py-3">
+                                <div className="flex items-baseline justify-between gap-2 mb-2">
+                                    <span className="text-[11px] font-extrabold uppercase tracking-wider text-neutral-500 dark:text-neutral-400">업종 분포</span>
+                                    <span className="text-[10.5px] font-mono text-neutral-400 tabular-nums shrink-0">{sectorMix.known}종목</span>
+                                </div>
+                                <div className="flex h-6 rounded-md overflow-hidden border border-neutral-200 dark:border-[#3a3834]">
+                                    {sectorMix.segs.map(seg => (
+                                        <div
+                                            key={seg.name}
+                                            title={`${seg.name} ${seg.n}종목 (${seg.pct.toFixed(0)}%)`}
+                                            style={{ width: `${seg.pct}%`, minWidth: '3px', background: seg.color }}
+                                            className="relative flex items-center justify-center"
+                                        >
+                                            {seg.pct >= 15 && (
+                                                <span className="text-[9.5px] font-black text-white tabular-nums">{seg.pct.toFixed(0)}%</span>
+                                            )}
+                                        </div>
+                                    ))}
+                                </div>
+                                <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1">
+                                    {sectorMix.segs.map(seg => (
+                                        <span key={seg.name} className="inline-flex items-center gap-1.5 text-[11px] text-neutral-600 dark:text-neutral-400">
+                                            <i className="w-2 h-2 rounded-[2px] shrink-0" style={{ background: seg.color }} />
+                                            <span className="font-semibold">{seg.name}</span>
+                                            <span className="font-mono tabular-nums text-neutral-400">{seg.n}</span>
+                                        </span>
+                                    ))}
+                                </div>
+                                {sectorMix.top3Pct >= 60 && (
+                                    <p className="mt-2.5 pt-2.5 border-t border-neutral-100 dark:border-[#35332e] text-[11.5px] leading-relaxed text-[#b8762e] dark:text-[#d9a05a] break-keep">
+                                        상위 3개 업종({sectorMix.topNames.join(' · ')})이 {sectorMix.top3Pct.toFixed(0)}%를 차지합니다.
+                                        여기서 고르면 사실상 그 업황에 거는 셈입니다.
+                                    </p>
+                                )}
+                            </div>
+                        )}
+
                         {/* 결과에 거는 조작(묶기)과 목록 복사 — 조건을 고르는 상단과 분리한다.
                             묶기는 "무엇을 걸러낼지"가 아니라 "고른 결과를 어떻게 늘어놓을지"라
                             결과 바로 위가 제자리다. */}

--- a/cf-idiotquant/app/(search)/search/components/ValuationSection.tsx
+++ b/cf-idiotquant/app/(search)/search/components/ValuationSection.tsx
@@ -252,9 +252,10 @@ export const ValuationSection = ({ data, isUs, isLoggedIn = true, loginHref = "/
     const max = hi + pad;
     const pos = (p: number) => (max > min ? ((p - min) / (max - min)) * 100 : 50);
 
+    // min·max 는 pos() 안에서만 쓰인다(끝값 라벨을 걷어내며 밖으로 내보낼 이유가 없어졌다).
     return {
       rows: [...rows].sort((a, b) => b.targetPrice - a.targetPrice),
-      curPrice, min, max, pos,
+      curPrice, pos,
     };
   }, [models]);
 
@@ -297,20 +298,12 @@ export const ValuationSection = ({ data, isUs, isLoggedIn = true, loginHref = "/
               "이 점이 어느 모델인지" 를 색으로 되짚을 필요가 없다.
               모든 행이 같은 min~max 스케일을 쓰므로 세로로 곧장 비교된다. */}
           <div className="rounded-[10px] overflow-hidden border border-neutral-100 dark:border-[#35332e]">
-            {/* 눈금 — 트랙 열 위에만 올린다. 그리드 정의를 행과 똑같이 맞춰야 라벨이 실제 위치를 가리킨다. */}
+            {/* 눈금 — 트랙 열 위에만 올린다. 그리드 정의를 행과 똑같이 맞춰야 라벨이 실제 위치를 가리킨다.
+                축 양 끝값(min·max)은 찍지 않는다. 실제 목표가가 아니라 가장 바깥 점이 잘리지 않게
+                12% 여백을 붙인 눈금 경계일 뿐인데, 현재가 옆에 나란히 서면 또 하나의 가격으로 읽힌다. */}
             <div className={cn(AXIS_GRID, "px-3 sm:px-4 pt-2 pb-1")}>
               <div />
               <div className="relative h-4">
-                {(axis.curPrice <= 0 || curLabelPos > 18) && (
-                  <span className="absolute left-0 text-[10px] font-mono text-neutral-300 dark:text-neutral-600">
-                    {currency}{Math.round(axis.min).toLocaleString()}
-                  </span>
-                )}
-                {(axis.curPrice <= 0 || curLabelPos < 82) && (
-                  <span className="absolute right-0 text-[10px] font-mono text-neutral-300 dark:text-neutral-600">
-                    {currency}{Math.round(axis.max).toLocaleString()}
-                  </span>
-                )}
                 {axis.curPrice > 0 && (
                   <>
                     <span

--- a/cf-idiotquant/app/(search)/search/components/ValuationSection.tsx
+++ b/cf-idiotquant/app/(search)/search/components/ValuationSection.tsx
@@ -183,6 +183,11 @@ export const ValuationSection = ({ data, isUs, isLoggedIn = true, loginHref = "/
   const [activeTab, setActiveTab] = useState<FilterTabType>("ALL");
   const currency = isUs ? "$" : "₩";
 
+  // 실제 시세. analyze 페이지가 이미 같은 필드를 직접 쓰고 있고, 같은 data prop 으로 들어온다.
+  const marketPrice = isUs
+    ? Number(data?.usDetail?.output?.last ?? 0)
+    : Number(data?.kiPrice?.output?.stck_prpr ?? 0);
+
   const models = useMemo(() => {
     const list: { type: ValuationModelType; result: ValuationResult }[] = [];
     if (isUs) {
@@ -238,9 +243,13 @@ export const ValuationSection = ({ data, isUs, isLoggedIn = true, loginHref = "/
       })
       .filter(r => r.targetPrice > 0);
 
-    // returnPct = targetPrice / 현재가 − 1 이므로 현재가를 역산할 수 있다
+    // 모델이 계산에 쓴 기준가 — returnPct = targetPrice / 기준가 − 1 이므로 역산할 수 있다.
+    // 예전에는 이 값을 그대로 "현재가"라고 적었는데, 첫 유효 모델 하나에서 나온 값이라
+    // 화면 상단 시세와 다른 시점일 수 있다. 이제는 시세를 우선 쓰고 이 값은 대조용으로 남긴다.
     const ref = rows.find(r => r.returnPct > -100);
-    const curPrice = ref ? ref.targetPrice / (1 + ref.returnPct / 100) : 0;
+    const modelBase = ref ? ref.targetPrice / (1 + ref.returnPct / 100) : 0;
+    // 시세를 못 읽는 경우(로딩 전·응답 누락)에는 기존대로 역산값으로 떨어진다 — 눈금이 비는 것보다 낫다.
+    const curPrice = marketPrice > 0 ? marketPrice : modelBase;
 
     const prices = [...rows.map(r => r.targetPrice), curPrice].filter(p => p > 0);
     if (prices.length === 0) return null;
@@ -255,9 +264,16 @@ export const ValuationSection = ({ data, isUs, isLoggedIn = true, loginHref = "/
     // min·max 는 pos() 안에서만 쓰인다(끝값 라벨을 걷어내며 밖으로 내보낼 이유가 없어졌다).
     return {
       rows: [...rows].sort((a, b) => b.targetPrice - a.targetPrice),
-      curPrice, pos,
+      curPrice, modelBase, usedMarketPrice: marketPrice > 0, pos,
     };
-  }, [models]);
+  }, [models, marketPrice]);
+
+  // 모델 기준가와 시세가 어긋나면 괴리율이 어느 가격 기준인지 헷갈린다 → 그 사실을 적는다.
+  // 0.5% 는 호가 한두 틱 수준의 차이를 잡음으로 흘려보내기 위한 문턱이다.
+  const baseGap = axis && axis.usedMarketPrice && axis.modelBase > 0
+    ? Math.abs(axis.modelBase - axis.curPrice) / axis.curPrice
+    : 0;
+  const showBaseNote = baseGap > 0.005;
 
   const curLabelPos = axis ? axis.pos(axis.curPrice) : 0;
 
@@ -293,6 +309,13 @@ export const ValuationSection = ({ data, isUs, isLoggedIn = true, loginHref = "/
               {axis.rows.length} Models
             </span>
           </div>
+
+          {showBaseNote && (
+            <p className="mb-2.5 text-[11px] leading-relaxed text-neutral-400 dark:text-neutral-500 break-keep">
+              아래 괴리율은 모델이 계산에 쓴 {currency}{Math.round(axis.modelBase).toLocaleString()} 기준입니다
+              (현재 시세 {currency}{Math.round(axis.curPrice).toLocaleString()}).
+            </p>
+          )}
 
           {/* 모델별 트랙 — 축과 목록을 한 줄에 합친다. 점과 이름이 같은 행에 있으면
               "이 점이 어느 모델인지" 를 색으로 되짚을 필요가 없다.


### PR DESCRIPTION
아티팩트로 제안한 개선 4건을 순서대로 적용했다. 기존 커밋(끝값 라벨 제거)이 같은 브랜치에 열려 있어 그 위에 쌓았다 — 커밋 단위로 나뉘어 있으므로 따로 읽을 수 있다.

| 커밋 | 내용 |
|---|---|
| `65907bc` | analyze: 적정주가 축의 끝값 라벨 제거 (이 PR의 원래 내용) |
| `6ae2129` | screener: 업종·일 거래대금·거래정지 필터 |
| `8cb6a22` | screener: 결과 표 위 업종 분포 띠 |
| `c167903` | screener: 유동성·거래정지 배지 |
| `d016368` | analyze: 적정주가 축의 현재가를 시세에서 |

## 1. 업종·일 거래대금·거래정지 필터

워커가 `migration 0013` 으로 세 값을 쌓기 시작했는데 `applyFilters` 에는 이를 쓰는 줄이 없었다. 지금까지 제외 조건은 종목명 문자열(`name.includes("홀딩스")`)뿐이었다.

- **업종** — 지금 목록에 실제로 있는 업종만, 종목 수 많은 순으로 칩 다중 선택
- **일 거래대금** — 1·3·10·50억 하한
- **거래정지** — `temp_stop_yn === 'Y'` 제외

세 카드 모두 **해당 값이 목록에 하나라도 있을 때만** 뜬다. 조작해도 아무 일이 없는 손잡이를 두는 것보다 없는 편이 낫다.

값이 아직 없는 종목은 거래대금 필터를 **통과시킨다**. 배포 직후처럼 일부만 채워진 구간에서 "모르는 것"을 "조건 위반"으로 취급하면 목록이 통째로 비어 고장난 것처럼 보인다.

> **관리종목은 넣지 않았다.** `iscd_stat_cls_code` 의 코드표가 두 저장소 어디에도 없다. 51/58 같은 코드 의미를 추측해 매핑하면 엉뚱한 종목이 조용히 걸러진다. 코드표를 확인해 주시면 바로 추가한다.

## 2. 업종 분포 띠

저PBR·NCAV 결과는 업황이 꺾인 산업 하나로 뒤덮이기 쉬운데, 표를 위에서부터 읽으면 그게 "싼 회사가 많다"로 보인다. 목록을 늘어놓기 전에 무엇을 받았는지 먼저 보여주고, 상위 3개 업종이 60% 이상이면 어느 업황에 거는 셈인지 한 줄로 적는다.

좁은 화면에서는 띠 안에 업종명을 넣을 자리가 없다 → 이름은 항상 아래 범례가 맡고, 띠 안에는 15% 이상인 조각에만 퍼센트를 얹는다. 얇은 조각도 `minWidth 3px` 로 남겨 "있는데 안 보이는" 업종이 생기지 않게 했다.

## 3. 유동성·거래정지 배지

거래대금 3억 미만이면 실제 금액을, 거래정지면 그 사실을 종목코드 옆에 붙인다. 정상 종목에는 아무것도 붙이지 않는다 — 모든 행에 배지가 달리면 신호가 아니라 잡음이 된다.

표에 열을 새로 만들지 않았다. 데스크탑 표는 이미 7열 고정폭이라 한 열을 더하면 좁은 노트북에서 눌리고, 카드 뷰에는 그 열이 아예 없어 같은 정보가 한쪽에만 생긴다.

스크리너는 종목을 **네 가지 뷰**(비율·카드·데스크탑 표·모바일 표)로 그린다. 처음엔 표 두 곳만 고쳤다가 기본 뷰(`ratio`)에 배지가 안 붙는 것을 확인하고, 판정 기준까지 `LiquidityBadge` 모듈로 묶어 네 뷰가 같은 것을 보게 했다. 필터와 배지가 같은 `trAmtEok`·`isHalted` 를 쓰므로 "필터에는 걸리는데 배지는 없는" 어긋남이 없다.

## 4. 적정주가 축의 현재가를 시세에서

트랙의 "현재가"는 시세가 아니라 첫 유효 모델 하나의 결과를 거꾸로 푼 값이었다. 정작 진짜 시세는 같은 `data` prop 안에 있고 같은 페이지 다른 곳에서 이미 쓰고 있었다 (`kiPrice.output.stck_prpr` / `usDetail.output.last`).

시세를 우선 쓰고 역산값은 대조용으로 남긴다. 시세를 못 읽으면 기존대로 역산값으로 떨어진다. 둘이 0.5% 넘게 어긋나면 괴리율이 어느 가격 기준인지 헤더 아래 한 줄로 적는다.

## 검증

목 응답으로 데스크탑(1280)·모바일(390) 양쪽에서 확인했다.

```
[desk] 업종카드:true 거래대금카드:true 거래정지:true | 가로overflow:0px
       거래대금 3억 필터: 60 → 36
[mob]  업종카드:true 거래대금카드:true 거래정지:true | 가로overflow:0px
       거래대금 3억 필터: 60 → 36
```

배지는 네 경우를 따로 확인했다 — 저유동(0.4억)→배지, 거래정지→배지, 정상(41억)→없음, 값 없음→없음. 뷰 3종 × 폭 2종 = 6조합 모두 **가로 overflow 0px**.

업종 쏠림 경고는 고르게 퍼진 데이터에서는 안 뜨므로, 상위 3개가 80%인 데이터를 따로 만들어 분기가 도는 것까지 확인했다.

`npx tsc --noEmit` · `npm run build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P