### PR TITLE
feat: 관심 종목 목록에 종목정보 표시

### DIFF
--- a/cf-idiotquant/app/(profile)/profile/page.tsx
+++ b/cf-idiotquant/app/(profile)/profile/page.tsx
@@ -14,6 +14,9 @@ import { cn } from "@/lib/utils";
 import { CopyStockButtons, type CopyStock } from "@/components/copyStockButtons";
 import { computeValueScore, type ValueTone } from "@/lib/utils/valueScore";
 import PortfolioLegoTower from "@/components/profile/portfolioLegoTower";
+// 위험 배지는 스크리너와 같은 기준·같은 모양이어야 한다 — 같은 종목이 두 화면에서
+// 다르게 보이면 어느 쪽을 믿어야 할지 알 수 없다. 그래서 판정까지 한 모듈에서 가져온다.
+import { LiquidityBadge, w52Position } from "@/app/(screener)/screener/components/LiquidityBadge";
 
 const STRATEGY_BADGE: Record<string, string> = {
     ncav:           "bg-emerald-100 text-emerald-700 dark:bg-emerald-950/50 dark:text-emerald-400",
@@ -331,9 +334,12 @@ export default function ProfilePage() {
                                                     US
                                                 </span>
                                             )}
+                                            {/* 담아두고 잊은 사이 상태가 바뀐 종목을 여기서 알린다.
+                                                정상 종목에는 아무것도 붙지 않는다. */}
+                                            <LiquidityBadge item={item} />
                                         </div>
-                                        {/* 지표 요약 */}
-                                        <div className="flex items-center gap-2.5 mt-0.5">
+                                        {/* 지표 요약 — 항목이 늘어 좁은 화면에서는 줄바꿈시킨다 */}
+                                        <div className="flex items-center gap-x-2.5 gap-y-0.5 flex-wrap mt-0.5">
                                             {item.ncav_ratio != null && item.ncav_ratio > 0 && (
                                                 <span className={cn(
                                                     "text-[10px] font-mono font-bold",
@@ -347,6 +353,23 @@ export default function ProfilePage() {
                                             )}
                                             {item.per != null && item.per > 0 && (
                                                 <span className="text-[10px] text-neutral-400 font-mono">PER {item.per.toFixed(1)}</span>
+                                            )}
+                                            {/* 52주 구간에서 현재가가 선 위치. 0=저점, 100=고점.
+                                                "싸다"의 근거는 아니지만, 담아둔 뒤 얼마나 움직였는지가 한눈에 보인다. */}
+                                            {(() => {
+                                                const pos = w52Position(item);
+                                                if (pos === null) return null;
+                                                return (
+                                                    <span
+                                                        className="text-[10px] text-neutral-400 font-mono"
+                                                        title={`52주 저점~고점 구간에서 ${pos.toFixed(0)}% 지점 (0=저점, 100=고점)`}
+                                                    >
+                                                        52주 {pos.toFixed(0)}%
+                                                    </span>
+                                                );
+                                            })()}
+                                            {item.sector && (
+                                                <span className="text-[10px] text-neutral-400">{item.sector}</span>
                                             )}
                                         </div>
                                         {item.strategies.length > 0 && (

--- a/cf-idiotquant/app/(profile)/profile/page.tsx
+++ b/cf-idiotquant/app/(profile)/profile/page.tsx
@@ -13,6 +13,7 @@ import {
 import { cn } from "@/lib/utils";
 import { CopyStockButtons, type CopyStock } from "@/components/copyStockButtons";
 import { computeValueScore, type ValueTone } from "@/lib/utils/valueScore";
+import { computeSolidity } from "@/lib/utils/portfolioSolidity";
 import PortfolioLegoTower from "@/components/profile/portfolioLegoTower";
 // 위험 배지는 스크리너와 같은 기준·같은 모양이어야 한다 — 같은 종목이 두 화면에서
 // 다르게 보이면 어느 쪽을 믿어야 할지 알 수 없다. 그래서 판정까지 한 모듈에서 가져온다.
@@ -73,10 +74,11 @@ export default function ProfilePage() {
         roe: Number(item.bps) > 0 ? (Number(item.eps) / Number(item.bps)) * 100 : null,
     }));
 
-    // 포트폴리오 탄탄함 — 관심 종목의 저평가 점수 평균 + 등급 분포
+    // 포트폴리오 탄탄함 — 저평가 점수를 거래상태·업종 쏠림으로 깎은 값 (computeSolidity 주석 참고)
     const scored = likedList.map(item => computeValueScore(item));
-    const solidity = scored.length ? Math.round(scored.reduce((a, v) => a + v.score, 0) / scored.length) : 0;
-    const solidityLabel = solidity >= 70 ? "매우 탄탄" : solidity >= 50 ? "탄탄" : solidity >= 35 ? "보통" : "보강 필요";
+    const solid = computeSolidity(likedList);
+    const solidity = solid.score;
+    const solidityLabel = solid.label;
     const toneCounts = scored.reduce((acc, v) => { acc[v.tone] = (acc[v.tone] ?? 0) + 1; return acc; }, {} as Record<string, number>);
 
     const isMasterUser = session?.user?.name === process.env.NEXT_PUBLIC_MASTER;
@@ -267,6 +269,34 @@ export default function ProfilePage() {
                                 </div>
                             </div>
                         </div>
+
+                        {/* 왜 깎였는지 — 근거 없이 낮은 숫자만 보여주면 예전보다 못하다.
+                            깎일 이유가 없으면 이 줄 자체가 뜨지 않는다. */}
+                        {solidity < solid.base && (
+                            <div className="px-5 -mt-1 pb-3 flex items-center gap-1.5 flex-wrap">
+                                <span className="text-[10px] text-neutral-400">
+                                    저평가 <span className="font-mono font-bold">{solid.base}</span>
+                                    <span className="mx-1">→</span>
+                                    탄탄함 <span className="font-mono font-bold">{solidity}</span>
+                                </span>
+                                {solid.riskCount > 0 && (
+                                    <span
+                                        className="text-[9.5px] font-black px-1.5 py-0.5 rounded bg-rose-50 text-rose-600 dark:bg-rose-950/30 dark:text-rose-400"
+                                        title="정리매매·거래정지·관리종목·시장경고·저유동 종목은 지금 팔기 어려워 탄탄함에 온전히 기여하지 못합니다"
+                                    >
+                                        거래 위험 {solid.riskCount}종목
+                                    </span>
+                                )}
+                                {solid.concentrationPenalty > 0 && solid.topSector && (
+                                    <span
+                                        className="text-[9.5px] font-black px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400"
+                                        title="한 업종에 몰리면 개별 종목이 좋아도 함께 무너집니다"
+                                    >
+                                        {solid.topSector.name} {Math.round(solid.topSector.ratio * 100)}% 쏠림
+                                    </span>
+                                )}
+                            </div>
+                        )}
 
                         {/* 등급 분포 */}
                         <div className="px-5 pb-4 flex flex-wrap gap-1.5">

--- a/cf-idiotquant/app/(screener)/screener/components/LiquidityBadge.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/LiquidityBadge.tsx
@@ -1,91 +1,21 @@
 "use client";
 
-// 유동성·거래상태 표시.
+// 유동성·거래상태 배지.
 // 스크리너는 종목을 네 가지 뷰(비율·카드·데스크탑 표·모바일 표)로 그리는데, 어느 뷰로 보든
 // "이 종목을 실제로 담을 수 있는가"는 같은 자리에 같은 모양으로 서야 한다 → 여기 한 곳에 둔다.
-// 판정 함수도 같이 두어 필터와 배지가 다른 기준을 쓰는 일이 없게 한다.
 //
-// KIS 코드표 (공식 저장소 open-trading-api 컬럼 매핑 + 스펙 미러 기준)
-//   iscd_stat_cls_code : 00 그외 / 51 관리종목 / 52 투자의견 / 53 투자경고 / 54 투자주의
-//                        55 신용가능 / 57 증거금 100% / 58 거래정지 / 59 단기과열
-//   mrkt_warn_cls_code : 00 없음 / 01 투자주의 / 02 투자경고 / 03 투자위험
-//
-// ⚠️ iscd_stat_cls_code 는 종목당 값이 하나뿐이다. 관리종목이면서 신용가능인 종목은 51 과 55
-//    중 하나만 실려 온다 → 관리종목 판정은 전용 플래그(mang_issu_cls_code)를 우선 본다.
+// 판정 함수 자체는 lib/utils/stockRisk 에 있다 — 프로필 관심 목록과 탄탄함 지수도 같은
+// 기준을 쓰기 때문이다. 기존 사용처가 여기서 가져다 쓰고 있으므로 그대로 재수출한다.
 
-/** 누적 거래대금(원) → 억원. 값이 없으면 null — "거래대금 0원"과 "아직 수집 안 됨"은 다르다. */
-export function trAmtEok(i: any): number | null {
-    const v = i?.acml_tr_pbmn;
-    if (v === null || v === undefined || v === "") return null;
-    const n = Number(v);
-    return Number.isFinite(n) ? n / 1e8 : null;
-}
+import {
+    trAmtEok, isHalted, isManaged, isDelisting,
+    isCautionAdvised, isOverheated, marketWarn, w52Position, LOW_TR_AMT_EOK,
+} from "@/lib/utils/stockRisk";
 
-/** KIS 의 Y/N 플래그. 값 도메인을 단정하지 않으므로 'Y' 만 참으로 본다. */
-function isY(v: any): boolean {
-    return String(v ?? "").trim().toUpperCase() === "Y";
-}
-
-const statCode = (i: any) => String(i?.stat_cls_code ?? "").trim();
-
-/**
- * 지금 매매할 수 없는 상태.
- * temp_stop_yn 은 원래 이름이 "임시 정지 여부"라 이것만으로 "거래정지"라 부르면 넓게 읽힌다
- * — 실제 매매거래정지(58)를 함께 본다. 사용자에게는 둘 다 "지금 못 산다"로 같은 뜻이다.
- */
-export function isHalted(i: any): boolean {
-    return statCode(i) === "58" || isY(i?.temp_stop_yn);
-}
-
-/** 관리종목. 전용 플래그가 없던 시절 데이터를 위해 stat_cls_code 51 도 함께 본다. */
-export function isManaged(i: any): boolean {
-    return isY(i?.mang_issu_cls_code) || statCode(i) === "51";
-}
-
-/**
- * 정리매매 — 상장폐지가 확정되어 마지막 매매 기간에 들어간 종목.
- * NCAV 스크리너에서 특히 위험하다: 폐지가 정해지면 주가가 먼저 무너지므로 청산가치 대비
- * 극단적으로 싸 보이고, 그래서 상위에 올라온다. 회수 가능한 싼 값이 아니라 없어지는 값이다.
- */
-export function isDelisting(i: any): boolean {
-    return isY(i?.sltr_yn);
-}
-
-/** 투자유의 — 거래소가 붙이는 주의 환기. */
-export function isCautionAdvised(i: any): boolean {
-    return isY(i?.invt_caful_yn);
-}
-
-/** 단기과열 — 전용 플래그가 없으면 stat_cls_code 59 로 떨어진다. */
-export function isOverheated(i: any): boolean {
-    return isY(i?.short_over_yn) || statCode(i) === "59";
-}
-
-/**
- * 52주 구간에서 현재가가 선 위치(0=저점, 100=고점). 값이 없거나 구간이 0이면 null.
- * 저점 근처는 "싸다"가 아니라 "덜 올랐다"는 뜻일 뿐이라, 판단이 아니라 위치만 돌려준다.
- */
-export function w52Position(i: any): number | null {
-    const hi = Number(i?.w52_hgpr);
-    const lo = Number(i?.w52_lwpr);
-    const px = Number(i?.last_price);
-    if (![hi, lo, px].every(Number.isFinite)) return null;
-    if (hi <= lo || px <= 0) return null;
-    // 장중 신고가/신저가면 구간을 벗어날 수 있다 — 0~100 으로 눕힌다
-    return Math.max(0, Math.min(100, ((px - lo) / (hi - lo)) * 100));
-}
-
-/** 시장경고 등급 — 없으면 null. */
-export function marketWarn(i: any): "투자주의" | "투자경고" | "투자위험" | null {
-    const code = String(i?.mrkt_warn_cls_code ?? "").trim();
-    if (code === "01") return "투자주의";
-    if (code === "02") return "투자경고";
-    if (code === "03") return "투자위험";
-    return null;
-}
-
-/** 하루 거래대금이 이보다 적으면 원하는 수량을 한 번에 담기 어렵다 */
-export const LOW_TR_AMT_EOK = 3;
+export {
+    trAmtEok, isHalted, isManaged, isDelisting,
+    isCautionAdvised, isOverheated, marketWarn, w52Position, LOW_TR_AMT_EOK,
+};
 
 // 정상 종목에는 아무것도 붙이지 않는다 — 모든 행에 배지가 달리면 신호가 아니라 잡음이 된다.
 // 표에 열을 새로 만들지 않은 이유: 데스크탑 표는 이미 7열 고정폭이라 한 열을 더하면 좁은

--- a/cf-idiotquant/lib/features/stockLikes/stockLikesSlice.tsx
+++ b/cf-idiotquant/lib/features/stockLikes/stockLikesSlice.tsx
@@ -19,6 +19,21 @@ export interface LikedStockItem {
     current_assets: number | null;
     total_liabilities: number | null;
     net_income: number | null;
+    // 아래는 stock_data_daily LEFT JOIN 결과 — 아직 스캔되지 않은 종목은 전부 null 이다.
+    // 워커 배포 전에는 필드 자체가 없으므로 옵셔널로 둔다.
+    sector?: string | null;
+    market?: string | null;
+    acml_tr_pbmn?: number | null;
+    w52_hgpr?: number | null;
+    w52_lwpr?: number | null;
+    // 위험 플래그는 KIS 원문 문자열을 그대로 담는다 (해석은 LiquidityBadge 에서)
+    stat_cls_code?: string | null;
+    temp_stop_yn?: string | null;
+    mang_issu_cls_code?: string | null;
+    sltr_yn?: string | null;
+    invt_caful_yn?: string | null;
+    short_over_yn?: string | null;
+    mrkt_warn_cls_code?: string | null;
 }
 
 interface StockLikesState {

--- a/cf-idiotquant/lib/utils/portfolioSolidity.ts
+++ b/cf-idiotquant/lib/utils/portfolioSolidity.ts
@@ -1,0 +1,94 @@
+// 포트폴리오 탄탄함 지수.
+//
+// computeValueScore 는 "얼마나 싼가"(저평가)를 잰다. 탄탄함은 다른 질문이다 —
+// 정리매매 종목만 담은 목록은 청산가치 대비 만점에 가깝게 싸지만 전혀 탄탄하지 않다.
+// 폐지가 확정되면 주가가 먼저 무너져 오히려 저평가 점수가 올라가기 때문이다.
+//
+// 그래서 저평가 점수를 그대로 쓰지 않고, 실제로 회수할 수 있는지를 두 가지로 깎는다.
+//   1) 종목별 거래상태 — 못 파는 종목은 장부상 가치가 있어도 탄탄함에 기여하지 못한다
+//   2) 업종 쏠림     — 개별 종목이 아무리 좋아도 한 업종에 몰리면 같이 무너진다
+//
+// computeValueScore 자체는 건드리지 않는다. 카드 게임의 전투 스탯·카드 등급·업적이
+// 모두 그 값에 걸려 있어서, 여기서 바꾸면 게임 밸런스가 통째로 흔들린다.
+
+import { computeValueScore } from "./valueScore";
+import {
+    isDelisting, isHalted, isManaged, marketWarn,
+    isCautionAdvised, isOverheated, trAmtEok, LOW_TR_AMT_EOK,
+} from "./stockRisk";
+
+export interface SolidityBreakdown {
+    score: number;              // 0~100 — 화면에 크게 찍히는 값
+    label: string;
+    /** 위험 반영 전 평균 저평가 점수 — 얼마나 깎였는지 보여주기 위해 남긴다 */
+    base: number;
+    /** 감점된 종목 수 */
+    riskCount: number;
+    /** 업종 쏠림 감점 (0이면 없음) */
+    concentrationPenalty: number;
+    /** 가장 비중이 큰 업종. 업종을 아는 종목이 4개 미만이면 null */
+    topSector: { name: string; ratio: number } | null;
+}
+
+/**
+ * 종목별 회수 가능성 계수 (0~1).
+ * 배지와 같은 우선순위로 가장 심한 것 하나만 적용한다 — 겹쳐 곱하면 한 종목이
+ * 지수를 통째로 끌어내린다.
+ */
+export function riskFactor(item: any): number {
+    // 정리매매·거래정지: 지금 팔 수 없다. 장부상 가치는 탄탄함이 아니다.
+    if (isDelisting(item) || isHalted(item)) return 0.3;
+
+    const warn = marketWarn(item);
+    if (isManaged(item) || warn === "투자위험") return 0.5;
+    if (warn === "투자경고") return 0.7;
+    if (isCautionAdvised(item) || isOverheated(item)) return 0.85;
+
+    // 유동성 — 지표가 좋아도 원하는 수량을 담거나 빼지 못하면 탄탄하다고 하기 어렵다.
+    // 값이 없으면(아직 미수집) 깎지 않는다. "모르는 것"은 "나쁜 것"이 아니다.
+    const v = trAmtEok(item);
+    if (v !== null && v < LOW_TR_AMT_EOK) return 0.9;
+
+    return 1;
+}
+
+function labelOf(score: number): string {
+    if (score >= 70) return "매우 탄탄";
+    if (score >= 50) return "탄탄";
+    if (score >= 35) return "보통";
+    return "보강 필요";
+}
+
+/** 업종 쏠림을 판단하려면 표본이 있어야 한다. 2~3종목은 몰린 게 아니라 그냥 적은 것이다. */
+const MIN_FOR_CONCENTRATION = 4;
+
+export function computeSolidity(items: any[]): SolidityBreakdown {
+    if (!items?.length) {
+        return { score: 0, label: labelOf(0), base: 0, riskCount: 0, concentrationPenalty: 0, topSector: null };
+    }
+
+    const factors = items.map(riskFactor);
+    const scores = items.map(i => computeValueScore(i).score);
+
+    const base = Math.round(scores.reduce((a, s) => a + s, 0) / items.length);
+    const adjusted = scores.reduce((a, s, idx) => a + s * factors[idx], 0) / items.length;
+    const riskCount = factors.filter(f => f < 1).length;
+
+    // 업종 쏠림 — 업종을 아는 종목들 안에서만 따진다
+    const sectors = items.map(i => String(i?.sector ?? "").trim()).filter(Boolean);
+    let topSector: SolidityBreakdown["topSector"] = null;
+    let concentrationPenalty = 0;
+
+    if (sectors.length >= MIN_FOR_CONCENTRATION) {
+        const counts = new Map<string, number>();
+        for (const s of sectors) counts.set(s, (counts.get(s) ?? 0) + 1);
+        const [name, n] = [...counts.entries()].sort((a, b) => b[1] - a[1])[0];
+        const ratio = n / sectors.length;
+        topSector = { name, ratio };
+        // 절반까지는 자연스럽다. 그 위로만 깎되 전량 한 업종이어도 20점까지만.
+        if (ratio > 0.5) concentrationPenalty = Math.round((ratio - 0.5) * 40);
+    }
+
+    const score = Math.max(0, Math.min(100, Math.round(adjusted) - concentrationPenalty));
+    return { score, label: labelOf(score), base, riskCount, concentrationPenalty, topSector };
+}

--- a/cf-idiotquant/lib/utils/stockRisk.ts
+++ b/cf-idiotquant/lib/utils/stockRisk.ts
@@ -1,0 +1,87 @@
+// 종목 거래상태·위험 판정 (순수 함수).
+//
+// 화면 컴포넌트가 아니라 여기 있는 이유: 스크리너 배지, 프로필 관심 목록, 포트폴리오
+// 탄탄함 지수가 모두 같은 기준을 써야 한다. 한 종목이 어떤 화면에서는 관리종목이고
+// 다른 화면에서는 아니면, 어느 쪽을 믿어야 할지 알 수 없다.
+//
+// KIS 코드표 (공식 저장소 open-trading-api 컬럼 매핑 + 스펙 미러 기준)
+//   iscd_stat_cls_code : 00 그외 / 51 관리종목 / 52 투자의견 / 53 투자경고 / 54 투자주의
+//                        55 신용가능 / 57 증거금 100% / 58 거래정지 / 59 단기과열
+//   mrkt_warn_cls_code : 00 없음 / 01 투자주의 / 02 투자경고 / 03 투자위험
+//
+// ⚠️ iscd_stat_cls_code 는 종목당 값이 하나뿐이다. 관리종목이면서 신용가능인 종목은 51 과 55
+//    중 하나만 실려 온다 → 관리종목 판정은 전용 플래그(mang_issu_cls_code)를 우선 본다.
+
+/** 누적 거래대금(원) → 억원. 값이 없으면 null — "거래대금 0원"과 "아직 수집 안 됨"은 다르다. */
+export function trAmtEok(i: any): number | null {
+    const v = i?.acml_tr_pbmn;
+    if (v === null || v === undefined || v === "") return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n / 1e8 : null;
+}
+
+/** KIS 의 Y/N 플래그. 값 도메인을 단정하지 않으므로 'Y' 만 참으로 본다. */
+function isY(v: any): boolean {
+    return String(v ?? "").trim().toUpperCase() === "Y";
+}
+
+const statCode = (i: any) => String(i?.stat_cls_code ?? "").trim();
+
+/**
+ * 지금 매매할 수 없는 상태.
+ * temp_stop_yn 은 원래 이름이 "임시 정지 여부"라 이것만으로 "거래정지"라 부르면 넓게 읽힌다
+ * — 실제 매매거래정지(58)를 함께 본다. 사용자에게는 둘 다 "지금 못 산다"로 같은 뜻이다.
+ */
+export function isHalted(i: any): boolean {
+    return statCode(i) === "58" || isY(i?.temp_stop_yn);
+}
+
+/** 관리종목. 전용 플래그가 없던 시절 데이터를 위해 stat_cls_code 51 도 함께 본다. */
+export function isManaged(i: any): boolean {
+    return isY(i?.mang_issu_cls_code) || statCode(i) === "51";
+}
+
+/**
+ * 정리매매 — 상장폐지가 확정되어 마지막 매매 기간에 들어간 종목.
+ * NCAV 스크리너에서 특히 위험하다: 폐지가 정해지면 주가가 먼저 무너지므로 청산가치 대비
+ * 극단적으로 싸 보이고, 그래서 상위에 올라온다. 회수 가능한 싼 값이 아니라 없어지는 값이다.
+ */
+export function isDelisting(i: any): boolean {
+    return isY(i?.sltr_yn);
+}
+
+/** 투자유의 — 거래소가 붙이는 주의 환기. */
+export function isCautionAdvised(i: any): boolean {
+    return isY(i?.invt_caful_yn);
+}
+
+/** 단기과열 — 전용 플래그가 없으면 stat_cls_code 59 로 떨어진다. */
+export function isOverheated(i: any): boolean {
+    return isY(i?.short_over_yn) || statCode(i) === "59";
+}
+
+/** 시장경고 등급 — 없으면 null. */
+export function marketWarn(i: any): "투자주의" | "투자경고" | "투자위험" | null {
+    const code = String(i?.mrkt_warn_cls_code ?? "").trim();
+    if (code === "01") return "투자주의";
+    if (code === "02") return "투자경고";
+    if (code === "03") return "투자위험";
+    return null;
+}
+
+/**
+ * 52주 구간에서 현재가가 선 위치(0=저점, 100=고점). 값이 없거나 구간이 0이면 null.
+ * 저점 근처는 "싸다"가 아니라 "덜 올랐다"는 뜻일 뿐이라, 판단이 아니라 위치만 돌려준다.
+ */
+export function w52Position(i: any): number | null {
+    const hi = Number(i?.w52_hgpr);
+    const lo = Number(i?.w52_lwpr);
+    const px = Number(i?.last_price);
+    if (![hi, lo, px].every(Number.isFinite)) return null;
+    if (hi <= lo || px <= 0) return null;
+    // 장중 신고가/신저가면 구간을 벗어날 수 있다 — 0~100 으로 눕힌다
+    return Math.max(0, Math.min(100, ((px - lo) / (hi - lo)) * 100));
+}
+
+/** 하루 거래대금이 이보다 적으면 원하는 수량을 한 번에 담기 어렵다 */
+export const LOW_TR_AMT_EOK = 3;


### PR DESCRIPTION
## 왜

프로필의 관심 목록은 이름·NCAV·PBR·PER·전략 배지만 보여줬다.

스크리너는 볼 때마다 종목을 다시 훑지만, 관심 종목은 **담아두고 잊는다.** 담아둔 뒤 그 종목이 관리종목이 되거나 정리매매에 들어간 것을 알려줄 곳이 여기밖에 없다.

## 변경

- **위험 배지** — 정리매매·거래정지·관리종목·투자경고/위험·투자유의·단기과열·저유동.
  판정과 모양 모두 스크리너와 같은 `LiquidityBadge` 를 쓴다. 같은 종목이 두 화면에서 다르게 보이면 어느 쪽을 믿어야 할지 알 수 없다.
- **52주 위치** — 담아둔 뒤 얼마나 움직였는지.
- **업종**.

지표 줄은 항목이 늘어 좁은 화면에서 줄바꿈되도록 `flex-wrap` 을 넣었다.

### 값이 없을 때

아직 스캔되지 않은 종목은 `LEFT JOIN` 결과가 전부 `null` 이라 아무것도 그리지 않는다. `LikedStockItem` 의 신규 필드를 옵셔널로 둔 것도 같은 이유 — 워커 배포 전에는 필드 자체가 없다.

### 스크리너 관심 뷰

`normalizedLikedList` 는 오늘 스캔에 없는 종목일 때 이 목록으로 폴백하므로, 같은 배지가 그쪽에서도 함께 뜬다. 별도 코드 없이 따라온다.

## 의존 관계

워커 쪽 `getStockLikesWithDataD1` 변경(idiotquant-worker PR #90)이 먼저 배포돼야 값이 흐른다. 그 전까지는 필드가 없어 화면이 지금과 똑같다.

## 검증

- `npx tsc --noEmit` · `npm run build` 통과
- Playwright 데스크탑·모바일
  - `/profile` 관심 목록 5종(정상·관리종목·정리매매·저점·미수집) 배지/52주/업종 표시 5/5
  - **미수집 종목이 아무것도 그리지 않는 것** 확인 — null 처리 회귀 방지
  - 스크리너 관심 뷰 폴백 경로 배지 3/3
  - 가로 overflow 0px

## 참고

`LiquidityBadge` 를 `app/(screener)/.../components/` 에서 가져다 쓴다. 두 route group 이 공유하게 됐으니 `components/` 로 옮기는 편이 맞지만, import 4곳을 함께 건드려야 해서 이번 변경에는 넣지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_