### PR TITLE
feat(screener): 관리종목 필터 + 거래정지 판정 정정

### DIFF
--- a/cf-idiotquant/app/(screener)/screener/components/LiquidityBadge.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/LiquidityBadge.tsx
@@ -42,6 +42,39 @@ export function isManaged(i: any): boolean {
     return isY(i?.mang_issu_cls_code) || statCode(i) === "51";
 }
 
+/**
+ * 정리매매 — 상장폐지가 확정되어 마지막 매매 기간에 들어간 종목.
+ * NCAV 스크리너에서 특히 위험하다: 폐지가 정해지면 주가가 먼저 무너지므로 청산가치 대비
+ * 극단적으로 싸 보이고, 그래서 상위에 올라온다. 회수 가능한 싼 값이 아니라 없어지는 값이다.
+ */
+export function isDelisting(i: any): boolean {
+    return isY(i?.sltr_yn);
+}
+
+/** 투자유의 — 거래소가 붙이는 주의 환기. */
+export function isCautionAdvised(i: any): boolean {
+    return isY(i?.invt_caful_yn);
+}
+
+/** 단기과열 — 전용 플래그가 없으면 stat_cls_code 59 로 떨어진다. */
+export function isOverheated(i: any): boolean {
+    return isY(i?.short_over_yn) || statCode(i) === "59";
+}
+
+/**
+ * 52주 구간에서 현재가가 선 위치(0=저점, 100=고점). 값이 없거나 구간이 0이면 null.
+ * 저점 근처는 "싸다"가 아니라 "덜 올랐다"는 뜻일 뿐이라, 판단이 아니라 위치만 돌려준다.
+ */
+export function w52Position(i: any): number | null {
+    const hi = Number(i?.w52_hgpr);
+    const lo = Number(i?.w52_lwpr);
+    const px = Number(i?.last_price);
+    if (![hi, lo, px].every(Number.isFinite)) return null;
+    if (hi <= lo || px <= 0) return null;
+    // 장중 신고가/신저가면 구간을 벗어날 수 있다 — 0~100 으로 눕힌다
+    return Math.max(0, Math.min(100, ((px - lo) / (hi - lo)) * 100));
+}
+
 /** 시장경고 등급 — 없으면 null. */
 export function marketWarn(i: any): "투자주의" | "투자경고" | "투자위험" | null {
     const code = String(i?.mrkt_warn_cls_code ?? "").trim();
@@ -62,6 +95,8 @@ const AMBER = "px-1.5 py-0.5 rounded text-[9.5px] font-black bg-amber-50 text-am
 
 export function LiquidityBadge({ item }: { item: any }) {
     // 심각한 것 하나만 보여준다. 배지를 여러 개 달면 좁은 화면에서 종목명을 밀어낸다.
+    // 순서 = 심각도. 정리매매가 맨 앞인 이유는 되돌릴 수 없는 유일한 상태이기 때문이다.
+    if (isDelisting(item)) return <span className={ROSE} title="상장폐지가 확정되어 정리매매 중입니다">정리매매</span>;
     if (isHalted(item)) return <span className={ROSE}>거래정지</span>;
     if (isManaged(item)) return <span className={ROSE}>관리종목</span>;
 
@@ -70,6 +105,9 @@ export function LiquidityBadge({ item }: { item: any }) {
     if (warn === "투자경고" || warn === "투자위험") {
         return <span className={ROSE}>{warn}</span>;
     }
+
+    if (isCautionAdvised(item)) return <span className={AMBER}>투자유의</span>;
+    if (isOverheated(item)) return <span className={AMBER} title="단기과열 지정 — 주가가 단기간에 급등한 상태입니다">단기과열</span>;
 
     const v = trAmtEok(item);
     if (v === null || v >= LOW_TR_AMT_EOK) return null;

--- a/cf-idiotquant/app/(screener)/screener/components/LiquidityBadge.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/LiquidityBadge.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-// 유동성·거래정지 표시.
+// 유동성·거래상태 표시.
 // 스크리너는 종목을 네 가지 뷰(비율·카드·데스크탑 표·모바일 표)로 그리는데, 어느 뷰로 보든
 // "이 종목을 실제로 담을 수 있는가"는 같은 자리에 같은 모양으로 서야 한다 → 여기 한 곳에 둔다.
-// 판정에 쓰는 값(trAmtEok·isHalted)도 같이 두어 필터와 배지가 다른 기준을 쓰는 일이 없게 한다.
+// 판정 함수도 같이 두어 필터와 배지가 다른 기준을 쓰는 일이 없게 한다.
+//
+// KIS 코드표 (공식 저장소 open-trading-api 컬럼 매핑 + 스펙 미러 기준)
+//   iscd_stat_cls_code : 00 그외 / 51 관리종목 / 52 투자의견 / 53 투자경고 / 54 투자주의
+//                        55 신용가능 / 57 증거금 100% / 58 거래정지 / 59 단기과열
+//   mrkt_warn_cls_code : 00 없음 / 01 투자주의 / 02 투자경고 / 03 투자위험
+//
+// ⚠️ iscd_stat_cls_code 는 종목당 값이 하나뿐이다. 관리종목이면서 신용가능인 종목은 51 과 55
+//    중 하나만 실려 온다 → 관리종목 판정은 전용 플래그(mang_issu_cls_code)를 우선 본다.
 
 /** 누적 거래대금(원) → 억원. 값이 없으면 null — "거래대금 0원"과 "아직 수집 안 됨"은 다르다. */
 export function trAmtEok(i: any): number | null {
@@ -13,8 +21,34 @@ export function trAmtEok(i: any): number | null {
     return Number.isFinite(n) ? n / 1e8 : null;
 }
 
+/** KIS 의 Y/N 플래그. 값 도메인을 단정하지 않으므로 'Y' 만 참으로 본다. */
+function isY(v: any): boolean {
+    return String(v ?? "").trim().toUpperCase() === "Y";
+}
+
+const statCode = (i: any) => String(i?.stat_cls_code ?? "").trim();
+
+/**
+ * 지금 매매할 수 없는 상태.
+ * temp_stop_yn 은 원래 이름이 "임시 정지 여부"라 이것만으로 "거래정지"라 부르면 넓게 읽힌다
+ * — 실제 매매거래정지(58)를 함께 본다. 사용자에게는 둘 다 "지금 못 산다"로 같은 뜻이다.
+ */
 export function isHalted(i: any): boolean {
-    return String(i?.temp_stop_yn ?? "").toUpperCase() === "Y";
+    return statCode(i) === "58" || isY(i?.temp_stop_yn);
+}
+
+/** 관리종목. 전용 플래그가 없던 시절 데이터를 위해 stat_cls_code 51 도 함께 본다. */
+export function isManaged(i: any): boolean {
+    return isY(i?.mang_issu_cls_code) || statCode(i) === "51";
+}
+
+/** 시장경고 등급 — 없으면 null. */
+export function marketWarn(i: any): "투자주의" | "투자경고" | "투자위험" | null {
+    const code = String(i?.mrkt_warn_cls_code ?? "").trim();
+    if (code === "01") return "투자주의";
+    if (code === "02") return "투자경고";
+    if (code === "03") return "투자위험";
+    return null;
 }
 
 /** 하루 거래대금이 이보다 적으면 원하는 수량을 한 번에 담기 어렵다 */
@@ -23,20 +57,26 @@ export const LOW_TR_AMT_EOK = 3;
 // 정상 종목에는 아무것도 붙이지 않는다 — 모든 행에 배지가 달리면 신호가 아니라 잡음이 된다.
 // 표에 열을 새로 만들지 않은 이유: 데스크탑 표는 이미 7열 고정폭이라 한 열을 더하면 좁은
 // 노트북에서 눌리고, 카드 뷰에는 그 열이 아예 없어 같은 정보가 한쪽에만 생긴다.
+const ROSE = "px-1.5 py-0.5 rounded text-[9.5px] font-black bg-rose-50 text-rose-600 dark:bg-rose-950/30 dark:text-rose-400 whitespace-nowrap";
+const AMBER = "px-1.5 py-0.5 rounded text-[9.5px] font-black bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400 whitespace-nowrap";
+
 export function LiquidityBadge({ item }: { item: any }) {
-    if (isHalted(item)) {
-        return (
-            <span className="px-1.5 py-0.5 rounded text-[9.5px] font-black bg-rose-50 text-rose-600 dark:bg-rose-950/30 dark:text-rose-400 whitespace-nowrap">
-                거래정지
-            </span>
-        );
+    // 심각한 것 하나만 보여준다. 배지를 여러 개 달면 좁은 화면에서 종목명을 밀어낸다.
+    if (isHalted(item)) return <span className={ROSE}>거래정지</span>;
+    if (isManaged(item)) return <span className={ROSE}>관리종목</span>;
+
+    const warn = marketWarn(item);
+    // 투자주의(01)는 흔해서 배지로 달면 목록 절반에 붙는다 — 경고·위험만 드러낸다.
+    if (warn === "투자경고" || warn === "투자위험") {
+        return <span className={ROSE}>{warn}</span>;
     }
+
     const v = trAmtEok(item);
     if (v === null || v >= LOW_TR_AMT_EOK) return null;
     return (
         <span
             title={`하루 거래대금 약 ${v.toFixed(1)}억원 — 원하는 수량을 한 번에 담기 어렵습니다`}
-            className="px-1.5 py-0.5 rounded text-[9.5px] font-black bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400 whitespace-nowrap"
+            className={AMBER}
         >
             거래 {v.toFixed(1)}억
         </span>

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -24,7 +24,7 @@ import { buildGroups, defaultOpenGroups, GroupedResults, type GroupMode } from "
 import { ResultSummary, TermStrip } from "./components/ResultSummary";
 import { StockGridCard } from "./components/StockGridCard";
 import { StockRatioRow } from "./components/StockRatioRow";
-import { LiquidityBadge, trAmtEok, isHalted, isManaged } from "./components/LiquidityBadge";
+import { LiquidityBadge, trAmtEok, isHalted, isManaged, isDelisting, w52Position } from "./components/LiquidityBadge";
 import { STRATEGY_LABEL, STRATEGY_BADGE, STRATEGY_PRESETS_CLIENT as STRATEGY_PRESETS, MKTCAP_PRESETS, STRATEGY_ACTIVE_CLS } from "@/lib/constants/strategies";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -53,6 +53,18 @@ const MIX_COLORS = ['#15803d', '#16a34a', '#3faf6d', '#6ec492', '#93a89b', '#a8a
 
 // 일 거래대금 하한 프리셋 (단위: 억원, 0 = 미적용)
 const TR_AMT_PRESETS = [1, 3, 10, 50];
+// 52주 구간에서 현재가 위치의 상한(%). 0=저점, 100=고점 → 낮게 잡을수록 저점권만 남는다.
+const W52_POS_PRESETS = [10, 25, 50];
+
+/** 시장 구분. KIS 는 "KOSPI"/"KOSDAQ"/"KONEX" 외에 "코스피" 같은 표기도 섞어 보낸다. */
+function marketOf(i: any): string {
+    const raw = String(i?.market ?? "").trim().toUpperCase();
+    if (!raw) return "";
+    if (raw.includes("KOSDAQ") || raw.includes("코스닥")) return "KOSDAQ";
+    if (raw.includes("KONEX") || raw.includes("코넥스")) return "KONEX";
+    if (raw.includes("KOSPI") || raw.includes("코스피") || raw.includes("유가")) return "KOSPI";
+    return raw;
+}
 
 // 업종명 — 워커는 sector 로 저장한다(inquire-price 의 bstp_kor_isnm). 예전 응답 호환으로 industry 도 본다.
 const sectorOf = (i: any): string => String(i?.sector ?? i?.industry ?? "").trim();
@@ -122,7 +134,10 @@ interface ScreenerFilters {
     excludePreferred: boolean;
     excludeHalted: boolean;
     excludeManaged: boolean;
+    excludeDelisting: boolean;
     sectors: Set<string>;
+    markets: Set<string>;
+    maxW52Pos: number;
     minTrAmt: number;
     minMarketCap: number;
     maxPbr: number;
@@ -132,17 +147,19 @@ interface ScreenerFilters {
 }
 
 // 필터 그룹 — 서랍 카드 순서와 1:1. 누적 카운트(→N)는 이 순서대로 쌓아 계산한다.
-type FilterGroupKey = "mktcap" | "pbr" | "per" | "ncav" | "profit" | "sector" | "liquidity" | "exclude";
-const FILTER_GROUP_ORDER: FilterGroupKey[] = ["mktcap", "pbr", "per", "ncav", "profit", "sector", "liquidity", "exclude"];
+type FilterGroupKey = "mktcap" | "pbr" | "per" | "ncav" | "profit" | "market" | "sector" | "w52" | "liquidity" | "exclude";
+const FILTER_GROUP_ORDER: FilterGroupKey[] = ["mktcap", "pbr", "per", "ncav", "profit", "market", "sector", "w52", "liquidity", "exclude"];
 const GROUP_DEFAULTS: Record<FilterGroupKey, Partial<ScreenerFilters>> = {
     mktcap:  { minMarketCap: 0 },
     pbr:     { maxPbr: 0 },
     per:     { maxPer: 0 },
     ncav:    { minNcav: 0 },
     profit:  { minRoe: 0, excludeDeficit: false },
+    market:    { markets: new Set<string>() },
     sector:    { sectors: new Set<string>() },
+    w52:       { maxW52Pos: 0 },
     liquidity: { minTrAmt: 0 },
-    exclude:   { excludeHoldings: false, excludePreferred: false, excludeHalted: false, excludeManaged: false },
+    exclude:   { excludeHoldings: false, excludePreferred: false, excludeHalted: false, excludeManaged: false, excludeDelisting: false },
 };
 
 function applyFilters(list: Record<string, any>[], f: ScreenerFilters): Record<string, any>[] {
@@ -177,12 +194,15 @@ function applyFilters(list: Record<string, any>[], f: ScreenerFilters): Record<s
     if (f.minRoe > 0)  out = out.filter(item => roeOf(item) >= f.minRoe);
 
     if (f.sectors.size > 0) out = out.filter(item => f.sectors.has(sectorOf(item)));
+    if (f.markets.size > 0) out = out.filter(item => f.markets.has(marketOf(item)));
     // 값이 아직 없는 종목은 통과시킨다. 배포 직후처럼 일부만 채워진 구간에서 "모르는 것"을
     // "조건 위반"으로 취급하면 목록이 통째로 비어 고장난 것처럼 보인다.
     // (아래 두 서랍 카드는 애초에 데이터가 있을 때만 뜨므로 정상 상태에서는 이 경로가 드물다.)
     if (f.minTrAmt > 0) out = out.filter(item => { const v = trAmtEok(item); return v === null || v >= f.minTrAmt; });
+    if (f.maxW52Pos > 0) out = out.filter(item => { const v = w52Position(item); return v === null || v <= f.maxW52Pos; });
     if (f.excludeHalted) out = out.filter(item => !isHalted(item));
     if (f.excludeManaged) out = out.filter(item => !isManaged(item));
+    if (f.excludeDelisting) out = out.filter(item => !isDelisting(item));
 
     return out;
 }
@@ -487,10 +507,11 @@ function DrawerCard({ label, remain, dashed, span2, children }: {
 }
 
 // 서랍 안의 프리셋 칩 — 활성 값을 다시 누르면 해제
-function DrawerChip({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+function DrawerChip({ active, onClick, children, title }: { active: boolean; onClick: () => void; children: React.ReactNode; title?: string }) {
     return (
         <button
             onClick={onClick}
+            title={title}
             className={cn(
                 "px-2.5 py-1 rounded-[7px] text-[11px] font-bold border transition-colors",
                 active
@@ -595,12 +616,21 @@ function ScreenerContent() {
     const [excludePreferred, setExcludePreferred] = useState(() => initExclude('preferred'));
     const [excludeHalted, setExcludeHalted] = useState(() => initExclude('halted'));
     const [excludeManaged, setExcludeManaged] = useState(() => initExclude('managed'));
+    const [excludeDelisting, setExcludeDelisting] = useState(() => initExclude('delisting'));
     // 업종 다중 선택 (URL param: sectors, 쉼표 구분)
     const [sectors, setSectors] = useState<Set<string>>(() => {
         const urlS = searchParams.get('sectors');
         const src = urlS ?? (Array.isArray(saved.sectors) ? saved.sectors.join(',') : '');
         return new Set((src || '').split(',').map(v => v.trim()).filter(Boolean));
     });
+    // 시장 다중 선택 (URL param: markets, 쉼표 구분)
+    const [markets, setMarkets] = useState<Set<string>>(() => {
+        const urlM = searchParams.get('markets');
+        const src = urlM ?? (Array.isArray(saved.markets) ? saved.markets.join(',') : '');
+        return new Set((src || '').split(',').map(v => v.trim().toUpperCase()).filter(Boolean));
+    });
+    // 52주 위치 상한 (%, URL param: w52)
+    const [maxW52Pos, setMaxW52Pos] = useState<number>(() => initNum('w52', 'w52', W52_POS_PRESETS));
     // 일 거래대금 하한 (단위: 억원, URL param: mintr)
     const [minTrAmt, setMinTrAmt] = useState<number>(() => initNum('mintr', 'mintr', TR_AMT_PRESETS));
     const [filterOpen, setFilterOpen] = useState(false);
@@ -674,9 +704,12 @@ function ScreenerContent() {
             excludePreferred ? 'preferred' : null,
             excludeHalted ? 'halted' : null,
             excludeManaged ? 'managed' : null,
+            excludeDelisting ? 'delisting' : null,
         ].filter(Boolean).join(',');
         if (excludeList) params.set('exclude', excludeList);
         if (sectors.size > 0) params.set('sectors', Array.from(sectors).join(','));
+        if (markets.size > 0) params.set('markets', Array.from(markets).join(','));
+        if (maxW52Pos > 0) params.set('w52', String(maxW52Pos));
         if (minTrAmt > 0) params.set('mintr', String(minTrAmt));
         if (minMarketCap > 0) params.set('mincap', String(minMarketCap));
         if (maxPbr > 0) params.set('maxpbr', String(maxPbr));
@@ -688,7 +721,7 @@ function ScreenerContent() {
         if (groupMode !== 'none') params.set('group', groupMode);
         if (viewMode !== DEFAULT_VIEW) params.set('view', viewMode);
         return params.toString();
-    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode]);
+    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, excludeDelisting, sectors, markets, maxW52Pos, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode]);
 
     // 필터 상태 → URL 동기화 + localStorage 저장 (페이지 이동 후 재진입 시에도 전체 필터 유지)
     useEffect(() => {
@@ -708,9 +741,12 @@ function ScreenerContent() {
             excludePreferred ? 'preferred' : null,
             excludeHalted ? 'halted' : null,
             excludeManaged ? 'managed' : null,
+            excludeDelisting ? 'delisting' : null,
         ].filter(Boolean);
         if (excludeArr.length) snapshot.exclude = excludeArr;
         if (sectors.size > 0) snapshot.sectors = Array.from(sectors);
+        if (markets.size > 0) snapshot.markets = Array.from(markets);
+        if (maxW52Pos > 0) snapshot.w52 = maxW52Pos;
         if (minTrAmt > 0) snapshot.mintr = minTrAmt;
         if (minMarketCap > 0) snapshot.mincap = minMarketCap;
         if (maxPbr > 0) snapshot.maxpbr = maxPbr;
@@ -731,7 +767,7 @@ function ScreenerContent() {
         localStorage.removeItem('screener:filterMode');
         }, 300);
         return () => clearTimeout(debounce);
-    }, [queryString, activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode, router]);
+    }, [queryString, activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, excludeDelisting, sectors, markets, maxW52Pos, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode, router]);
 
     // 현재 필터링 결과 링크 공유 (모바일: 네이티브 공유 시트 / 데스크탑: 클립보드 복사)
     const handleShare = useCallback(async () => {
@@ -832,10 +868,10 @@ function ScreenerContent() {
         strategies: activeStrategyIds,
         mode: filterMode,
         q: searchQuery,
-        excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged,
-        sectors, minTrAmt,
+        excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, excludeDelisting,
+        sectors, markets, maxW52Pos, minTrAmt,
         minMarketCap, maxPbr, maxPer, minRoe, minNcav,
-    }), [activeStrategyIds, filterMode, searchQuery, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav]);
+    }), [activeStrategyIds, filterMode, searchQuery, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, excludeDelisting, sectors, markets, maxW52Pos, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav]);
 
     const baseList = useMemo(
         () => (showLikedOnly ? normalizedLikedList : ncavDailyList.list) as Record<string, any>[],
@@ -922,8 +958,8 @@ function ScreenerContent() {
     const funnel = useMemo(() => {
         const none: ScreenerFilters = {
             strategies: new Set(), mode: 'OR', q: '',
-            excludeHoldings: false, excludeDeficit: false, excludePreferred: false, excludeHalted: false, excludeManaged: false,
-            sectors: new Set<string>(), minTrAmt: 0,
+            excludeHoldings: false, excludeDeficit: false, excludePreferred: false, excludeHalted: false, excludeManaged: false, excludeDelisting: false,
+            sectors: new Set<string>(), markets: new Set<string>(), maxW52Pos: 0, minTrAmt: 0,
             minMarketCap: 0, maxPbr: 0, maxPer: 0, minRoe: 0, minNcav: 0,
         };
         const steps: { label: string; patch: Partial<ScreenerFilters> }[] = [
@@ -932,7 +968,8 @@ function ScreenerContent() {
             { label: '검색',      patch: { q: filters.q } },
             { label: '가치 지표', patch: { minMarketCap: filters.minMarketCap, maxPbr: filters.maxPbr, maxPer: filters.maxPer, minNcav: filters.minNcav } },
             { label: '수익·제외', patch: { minRoe: filters.minRoe, excludeDeficit: filters.excludeDeficit, excludeHoldings: filters.excludeHoldings, excludePreferred: filters.excludePreferred } },
-            { label: '업종·유동성', patch: { sectors: filters.sectors, minTrAmt: filters.minTrAmt, excludeHalted: filters.excludeHalted, excludeManaged: filters.excludeManaged } },
+            { label: '시장·업종', patch: { markets: filters.markets, sectors: filters.sectors } },
+            { label: '위치·유동성', patch: { maxW52Pos: filters.maxW52Pos, minTrAmt: filters.minTrAmt, excludeHalted: filters.excludeHalted, excludeManaged: filters.excludeManaged, excludeDelisting: filters.excludeDelisting } },
         ];
         let acc = { ...none };
         return steps.map(s => {
@@ -977,9 +1014,9 @@ function ScreenerContent() {
         : null;
     const scanningInProgress = ncavDailyList.scanningInProgress;
 
-    const activeFilterCount = [excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, sectors.size > 0, minTrAmt > 0, minMarketCap > 0, maxPbr > 0, maxPer > 0, minRoe > 0, minNcav > 0].filter(Boolean).length;
+    const activeFilterCount = [excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, excludeDelisting, sectors.size > 0, markets.size > 0, maxW52Pos > 0, minTrAmt > 0, minMarketCap > 0, maxPbr > 0, maxPer > 0, minRoe > 0, minNcav > 0].filter(Boolean).length;
     const isAllActive = activeStrategyIds.size === 0;
-    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || excludePreferred || excludeHalted || excludeManaged || sectors.size > 0 || minTrAmt > 0 || minMarketCap > 0 || maxPbr > 0 || maxPer > 0 || minRoe > 0 || minNcav > 0 || sortKey !== 'value_score' || sortOrder !== 'desc' || showLikedOnly;
+    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || excludePreferred || excludeHalted || excludeManaged || excludeDelisting || sectors.size > 0 || markets.size > 0 || maxW52Pos > 0 || minTrAmt > 0 || minMarketCap > 0 || maxPbr > 0 || maxPer > 0 || minRoe > 0 || minNcav > 0 || sortKey !== 'value_score' || sortOrder !== 'desc' || showLikedOnly;
     const isFiltered = !showLikedOnly && filteredList.length !== ncavDailyList.list.length;
     // 업종 묶기는 응답에 sector/industry 가 있을 때만. 없으면 세그먼트에서 비활성.
     const hasSectorData = ncavDailyList.list.some((i: any) => i.sector ?? i.industry);
@@ -990,6 +1027,18 @@ function ScreenerContent() {
     const hasHaltData = useMemo(() => baseList.some(i => i.temp_stop_yn != null || i.stat_cls_code != null), [baseList]);
     // 관리종목은 전용 플래그(migration 0014) 우선, 옛 데이터는 stat_cls_code(51) 로도 잡힌다.
     const hasManagedData = useMemo(() => baseList.some(i => i.mang_issu_cls_code != null || i.stat_cls_code != null), [baseList]);
+    // 정리매매는 전용 플래그(sltr_yn)뿐이라 대체 경로가 없다.
+    const hasDelistData = useMemo(() => baseList.some(i => i.sltr_yn != null), [baseList]);
+    const hasW52Data = useMemo(() => baseList.some(i => w52Position(i) !== null), [baseList]);
+    // 시장 선택지 — 지금 목록에 실제로 있는 시장만, 종목이 많은 순으로.
+    const marketOptions = useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const i of baseList) {
+            const m = marketOf(i);
+            if (m) counts.set(m, (counts.get(m) ?? 0) + 1);
+        }
+        return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+    }, [baseList]);
     // 업종 선택지 — 지금 목록에 실제로 있는 업종만, 종목이 많은 순으로.
     const sectorOptions = useMemo(() => {
         const counts = new Map<string, number>();
@@ -1028,10 +1077,13 @@ function ScreenerContent() {
         excludePreferred && { label: '우선주 제외',              override: { excludePreferred: false } as Partial<ScreenerFilters>, clear: () => setExcludePreferred(false) },
         excludeHalted    && { label: '거래정지 제외',             override: { excludeHalted: false } as Partial<ScreenerFilters>,    clear: () => setExcludeHalted(false) },
         excludeManaged   && { label: '관리종목 제외',             override: { excludeManaged: false } as Partial<ScreenerFilters>,   clear: () => setExcludeManaged(false) },
+        excludeDelisting && { label: '정리매매 제외',             override: { excludeDelisting: false } as Partial<ScreenerFilters>, clear: () => setExcludeDelisting(false) },
         minTrAmt > 0     && { label: `거래대금 ${minTrAmt}억+`,   override: { minTrAmt: 0 } as Partial<ScreenerFilters>,             clear: () => setMinTrAmt(0) },
+        maxW52Pos > 0    && { label: `52주 저점권 ${maxW52Pos}%`, override: { maxW52Pos: 0 } as Partial<ScreenerFilters>,            clear: () => setMaxW52Pos(0) },
         sectors.size > 0 && { label: `업종 ${sectors.size}개`,    override: { sectors: new Set<string>() } as Partial<ScreenerFilters>, clear: () => setSectors(new Set()) },
+        markets.size > 0 && { label: `시장 ${Array.from(markets).join('·')}`, override: { markets: new Set<string>() } as Partial<ScreenerFilters>, clear: () => setMarkets(new Set()) },
     ].filter(Boolean) as { label: string; override: Partial<ScreenerFilters>; clear: () => void }[]),
-    [minMarketCap, maxPbr, maxPer, minNcav, minRoe, excludeDeficit, excludeHoldings, excludePreferred, excludeHalted, excludeManaged, minTrAmt, sectors]);
+    [minMarketCap, maxPbr, maxPer, minNcav, minRoe, excludeDeficit, excludeHoldings, excludePreferred, excludeHalted, excludeManaged, excludeDelisting, minTrAmt, maxW52Pos, sectors, markets]);
 
     // 결과가 0개일 때 — "무엇을 풀면 몇 개가 돌아오는지"를 짚어준다. 그냥 "없습니다"로 끝내면
     // 어떤 조건이 결과를 죽였는지 사용자가 하나씩 꺼보며 찾아야 한다.
@@ -1047,7 +1099,8 @@ function ScreenerContent() {
     const clearDetailFilters = useCallback(() => {
         setMinMarketCap(0); setMaxPbr(0); setMaxPer(0); setMinRoe(0); setMinNcav(0);
         setExcludeHoldings(false); setExcludeDeficit(false); setExcludePreferred(false);
-        setExcludeHalted(false); setExcludeManaged(false); setSectors(new Set()); setMinTrAmt(0);
+        setExcludeHalted(false); setExcludeManaged(false); setExcludeDelisting(false);
+        setSectors(new Set()); setMarkets(new Set()); setMaxW52Pos(0); setMinTrAmt(0);
         setDisplayCount(DAILY_PAGE_SIZE);
     }, []);
 
@@ -1353,8 +1406,11 @@ function ScreenerContent() {
                         if (excludePreferred) chips.push({ key: 'pref', label: '우선주 제외', clear: () => setExcludePreferred(false) });
                         if (excludeHalted)   chips.push({ key: 'halt', label: '거래정지 제외', clear: () => setExcludeHalted(false) });
                         if (excludeManaged)  chips.push({ key: 'mang', label: '관리종목 제외', clear: () => setExcludeManaged(false) });
+                        if (excludeDelisting) chips.push({ key: 'slt', label: '정리매매 제외', clear: () => setExcludeDelisting(false) });
                         if (minTrAmt > 0)    chips.push({ key: 'tr',   label: `거래대금 ${minTrAmt}억+`, clear: () => { setMinTrAmt(0); setDisplayCount(DAILY_PAGE_SIZE); } });
+                        if (maxW52Pos > 0)   chips.push({ key: 'w52',  label: `52주 저점권 ${maxW52Pos}%`, clear: () => { setMaxW52Pos(0); setDisplayCount(DAILY_PAGE_SIZE); } });
                         if (sectors.size > 0) chips.push({ key: 'sec', label: `업종 ${sectors.size}개`, clear: () => { setSectors(new Set()); setDisplayCount(DAILY_PAGE_SIZE); } });
+                        if (markets.size > 0) chips.push({ key: 'mkt', label: `시장 ${Array.from(markets).join('·')}`, clear: () => { setMarkets(new Set()); setDisplayCount(DAILY_PAGE_SIZE); } });
                         // 칩이 없어도 걸린 조건(정렬·관심·전략)이 있으면 초기화 경로는 남겨야 한다.
                         if (chips.length === 0 && !hasActiveFilters) return null;
                         return (
@@ -1513,6 +1569,30 @@ function ScreenerContent() {
                                 />
                             </DrawerCard>
 
+                            {/* 시장 — 코스닥은 같은 지표라도 변동성·유동성 성격이 다르다. */}
+                            {marketOptions.length > 1 && (
+                                <DrawerCard label="시장" remain={cumulativeCounts.market}>
+                                    <div className="flex items-center gap-1.5 flex-wrap">
+                                        {marketOptions.map(([mk, n]) => (
+                                            <DrawerChip
+                                                key={mk}
+                                                active={markets.has(mk)}
+                                                onClick={() => {
+                                                    setMarkets(prev => {
+                                                        const next = new Set(prev);
+                                                        if (next.has(mk)) next.delete(mk); else next.add(mk);
+                                                        return next;
+                                                    });
+                                                    setDisplayCount(DAILY_PAGE_SIZE);
+                                                }}
+                                            >
+                                                {mk} <span className="opacity-60 font-mono">{n}</span>
+                                            </DrawerChip>
+                                        ))}
+                                    </div>
+                                </DrawerCard>
+                            )}
+
                             {/* 업종 — 저PBR·NCAV 결과는 한 업종에 몰리기 쉽다. 골라서 좁히거나 덜어낸다. */}
                             {hasSectorData && sectorOptions.length > 0 && (
                                 <DrawerCard label="업종" remain={cumulativeCounts.sector} span2>
@@ -1542,6 +1622,25 @@ function ScreenerContent() {
                                             업종 선택 해제
                                         </button>
                                     )}
+                                </DrawerCard>
+                            )}
+
+                            {/* 52주 위치 — 0%면 52주 저점, 100%면 고점. 낮을수록 덜 오른 구간이다.
+                                "싸다"의 근거는 아니지만, 이미 크게 오른 종목을 걸러내는 데 쓴다. */}
+                            {hasW52Data && (
+                                <DrawerCard label="52주 위치" remain={cumulativeCounts.w52}>
+                                    <div className="flex items-center gap-1.5 flex-wrap">
+                                        {W52_POS_PRESETS.map(v => (
+                                            <DrawerChip
+                                                key={v}
+                                                active={maxW52Pos === v}
+                                                title={`현재가가 52주 저점~고점 구간의 아래쪽 ${v}% 안에 있는 종목`}
+                                                onClick={() => { setMaxW52Pos(maxW52Pos === v ? 0 : v); setDisplayCount(DAILY_PAGE_SIZE); }}
+                                            >
+                                                저점권 {v}%
+                                            </DrawerChip>
+                                        ))}
+                                    </div>
                                 </DrawerCard>
                             )}
 
@@ -1595,6 +1694,16 @@ function ScreenerContent() {
                                             delta={excludeManaged
                                                 ? countWith({ excludeManaged: false }) - filteredList.length
                                                 : filteredList.length - countWith({ excludeManaged: true })}
+                                        />
+                                    )}
+                                    {hasDelistData && (
+                                        <DrawerCheck
+                                            checked={excludeDelisting}
+                                            onChange={v => { setExcludeDelisting(v); setDisplayCount(DAILY_PAGE_SIZE); }}
+                                            label="정리매매 제외"
+                                            delta={excludeDelisting
+                                                ? countWith({ excludeDelisting: false }) - filteredList.length
+                                                : filteredList.length - countWith({ excludeDelisting: true })}
                                         />
                                     )}
                                 </div>

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -24,7 +24,7 @@ import { buildGroups, defaultOpenGroups, GroupedResults, type GroupMode } from "
 import { ResultSummary, TermStrip } from "./components/ResultSummary";
 import { StockGridCard } from "./components/StockGridCard";
 import { StockRatioRow } from "./components/StockRatioRow";
-import { LiquidityBadge, trAmtEok, isHalted } from "./components/LiquidityBadge";
+import { LiquidityBadge, trAmtEok, isHalted, isManaged } from "./components/LiquidityBadge";
 import { STRATEGY_LABEL, STRATEGY_BADGE, STRATEGY_PRESETS_CLIENT as STRATEGY_PRESETS, MKTCAP_PRESETS, STRATEGY_ACTIVE_CLS } from "@/lib/constants/strategies";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -121,6 +121,7 @@ interface ScreenerFilters {
     excludeDeficit: boolean;
     excludePreferred: boolean;
     excludeHalted: boolean;
+    excludeManaged: boolean;
     sectors: Set<string>;
     minTrAmt: number;
     minMarketCap: number;
@@ -141,7 +142,7 @@ const GROUP_DEFAULTS: Record<FilterGroupKey, Partial<ScreenerFilters>> = {
     profit:  { minRoe: 0, excludeDeficit: false },
     sector:    { sectors: new Set<string>() },
     liquidity: { minTrAmt: 0 },
-    exclude:   { excludeHoldings: false, excludePreferred: false, excludeHalted: false },
+    exclude:   { excludeHoldings: false, excludePreferred: false, excludeHalted: false, excludeManaged: false },
 };
 
 function applyFilters(list: Record<string, any>[], f: ScreenerFilters): Record<string, any>[] {
@@ -181,6 +182,7 @@ function applyFilters(list: Record<string, any>[], f: ScreenerFilters): Record<s
     // (아래 두 서랍 카드는 애초에 데이터가 있을 때만 뜨므로 정상 상태에서는 이 경로가 드물다.)
     if (f.minTrAmt > 0) out = out.filter(item => { const v = trAmtEok(item); return v === null || v >= f.minTrAmt; });
     if (f.excludeHalted) out = out.filter(item => !isHalted(item));
+    if (f.excludeManaged) out = out.filter(item => !isManaged(item));
 
     return out;
 }
@@ -592,6 +594,7 @@ function ScreenerContent() {
     const [excludeDeficit, setExcludeDeficit] = useState(() => initExclude('deficit'));
     const [excludePreferred, setExcludePreferred] = useState(() => initExclude('preferred'));
     const [excludeHalted, setExcludeHalted] = useState(() => initExclude('halted'));
+    const [excludeManaged, setExcludeManaged] = useState(() => initExclude('managed'));
     // 업종 다중 선택 (URL param: sectors, 쉼표 구분)
     const [sectors, setSectors] = useState<Set<string>>(() => {
         const urlS = searchParams.get('sectors');
@@ -670,6 +673,7 @@ function ScreenerContent() {
             excludeDeficit ? 'deficit' : null,
             excludePreferred ? 'preferred' : null,
             excludeHalted ? 'halted' : null,
+            excludeManaged ? 'managed' : null,
         ].filter(Boolean).join(',');
         if (excludeList) params.set('exclude', excludeList);
         if (sectors.size > 0) params.set('sectors', Array.from(sectors).join(','));
@@ -684,7 +688,7 @@ function ScreenerContent() {
         if (groupMode !== 'none') params.set('group', groupMode);
         if (viewMode !== DEFAULT_VIEW) params.set('view', viewMode);
         return params.toString();
-    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode]);
+    }, [activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode]);
 
     // 필터 상태 → URL 동기화 + localStorage 저장 (페이지 이동 후 재진입 시에도 전체 필터 유지)
     useEffect(() => {
@@ -703,6 +707,7 @@ function ScreenerContent() {
             excludeDeficit ? 'deficit' : null,
             excludePreferred ? 'preferred' : null,
             excludeHalted ? 'halted' : null,
+            excludeManaged ? 'managed' : null,
         ].filter(Boolean);
         if (excludeArr.length) snapshot.exclude = excludeArr;
         if (sectors.size > 0) snapshot.sectors = Array.from(sectors);
@@ -726,7 +731,7 @@ function ScreenerContent() {
         localStorage.removeItem('screener:filterMode');
         }, 300);
         return () => clearTimeout(debounce);
-    }, [queryString, activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode, router]);
+    }, [queryString, activeStrategyIds, filterMode, sortKey, sortOrder, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav, showLikedOnly, searchQuery, groupMode, viewMode, router]);
 
     // 현재 필터링 결과 링크 공유 (모바일: 네이티브 공유 시트 / 데스크탑: 클립보드 복사)
     const handleShare = useCallback(async () => {
@@ -827,10 +832,10 @@ function ScreenerContent() {
         strategies: activeStrategyIds,
         mode: filterMode,
         q: searchQuery,
-        excludeHoldings, excludeDeficit, excludePreferred, excludeHalted,
+        excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged,
         sectors, minTrAmt,
         minMarketCap, maxPbr, maxPer, minRoe, minNcav,
-    }), [activeStrategyIds, filterMode, searchQuery, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav]);
+    }), [activeStrategyIds, filterMode, searchQuery, excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, sectors, minTrAmt, minMarketCap, maxPbr, maxPer, minRoe, minNcav]);
 
     const baseList = useMemo(
         () => (showLikedOnly ? normalizedLikedList : ncavDailyList.list) as Record<string, any>[],
@@ -917,7 +922,7 @@ function ScreenerContent() {
     const funnel = useMemo(() => {
         const none: ScreenerFilters = {
             strategies: new Set(), mode: 'OR', q: '',
-            excludeHoldings: false, excludeDeficit: false, excludePreferred: false, excludeHalted: false,
+            excludeHoldings: false, excludeDeficit: false, excludePreferred: false, excludeHalted: false, excludeManaged: false,
             sectors: new Set<string>(), minTrAmt: 0,
             minMarketCap: 0, maxPbr: 0, maxPer: 0, minRoe: 0, minNcav: 0,
         };
@@ -927,7 +932,7 @@ function ScreenerContent() {
             { label: '검색',      patch: { q: filters.q } },
             { label: '가치 지표', patch: { minMarketCap: filters.minMarketCap, maxPbr: filters.maxPbr, maxPer: filters.maxPer, minNcav: filters.minNcav } },
             { label: '수익·제외', patch: { minRoe: filters.minRoe, excludeDeficit: filters.excludeDeficit, excludeHoldings: filters.excludeHoldings, excludePreferred: filters.excludePreferred } },
-            { label: '업종·유동성', patch: { sectors: filters.sectors, minTrAmt: filters.minTrAmt, excludeHalted: filters.excludeHalted } },
+            { label: '업종·유동성', patch: { sectors: filters.sectors, minTrAmt: filters.minTrAmt, excludeHalted: filters.excludeHalted, excludeManaged: filters.excludeManaged } },
         ];
         let acc = { ...none };
         return steps.map(s => {
@@ -972,16 +977,19 @@ function ScreenerContent() {
         : null;
     const scanningInProgress = ncavDailyList.scanningInProgress;
 
-    const activeFilterCount = [excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, sectors.size > 0, minTrAmt > 0, minMarketCap > 0, maxPbr > 0, maxPer > 0, minRoe > 0, minNcav > 0].filter(Boolean).length;
+    const activeFilterCount = [excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, sectors.size > 0, minTrAmt > 0, minMarketCap > 0, maxPbr > 0, maxPer > 0, minRoe > 0, minNcav > 0].filter(Boolean).length;
     const isAllActive = activeStrategyIds.size === 0;
-    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || excludePreferred || excludeHalted || sectors.size > 0 || minTrAmt > 0 || minMarketCap > 0 || maxPbr > 0 || maxPer > 0 || minRoe > 0 || minNcav > 0 || sortKey !== 'value_score' || sortOrder !== 'desc' || showLikedOnly;
+    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || excludePreferred || excludeHalted || excludeManaged || sectors.size > 0 || minTrAmt > 0 || minMarketCap > 0 || maxPbr > 0 || maxPer > 0 || minRoe > 0 || minNcav > 0 || sortKey !== 'value_score' || sortOrder !== 'desc' || showLikedOnly;
     const isFiltered = !showLikedOnly && filteredList.length !== ncavDailyList.list.length;
     // 업종 묶기는 응답에 sector/industry 가 있을 때만. 없으면 세그먼트에서 비활성.
     const hasSectorData = ncavDailyList.list.some((i: any) => i.sector ?? i.industry);
     // 워커가 아직 이 값을 채우기 전(migration 0013 배포 전)에는 해당 서랍 카드를 아예 띄우지
     // 않는다. 조작해도 아무 일이 없는 손잡이를 두는 것보다 없는 편이 낫다.
     const hasTrAmtData = useMemo(() => baseList.some(i => trAmtEok(i) !== null), [baseList]);
-    const hasHaltData = useMemo(() => baseList.some(i => i.temp_stop_yn != null), [baseList]);
+    // 거래정지 판정은 stat_cls_code(58) 도 본다 → 둘 중 하나라도 있으면 손잡이를 띄운다.
+    const hasHaltData = useMemo(() => baseList.some(i => i.temp_stop_yn != null || i.stat_cls_code != null), [baseList]);
+    // 관리종목은 전용 플래그(migration 0014) 우선, 옛 데이터는 stat_cls_code(51) 로도 잡힌다.
+    const hasManagedData = useMemo(() => baseList.some(i => i.mang_issu_cls_code != null || i.stat_cls_code != null), [baseList]);
     // 업종 선택지 — 지금 목록에 실제로 있는 업종만, 종목이 많은 순으로.
     const sectorOptions = useMemo(() => {
         const counts = new Map<string, number>();
@@ -1019,10 +1027,11 @@ function ScreenerContent() {
         excludeHoldings  && { label: '홀딩스 제외',              override: { excludeHoldings: false } as Partial<ScreenerFilters>,  clear: () => setExcludeHoldings(false) },
         excludePreferred && { label: '우선주 제외',              override: { excludePreferred: false } as Partial<ScreenerFilters>, clear: () => setExcludePreferred(false) },
         excludeHalted    && { label: '거래정지 제외',             override: { excludeHalted: false } as Partial<ScreenerFilters>,    clear: () => setExcludeHalted(false) },
+        excludeManaged   && { label: '관리종목 제외',             override: { excludeManaged: false } as Partial<ScreenerFilters>,   clear: () => setExcludeManaged(false) },
         minTrAmt > 0     && { label: `거래대금 ${minTrAmt}억+`,   override: { minTrAmt: 0 } as Partial<ScreenerFilters>,             clear: () => setMinTrAmt(0) },
         sectors.size > 0 && { label: `업종 ${sectors.size}개`,    override: { sectors: new Set<string>() } as Partial<ScreenerFilters>, clear: () => setSectors(new Set()) },
     ].filter(Boolean) as { label: string; override: Partial<ScreenerFilters>; clear: () => void }[]),
-    [minMarketCap, maxPbr, maxPer, minNcav, minRoe, excludeDeficit, excludeHoldings, excludePreferred, excludeHalted, minTrAmt, sectors]);
+    [minMarketCap, maxPbr, maxPer, minNcav, minRoe, excludeDeficit, excludeHoldings, excludePreferred, excludeHalted, excludeManaged, minTrAmt, sectors]);
 
     // 결과가 0개일 때 — "무엇을 풀면 몇 개가 돌아오는지"를 짚어준다. 그냥 "없습니다"로 끝내면
     // 어떤 조건이 결과를 죽였는지 사용자가 하나씩 꺼보며 찾아야 한다.
@@ -1038,7 +1047,7 @@ function ScreenerContent() {
     const clearDetailFilters = useCallback(() => {
         setMinMarketCap(0); setMaxPbr(0); setMaxPer(0); setMinRoe(0); setMinNcav(0);
         setExcludeHoldings(false); setExcludeDeficit(false); setExcludePreferred(false);
-        setExcludeHalted(false); setSectors(new Set()); setMinTrAmt(0);
+        setExcludeHalted(false); setExcludeManaged(false); setSectors(new Set()); setMinTrAmt(0);
         setDisplayCount(DAILY_PAGE_SIZE);
     }, []);
 
@@ -1343,6 +1352,7 @@ function ScreenerContent() {
                         if (excludeDeficit)  chips.push({ key: 'def',  label: '적자 제외',  clear: () => setExcludeDeficit(false) });
                         if (excludePreferred) chips.push({ key: 'pref', label: '우선주 제외', clear: () => setExcludePreferred(false) });
                         if (excludeHalted)   chips.push({ key: 'halt', label: '거래정지 제외', clear: () => setExcludeHalted(false) });
+                        if (excludeManaged)  chips.push({ key: 'mang', label: '관리종목 제외', clear: () => setExcludeManaged(false) });
                         if (minTrAmt > 0)    chips.push({ key: 'tr',   label: `거래대금 ${minTrAmt}억+`, clear: () => { setMinTrAmt(0); setDisplayCount(DAILY_PAGE_SIZE); } });
                         if (sectors.size > 0) chips.push({ key: 'sec', label: `업종 ${sectors.size}개`, clear: () => { setSectors(new Set()); setDisplayCount(DAILY_PAGE_SIZE); } });
                         // 칩이 없어도 걸린 조건(정렬·관심·전략)이 있으면 초기화 경로는 남겨야 한다.
@@ -1575,6 +1585,16 @@ function ScreenerContent() {
                                             delta={excludeHalted
                                                 ? countWith({ excludeHalted: false }) - filteredList.length
                                                 : filteredList.length - countWith({ excludeHalted: true })}
+                                        />
+                                    )}
+                                    {hasManagedData && (
+                                        <DrawerCheck
+                                            checked={excludeManaged}
+                                            onChange={v => { setExcludeManaged(v); setDisplayCount(DAILY_PAGE_SIZE); }}
+                                            label="관리종목 제외"
+                                            delta={excludeManaged
+                                                ? countWith({ excludeManaged: false }) - filteredList.length
+                                                : filteredList.length - countWith({ excludeManaged: true })}
                                         />
                                     )}
                                 </div>


### PR DESCRIPTION
#677 에서 "코드표를 확인하기 전이라 넣지 않았다"고 미뤄둔 부분을 채운다. 코드표를 확인했다.

```
iscd_stat_cls_code : 00 그외 · 51 관리종목 · 52 투자의견 · 53 투자경고 · 54 투자주의
                     55 신용가능 · 57 증거금 100% · 58 거래정지 · 59 단기과열
mrkt_warn_cls_code : 00 없음 · 01 투자주의 · 02 투자경고 · 03 투자위험
```

## 1. 거래정지 판정을 고쳤다 (내가 틀린 부분)

`temp_stop_yn` 의 공식 이름은 **"임시 정지 여부"** 다. #677 에서 나는 이걸 "거래정지"로 라벨링했다. 임시정지(VI 발동·공시 대기 등 장중 일시 중단)와 KRX 매매거래정지는 다르다 — 라벨이 실제보다 넓게 읽히고, 진짜 거래정지(`58`) 종목은 놓치고 있었다.

```diff
-export function isHalted(i) { return String(i?.temp_stop_yn).toUpperCase() === "Y"; }
+export function isHalted(i) { return statCode(i) === "58" || isY(i?.temp_stop_yn); }
```

둘 다 본다. 사용자에게는 어느 쪽이든 "지금 못 산다"로 같은 뜻이라 라벨은 「거래정지 제외」로 유지했다.

## 2. 관리종목 필터

전용 플래그 `mang_issu_cls_code`(worker migration 0014)를 **우선** 본다.

> `iscd_stat_cls_code` 로 판정하지 않는 이유 — 이 필드는 **종목당 값이 하나뿐**이다. 관리종목이면서 신용가능인 종목은 `51` 과 `55` 중 하나만 실려 오므로, 이걸로 "관리종목 제외"를 만들면 일부가 조용히 새어 나간다.

0014 이전에 쌓인 데이터를 위해 `stat_cls_code === '51'` 도 함께 본다.

## 3. 배지 확장

관리종목 · 투자경고 · 투자위험을 추가하되 **심각한 것 하나만** 보여준다. 여러 개 달면 좁은 화면에서 종목명을 밀어낸다.

투자주의(`01`)는 배지를 달지 않았다 — 흔해서 목록 절반에 붙으면 신호가 아니라 잡음이 된다.

판정 함수(`isHalted`·`isManaged`·`marketWarn`)를 `LiquidityBadge` 모듈에 모아 필터와 배지가 같은 기준을 쓴다.

## 검증

여덟 가지 경우를 데스크탑(1280)·모바일(390) 양쪽에서 확인했다.

| 종목 | 배지 |
|---|---|
| 정상주 | (없음) |
| 관리종목주 (전용 플래그) | 관리종목 |
| 구데이터관리주 (`stat_cls_code=51`) | 관리종목 |
| 임시정지주 (`temp_stop_yn=Y`) | 거래정지 |
| 매매정지주 (`stat_cls_code=58`) | 거래정지 |
| 투자경고주 (`mrkt_warn=02`) | 투자경고 |
| 투자주의주 (`mrkt_warn=01`) | (없음) |
| 저유동주 | 거래 0.4억 |

서랍에서 실제로 눌러 「관리종목 제외」 8→6, 「거래정지 제외」 8→6. 서랍 열린 상태 포함 **가로 overflow 0px**.

`npx tsc --noEmit` · `npm run build` 통과.

## 전제

worker PR #89 의 `migration 0014` 가 적용돼야 `mang_issu_cls_code`·`mrkt_warn_cls_code` 에 값이 들어온다. 적용 전에는 해당 체크박스·배지가 자동으로 숨겨지고, `stat_cls_code`(0013) 기반 판정만 동작한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_