### PR TITLE
fix(replay): 날것의 응답을 토스트에 그대로 뿌리지 않게

### DIFF
--- a/cf-idiotquant/lib/features/paper/replayAPI.ts
+++ b/cf-idiotquant/lib/features/paper/replayAPI.ts
@@ -15,7 +15,16 @@ async function replayRequest(method: "GET" | "POST", body?: object) {
         let json: any = null;
         try { json = text ? JSON.parse(text) : null; } catch { /* 비 JSON 응답(예: 404 HTML) */ }
         if (!json || typeof json !== "object") {
-            return { success: false, status: res.status, error: text ? text.slice(0, 100) : `HTTP ${res.status}` };
+            // 원문은 콘솔에만. 예전에 이 자리에서 text.slice(0,100) 을 그대로 에러 메시지로 써서
+            // Cloudflare 오류 페이지의 <!DOCTYPE html ... 이 토스트에 뜬 적이 있다.
+            console.error("[replay] 예상치 못한 응답", res.status, text.slice(0, 500));
+            return {
+                success: false,
+                status: res.status,
+                error: res.status === 404 ? "서버에 아직 이 기능이 없습니다. 잠시 후 다시 시도해주세요."
+                    : res.status >= 500 ? "서버에서 판을 준비하지 못했습니다. 잠시 후 다시 시도해주세요."
+                        : "서버 응답을 이해하지 못했습니다.",
+            };
         }
         return { ...json, status: res.status };
     } catch {


### PR DESCRIPTION
## 무슨 일이 있었나

"한 판 시작"을 누르면 토스트에 이게 떴다.

```
<!DOCTYPE html> <!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en-US"> <[endif]--> <!--[if I
```

`replayRequest` 는 "JSON 이 아니다"까지는 알아챘지만, 응답 본문을 `text.slice(0, 100)` 해서 그대로 에러 메시지로 썼다. 그래서 Cloudflare 오류 페이지가 화면에 실렸고, 100자로 잘리는 바람에 정작 필요한 오류 번호(1101)는 사라졌다.

서버 쪽 원인과 대응은 워커 PR #93 에 있다.

## 바뀐 것

`lib/features/paper/replayAPI.ts` — JSON 이 아니면 상태 코드로 사람이 읽을 문구를 고르고, 원문은 `console.error` 로 500자까지 남긴다.

| 상태 | 화면 |
|---|---|
| 404 | 서버에 아직 이 기능이 없습니다. 잠시 후 다시 시도해주세요. |
| 5xx | 서버에서 판을 준비하지 못했습니다. 잠시 후 다시 시도해주세요. |
| 그 외 | 서버 응답을 이해하지 못했습니다. |

`lib/features/deck/deckAPI.tsx` 에도 같은 모양의 폴백이 있지만 이번 변경이 만든 게 아니라 손대지 않았다. 같은 함정이 있다는 것만 적어 둔다.

## 검증

브라우저 e2e 로 `/user/replay` 응답을 흉내내 실제 화면을 확인했다. 실제 사용자가 본 그 1101 HTML 을 그대로 썼다.

| 케이스 | 결과 |
|---|---|
| 1101 HTML 200 | ✅ 사람 말 · HTML 노출 없음 |
| HTML 404 (워커 미배포) | ✅ |
| HTML 500 | ✅ |
| 빈 응답 502 | ✅ |
| JSON 503 (마이그레이션 미적용) | ✅ "마이그레이션 0016 을 적용해주세요" 그대로 표시 |

같은 e2e 를 고치기 전 코드에 돌리면 4건이 실패하고 HTML 이 화면에 뜬다 — 버그를 실제로 재현하는 검사임을 확인했다.

정상 경로도 재확인: 로그인·비로그인 양쪽 한 판 완주, 진행 중 미래 캔들 노출 없음, 비로그인 서버 호출 0회. `npx tsc --noEmit` · `npm run build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_