### PR TITLE
feat(profile): 관심 종목이 없을 때 시작 화면으로

### DIFF
--- a/cf-idiotquant/app/(profile)/profile/page.tsx
+++ b/cf-idiotquant/app/(profile)/profile/page.tsx
@@ -13,8 +13,20 @@ import {
 import { cn } from "@/lib/utils";
 import { CopyStockButtons, type CopyStock } from "@/components/copyStockButtons";
 import { computeValueScore, type ValueTone } from "@/lib/utils/valueScore";
-import { computeSolidity } from "@/lib/utils/portfolioSolidity";
+import { computeSolidity, quadrantOf, type SolidityPoint } from "@/lib/utils/portfolioSolidity";
 import SolidityPlane from "@/components/profile/solidityPlane";
+
+// 아직 아무것도 담지 않은 사용자에게 좌표평면이 무엇을 말하는지 보여주기 위한 예시.
+// 실제 종목이 아니며 카드 머리에 "예시"라고 못박는다 — 자기 종목으로 오해하면
+// 담기도 전에 위험 신호를 본 것이 된다.
+const SAMPLE_POINTS: SolidityPoint[] = [
+    { name: "싸고 팔 수 있는 종목", ticker: "s1", value: 86, safety: 100 },
+    { name: "싸고 팔 수 있는 종목", ticker: "s2", value: 72, safety: 100 },
+    { name: "싸고 팔 수 있는 종목", ticker: "s3", value: 64, safety: 90 },
+    { name: "특별히 싸지 않은 종목", ticker: "s4", value: 34, safety: 100 },
+    { name: "상장폐지가 정해진 종목", ticker: "s5", value: 95, safety: 30 },
+    { name: "관리종목으로 지정된 종목", ticker: "s6", value: 78, safety: 50 },
+].map(p => ({ ...p, quadrant: quadrantOf(p.value, p.safety) }));
 import PortfolioLegoTower from "@/components/profile/portfolioLegoTower";
 // 위험 배지는 스크리너와 같은 기준·같은 모양이어야 한다 — 같은 종목이 두 화면에서
 // 다르게 보이면 어느 쪽을 믿어야 할지 알 수 없다. 그래서 판정까지 한 모듈에서 가져온다.
@@ -85,7 +97,14 @@ export default function ProfilePage() {
     const isMasterUser = session?.user?.name === process.env.NEXT_PUBLIC_MASTER;
     const isAdmin = (session?.user as any)?.role === "admin";
 
+    // 아직 아무것도 담지 않은 사용자. 불러오는 중에는 켜지 않는다 — 목록이 있는 사용자에게
+    // 온보딩 카드가 잠깐 떴다 사라지면 방금 본 것이 무엇인지 알 수 없다.
+    const isNewUser = likesState === "fulfilled" && likedList.length === 0;
+
     const DELETE_CONFIRM_PHRASE = "탈퇴";
+    // 회원 탈퇴는 한 단계 안에 둔다. 가입 직후 화면에서 가장 큰 액션이 계정 삭제일 이유가 없다.
+    // 경로를 없애는 것이 아니라 실수로 누를 자리에서 치우는 것이다.
+    const [showDanger, setShowDanger] = useState(false);
     const [confirmingDelete, setConfirmingDelete] = useState(false);
     const [deleteConfirmText, setDeleteConfirmText] = useState("");
     const [deleting, setDeleting] = useState(false);
@@ -143,8 +162,82 @@ export default function ProfilePage() {
 
                 {/* Header */}
                 <h1 className="text-lg font-black text-neutral-900 dark:text-neutral-50 px-1">
-                    내 계정
+                    {isNewUser ? "시작하기" : "내 계정"}
                 </h1>
+
+                {/* 아직 담은 종목이 없을 때만 — 다음에 할 일을 맨 위에 둔다.
+                    지금까지 이 자리는 이름과 이메일이었는데, 사용자가 이미 아는 정보다. */}
+                {isNewUser && (
+                    <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200/70 dark:border-[#35332e] shadow-sm overflow-hidden">
+                        <div className="px-5 pt-4 pb-2 flex items-center justify-between">
+                            <span className="text-[10px] font-bold text-neutral-400 dark:text-neutral-500 uppercase tracking-widest">
+                                3단계 중 1단계
+                            </span>
+                            <span className="text-[10px] font-bold text-neutral-400 font-mono tabular-nums">1 / 3</span>
+                        </div>
+                        <div className="px-5">
+                            <div className="h-1 rounded-full bg-neutral-100 dark:bg-[#35332e] overflow-hidden">
+                                <div className="h-full w-1/3 rounded-full bg-[#16a34a]" />
+                            </div>
+                        </div>
+                        <ol className="px-5 pt-3 pb-1 flex flex-col gap-1.5">
+                            {[
+                                { done: true, label: "가입했습니다" },
+                                { done: false, now: true, label: "싼 종목을 찾아 관심에 담기" },
+                                { done: false, label: "탄탄함으로 위험한 종목 걸러내기" },
+                            ].map((s, i) => (
+                                <li key={i} className="flex items-center gap-2">
+                                    <span className={cn(
+                                        "w-3 h-3 rounded-full shrink-0 border-2",
+                                        s.done
+                                            ? "bg-[#16a34a] border-[#16a34a]"
+                                            : s.now
+                                                ? "border-[#16a34a]"
+                                                : "border-neutral-200 dark:border-[#3f3d37]"
+                                    )} />
+                                    <span className={cn(
+                                        "text-xs",
+                                        s.done
+                                            ? "text-neutral-400 dark:text-neutral-500"
+                                            : s.now
+                                                ? "font-black text-neutral-800 dark:text-neutral-100"
+                                                : "text-neutral-400 dark:text-neutral-500"
+                                    )}>
+                                        {s.label}
+                                    </span>
+                                </li>
+                            ))}
+                        </ol>
+                        <div className="px-5 pt-2.5 pb-4">
+                            <Link
+                                href="/screener"
+                                className="flex items-center justify-center gap-1.5 w-full py-3 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-sm font-bold transition-colors"
+                            >
+                                싼 종목 찾아보기
+                                <ChevronRight size={15} />
+                            </Link>
+                        </div>
+                    </div>
+                )}
+
+                {/* 담기 전에 무엇을 보게 되는지 — 담을 이유를 설명해야 할 자리에서
+                    핵심 개념을 숨기고 있었다. */}
+                {isNewUser && (
+                    <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200/70 dark:border-[#35332e] shadow-sm overflow-hidden">
+                        <div className="px-5 pt-4 pb-1 flex items-center justify-between">
+                            <div className="flex items-center gap-1.5">
+                                <Blocks size={12} className="text-[#16a34a]" />
+                                <span className="text-[10px] font-bold text-neutral-400 dark:text-neutral-500 uppercase tracking-widest">
+                                    탄탄함이란
+                                </span>
+                            </div>
+                            <span className="text-[10px] font-bold px-1.5 py-0.5 rounded bg-neutral-100 dark:bg-[#35332e] text-neutral-500 dark:text-neutral-400">
+                                예시
+                            </span>
+                        </div>
+                        <SolidityPlane points={SAMPLE_POINTS} value={72} safety={78} trapCount={2} sample />
+                    </div>
+                )}
 
                 {/* Profile card */}
                 <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200/70 dark:border-[#35332e] shadow-sm overflow-hidden">
@@ -319,7 +412,9 @@ export default function ProfilePage() {
                     </div>
                 )}
 
-                {/* 관심 종목 */}
+                {/* 관심 종목 — 비었을 때는 위의 시작하기 카드가 같은 말을 더 잘 하므로 띄우지 않는다.
+                    "종목이 없습니다 / 발굴 페이지에서 추가해보세요"를 두 번 보여줄 이유가 없다. */}
+                {!isNewUser && (
                 <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200/70 dark:border-[#35332e] shadow-sm overflow-hidden">
                     <div className="px-5 pt-4 pb-2 flex items-center justify-between">
                         <div className="flex items-center gap-1.5">
@@ -451,6 +546,7 @@ export default function ProfilePage() {
                         </div>
                     )}
                 </div>
+                )}
 
                 {/* Account actions */}
                 <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200/70 dark:border-[#35332e] shadow-sm overflow-hidden">
@@ -473,7 +569,16 @@ export default function ProfilePage() {
 
                     <div className="border-t border-neutral-200/70 dark:border-[#35332e]" />
 
-                    {!confirmingDelete ? (
+                    {/* 탈퇴는 접어 둔다 — 로그아웃 바로 아래에서 가장 큰 빨간 버튼일 이유가 없다.
+                        열려 있는 동안에는 지금과 똑같이 동작한다. */}
+                    {!showDanger && !confirmingDelete ? (
+                        <button
+                            onClick={() => setShowDanger(true)}
+                            className="w-full px-5 py-3 text-left text-[11px] font-semibold text-neutral-400 dark:text-neutral-500 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors"
+                        >
+                            계정 설정 더 보기
+                        </button>
+                    ) : !confirmingDelete ? (
                         <button
                             onClick={() => setConfirmingDelete(true)}
                             disabled={isAdmin}

--- a/cf-idiotquant/components/profile/solidityPlane.tsx
+++ b/cf-idiotquant/components/profile/solidityPlane.tsx
@@ -47,13 +47,15 @@ const px = (v: number) => PAD.l + v;
 const py = (v: number) => PAD.t + (100 - v);   // Y 는 위가 큰 값
 
 export default function SolidityPlane({
-    points, value, safety, trapCount,
+    points, value, safety, trapCount, sample = false,
 }: {
     points: SolidityPoint[];
     /** 포트폴리오 평균 — 큰 표식 */
     value: number;
     safety: number;
     trapCount: number;
+    /** 아직 담은 종목이 없는 사용자에게 개념만 보여주는 예시. 오른쪽 설명이 바뀐다. */
+    sample?: boolean;
 }) {
     const uid = useId();
     const [active, setActive] = useState<SolidityPoint | null>(null);
@@ -199,6 +201,17 @@ export default function SolidityPlane({
                                     : "text-neutral-500 dark:text-neutral-400"
                             )}>
                                 {QUADRANT_LABEL[active.quadrant]} — {QUADRANT_DESC[active.quadrant]}
+                            </p>
+                        </div>
+                    ) : sample ? (
+                        <div>
+                            <p className="text-[11px] leading-relaxed text-neutral-600 dark:text-neutral-300">
+                                가로는 <b className="font-black text-[#16a34a] dark:text-[#22c55e]">얼마나 싼가</b>,
+                                세로는 <b className="font-black text-[#16a34a] dark:text-[#22c55e]">지금 팔 수 있는가</b>입니다.
+                            </p>
+                            <p className="text-[10px] leading-relaxed text-neutral-500 dark:text-neutral-400 mt-1.5">
+                                오른쪽 아래 <b className="font-bold text-rose-600 dark:text-rose-400">함정</b>은
+                                싼 이유가 상장폐지인 종목입니다. 관심 종목을 담으면 여기 들어온 것을 알려드립니다.
                             </p>
                         </div>
                     ) : trapCount > 0 ? (


### PR DESCRIPTION
## 무엇이 문제였나

가입 직후(`role: "user"`, 관심 0개) 화면을 390×844 에서 실측했습니다.

| | |
|---|---|
| 계정 관리 (프로필 90 + 계정 174) | **264px** |
| 제품 관련 (관심 종목 빈 상태) | 156px |
| 다음 행동 CTA `발굴 페이지` | **59 × 13px** (문장 속 링크) |
| 회원 탈퇴 버튼 | **356 × 67px** |
| 빈 공간 | 269px |

**가입 직후 화면에서 가장 큰 액션이 계정 삭제였습니다** — 면적으로 31배.

그리고 이 서비스의 핵심 개념인 탄탄함 좌표평면은 `likedList.length > 0` 게이트에 막혀 신규 사용자에게 보이지 않았습니다. 담을 이유를 설명해야 할 자리에서 그 이유를 숨기고 있었습니다.

## 무엇이 바뀌나

**관심 종목이 0개일 때만** 바뀝니다. 담은 종목이 있는 사용자의 화면은 그대로입니다.

- 제목 `내 계정` → `시작하기`
- 맨 위에 3단계 진행 카드. 지금까지 첫 카드는 이름과 이메일이었는데 사용자가 이미 아는 정보입니다.
- CTA 를 버튼으로: **59×13 → 316×44**(모바일) / 342×44(데스크탑)
- 탄탄함 좌표평면을 **예시**로 먼저 보여줍니다. 자기 종목으로 오해하면 담기도 전에 위험 신호를 본 것이 되므로 카드 머리에 `예시`를 못박았습니다.
- 관심 종목 카드는 비었을 때 띄우지 않습니다 — 위 카드가 같은 말을 더 잘 합니다. "종목이 없습니다 / 발굴 페이지에서 추가해보세요"를 두 번 보여줄 이유가 없습니다.

### 회원 탈퇴 (모든 사용자 해당)

`계정 설정 더 보기` 뒤로 한 단계 넣었습니다. **경로를 없애는 것이 아니라** 실수로 누를 자리에서 치우는 것이고, 펼치면 지금과 똑같이 동작합니다. 로그아웃은 자주 쓰므로 그대로 뒀습니다.

원 제안은 로그아웃까지 안으로 넣는 것이었는데, 자주 쓰는 기능을 숨기는 손해가 더 커서 탈퇴만 접었습니다.

## 결과

| | 이전 | 이후 |
|---|---|---|
| 첫 화면 최대 액션 | 회원 탈퇴 | 종목 찾아보기 |
| CTA 크기 | 59×13px | 316×44px |
| 빈 공간(모바일) | 269px | **19px** |
| 제품 설명 | 0줄 | 예시 좌표평면 |

모바일에서 전부 한 화면(844px) 안에 들어옵니다.

## 검증

- Playwright — **신규(0종목) / 기존(5종목) × 모바일 / 데스크탑 4가지 조합**, 실패 0
  - 신규: 제목·진행 카드·CTA 문구·예시 표시·축 설명·중복 문구 없음·탈퇴가 첫 화면에 없음·펼치면 나옴·CTA 높이 ≥40px
  - **기존: 진행 카드 없음 · 예시 카드 없음 · 관심 목록 정상 · 탄탄함 카드 정상 · 위험 배지 정상** (회귀 방지)
  - 가로 overflow 0px
- 단위 테스트 17개, `tsc --noEmit`, `npm run build`

## 남은 것

데스크탑은 본문이 `max-w-sm`(384px)으로 고정돼 있어 빈 공간이 183px 남습니다. 앞서 제안한 2열 레이아웃과 함께 다뤄야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_