### PR TITLE
fix(game): 모바일에서 판 화면을 스크롤 없이 한 장으로

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -33,7 +33,7 @@ import { safeNum } from "@/lib/utils/numbers";
 // recharts 를 초기 번들에서 뺀다
 const LineChart = dynamic(() => import("@/components/LineChart"), {
     ssr: false,
-    loading: () => <div className="h-64 rounded-2xl bg-neutral-100 dark:bg-[#242320] animate-pulse" />,
+    loading: () => <div className="h-full min-h-[120px] rounded-2xl bg-neutral-100 dark:bg-[#242320] animate-pulse" />,
 });
 
 const pct = (v: number) => `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
@@ -172,37 +172,76 @@ export default function ReplayGamePage() {
 
     const maxBuy = price > 0 ? Math.floor((round?.cash ?? 0) / price) : 0;
 
+    // 계좌 4칸. 모바일 압축 줄과 데스크톱 카드가 같은 값을 쓰도록 한 곳에서 만든다.
+    const stats = round ? [
+        {
+            label: "총 자산", value: fmtKrw(totalAssets), sub: `시드 ${fmtKrw(round.seed)}`,
+            icon: <Wallet size={15} />, iconBg: "bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500",
+        },
+        {
+            label: "예수금", value: fmtKrw(round.cash), sub: round.qty > 0 ? `보유 ${round.qty}주` : "보유 없음",
+            icon: <Coins size={15} />, iconBg: "bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500",
+        },
+        {
+            label: round.status === "done" ? "마지막 가격" : "현재가", value: fmtKrw(price),
+            sub: round.qty > 0 ? `평단 ${fmtKrw(avg)}` : round.status === "done" ? "청산 완료" : "아직 안 삼",
+            icon: <Eye size={15} />, iconBg: "bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500",
+        },
+        {
+            label: "수익률", value: pct(totalRate), sub: `실현 ${fmtKrw(round.realized)}`,
+            icon: <PnlIcon positive={totalPnl >= 0} />, iconBg: pnlIconBg(totalPnl >= 0),
+            valueColor: pnlValueColor(totalPnl >= 0), accentColor: pnlAccentColor(totalPnl >= 0),
+        },
+    ] : [];
+
     if (loading) {
         return <div className="min-h-screen bg-[#faf9f7] dark:bg-[#1a1917] flex items-center justify-center text-sm text-neutral-400">불러오는 중…</div>;
     }
 
     return (
-        <div className="min-h-screen bg-[#faf9f7] dark:bg-[#1a1917] pb-24">
+        // min-h-screen 을 그대로 쓰면 main 의 pt-48 + pb-64 가 더해져 내용과 무관하게 112px 이
+        // 항상 스크롤된다. 모바일에서는 크롬을 뺀 높이를 바닥으로 삼는다.
+        <div className={cn("bg-[#faf9f7] dark:bg-[#1a1917]", round ? "md:min-h-screen" : "min-h-[calc(100dvh-112px)] md:min-h-screen")}>
             <ToastContainer toasts={toasts} onRemove={removeToast} />
 
-            <div className="max-w-4xl mx-auto px-4 sm:px-5 py-6 sm:py-10 flex flex-col gap-5">
+            <div className={cn(
+                "max-w-4xl mx-auto px-4 sm:px-5 flex flex-col",
+                // 판이 열려 있는 동안은 모바일에서 스크롤 없이 한 화면에 담는다 — 차트를 보고
+                // 버튼을 누르는 게 매일 반복되는 동작이라, 그 둘이 같은 화면에 있어야 한다.
+                // layout.tsx 의 main 이 상단 헤더 48 + 하단 탭 64 를 이미 비워 두므로 그만큼 뺀다.
+                // 100dvh 라야 모바일 브라우저 주소창이 접혔다 펴져도 어긋나지 않는다.
+                // overflow-y-auto 는 안전장치다. 아주 작은 화면에서 고정 부분만으로도 자리가
+                // 모자라면 잘리는 대신 스크롤된다 — 버튼이 화면 밖으로 사라지면 판을 못 이어간다.
+                round
+                    ? "h-[calc(100dvh-112px)] md:h-auto overflow-y-auto md:overflow-visible py-3 sm:py-6 md:py-10 gap-3 sm:gap-4 md:pb-24"
+                    : "py-6 sm:py-10 pb-10 md:pb-24 gap-5",
+            )}>
 
                 {!round && <StartScreen onStart={start} busy={busy} isLoggedIn={isLoggedIn} coins={coins} bestReturn={bestReturn} history={history} />}
 
                 {round && (
                     <>
-                        <header className="flex flex-wrap items-end justify-between gap-3">
-                            <div>
-                                <p className="text-[10px] font-black uppercase tracking-[0.2em] text-[#a1730a] dark:text-[#e3b34a] mb-1.5">
+                        {/* 모바일에서는 한 줄. 큰 제목은 넓은 화면에서만 — 매일 다시 읽을 문장은 아니다. */}
+                        <header className="flex items-center justify-between gap-3 shrink-0">
+                            <div className="min-w-0">
+                                <p className="text-[10px] font-black uppercase tracking-[0.2em] text-[#a1730a] dark:text-[#e3b34a] sm:mb-1.5">
                                     {round.status === "done" ? "Result" : `Day ${round.cursor - CONTEXT_DAYS + 1} / ${TOTAL_DAYS - CONTEXT_DAYS + 1}`}
                                 </p>
-                                <h1 className="text-xl sm:text-2xl font-black text-neutral-900 dark:text-white break-keep">
+                                <h1 className="hidden sm:block text-xl sm:text-2xl font-black text-neutral-900 dark:text-white break-keep">
                                     {round.status === "done" ? "한 판 끝" : "이 회사, 지금 사시겠습니까?"}
                                 </h1>
+                                <p className="sm:hidden text-[15px] font-black text-neutral-900 dark:text-white leading-tight">
+                                    {round.status === "done" ? "한 판 끝" : "사시겠습니까?"}
+                                </p>
                             </div>
                             {round.status === "playing" ? (
                                 <button onClick={giveUp} disabled={busy}
-                                    className="inline-flex items-center gap-1.5 min-h-[40px] px-3 rounded-xl text-xs font-bold text-neutral-500 dark:text-neutral-400 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40 transition-colors">
-                                    <Flag size={14} /> 여기서 그만
+                                    className="shrink-0 inline-flex items-center gap-1.5 min-h-[40px] px-3 rounded-xl text-xs font-bold text-neutral-500 dark:text-neutral-400 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40 transition-colors">
+                                    <Flag size={14} /> 그만
                                 </button>
                             ) : (
                                 <button onClick={reset}
-                                    className="inline-flex items-center gap-1.5 min-h-[40px] px-3 rounded-xl text-xs font-black text-white bg-[#0d2a1a] dark:bg-[#e3b34a] dark:text-[#2a1c00] hover:opacity-90 transition-opacity">
+                                    className="shrink-0 inline-flex items-center gap-1.5 min-h-[40px] px-3 rounded-xl text-xs font-black text-white bg-[#0d2a1a] dark:bg-[#e3b34a] dark:text-[#2a1c00] hover:opacity-90 transition-opacity">
                                     <RotateCcw size={14} /> 한 판 더
                                 </button>
                             )}
@@ -210,63 +249,81 @@ export default function ReplayGamePage() {
 
                         {round.status === "done" && <ResultBanner round={round} />}
 
-                        {/* ── 차트 ────────────────────────── */}
-                        <SectionPanel>
-                            <SectionHeader
-                                icon={<TrendingUp size={16} />}
-                                title={round.status === "done" ? (round.name ?? "차트") : "블라인드 차트"}
-                                subtitle={round.status === "done"
-                                    ? `${round.ticker} · ${fmtDate(round.start_date)} ~ ${fmtDate(round.end_date)}`
-                                    : "종목명과 시기는 끝나야 열립니다"}
-                            />
-                            <LineChart
-                                height={260}
-                                category_array={visible.map(c => c.d.slice(4))}
-                                data_array={[
-                                    { name: "종가", data: visible.map(c => c.c) },
-                                    ...(round.qty > 0 ? [{ name: "내 평단", data: visible.map(() => Math.round(avg)), color: "#e3b34a" }] : []),
-                                ]}
-                            />
+                        {/* ── 차트 ──────────────────────────
+                            남는 세로 공간을 전부 차트가 가져간다. 화면이 작으면 차트만 줄고
+                            계좌·버튼은 그대로 남는다 — 판을 이어가는 데 필요한 건 그쪽이다. */}
+                        {/* min-h-0 을 주면 안 된다 — flex 가 패널을 내용보다 작게 줄여 차트가 패널을
+                            뚫고 나온다(320px 에서 계좌 카드 위에 겹쳐 그려졌다). 기본값 min-height:auto
+                            라야 내용 높이가 바닥이 되고, 자리가 정말 모자라면 바깥이 스크롤된다. */}
+                        <SectionPanel className="flex-1 flex flex-col p-3 sm:p-5">
+                            <div className="sm:hidden flex items-baseline justify-between gap-2 mb-1.5 shrink-0">
+                                <h2 className="text-[13px] font-black text-neutral-900 dark:text-neutral-100 shrink-0">
+                                    {round.status === "done" ? (round.name ?? "차트") : "블라인드 차트"}
+                                </h2>
+                                <p className="text-[10px] text-neutral-400 truncate">
+                                    {round.status === "done"
+                                        ? `${round.ticker} · ${fmtDate(round.start_date)}~${fmtDate(round.end_date)}`
+                                        : "종목·시기는 끝나야 열립니다"}
+                                </p>
+                            </div>
+                            <div className="hidden sm:block">
+                                <SectionHeader
+                                    icon={<TrendingUp size={16} />}
+                                    title={round.status === "done" ? (round.name ?? "차트") : "블라인드 차트"}
+                                    subtitle={round.status === "done"
+                                        ? `${round.ticker} · ${fmtDate(round.start_date)} ~ ${fmtDate(round.end_date)}`
+                                        : "종목명과 시기는 끝나야 열립니다"}
+                                />
+                            </div>
+                            {/* recharts 의 ResponsiveContainer 는 부모 높이가 flex 로 정해지면 한 번 잰
+                                크기를 붙들고 있어 칸이 줄어도 그대로 그린다 — 320px 에서 차트가 패널을
+                                뚫고 나와 계좌 카드 위에 겹쳐 그려졌다. absolute inset-0 으로 실제 픽셀
+                                상자를 주면 줄어드는 쪽도 따라온다. */}
+                            <div className="relative flex-1 min-h-[120px] sm:min-h-[260px] overflow-hidden">
+                                <div className="absolute inset-0">
+                                    <LineChart
+                                        height="100%"
+                                        legend_disable={round.qty < 1}
+                                        category_array={visible.map(c => c.d.slice(4))}
+                                        data_array={[
+                                            { name: "종가", data: visible.map(c => c.c) },
+                                            ...(round.qty > 0 ? [{ name: "내 평단", data: visible.map(() => Math.round(avg)), color: "#e3b34a" }] : []),
+                                        ]}
+                                    />
+                                </div>
+                            </div>
                         </SectionPanel>
 
-                        {/* ── 계좌 ────────────────────────── */}
-                        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
-                            <KpiCard label="총 자산" value={fmtKrw(totalAssets)} sub={`시드 ${fmtKrw(round.seed)}`}
-                                icon={<Wallet size={15} />} iconBg="bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500" />
-                            <KpiCard label="예수금" value={fmtKrw(round.cash)} sub={round.qty > 0 ? `보유 ${round.qty}주` : "보유 없음"}
-                                icon={<Coins size={15} />} iconBg="bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500" />
-                            <KpiCard
-                                label={round.status === "done" ? "마지막 가격" : "현재가"}
-                                value={fmtKrw(price)}
-                                sub={round.qty > 0 ? `평단 ${fmtKrw(avg)}` : round.status === "done" ? "청산 완료" : "아직 안 삼"}
-                                icon={<Eye size={15} />} iconBg="bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500" />
-                            <KpiCard label="수익률" value={pct(totalRate)} sub={`실현 ${fmtKrw(round.realized)}`}
-                                icon={<PnlIcon positive={totalPnl >= 0} />}
-                                iconBg={pnlIconBg(totalPnl >= 0)}
-                                valueColor={pnlValueColor(totalPnl >= 0)}
-                                accentColor={pnlAccentColor(totalPnl >= 0)} />
+                        {/* ── 계좌 ──────────────────────────
+                            모바일은 눌러야 할 버튼에 자리를 내주려고 줄로 압축하고,
+                            넓은 화면에서는 원래 카드를 그대로 쓴다. 값은 stats 한 곳에서 온다. */}
+                        <div className="grid grid-cols-2 gap-2 sm:hidden shrink-0">
+                            {stats.map(s => <MiniStat key={s.label} {...s} />)}
+                        </div>
+                        <div className="hidden sm:grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
+                            {stats.map(s => <KpiCard key={s.label} {...s} />)}
                         </div>
 
                         {/* ── 조작 ────────────────────────── */}
                         {round.status === "playing" && (
-                            <SectionPanel>
-                                <div className="flex flex-col gap-4">
-                                    <div className="flex items-center gap-2">
-                                        <span className="text-xs font-black text-neutral-400 uppercase tracking-wider shrink-0">수량</span>
+                            <SectionPanel className="shrink-0 p-3 sm:p-5">
+                                <div className="flex flex-col gap-2 sm:gap-4">
+                                    <div className="flex items-center gap-1.5 sm:gap-2">
+                                        <span className="text-[10px] sm:text-xs font-black text-neutral-400 uppercase tracking-wider shrink-0">수량</span>
                                         <input
                                             type="number" min={1} value={qty} aria-label="주문 수량"
                                             onChange={e => setQty(Math.max(1, Math.floor(Number(e.target.value) || 1)))}
-                                            className="w-24 min-h-[44px] px-3 rounded-xl text-sm text-right font-mono bg-neutral-50 dark:bg-[#1a1917] border border-neutral-200 dark:border-[#35332e] text-neutral-900 dark:text-white"
+                                            className="w-16 sm:w-24 min-h-[40px] sm:min-h-[44px] px-2 sm:px-3 rounded-xl text-sm text-right font-mono bg-neutral-50 dark:bg-[#1a1917] border border-neutral-200 dark:border-[#35332e] text-neutral-900 dark:text-white"
                                         />
-                                        <div className="flex gap-1.5 flex-wrap">
+                                        <div className="flex gap-1 sm:gap-1.5 flex-1 justify-end">
                                             {[10, 50, 100].map(n => (
                                                 <button key={n} onClick={() => setQty(n)}
-                                                    className="min-h-[36px] px-2.5 rounded-lg text-[11px] font-bold text-neutral-500 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26]">
+                                                    className="min-h-[36px] px-2 sm:px-2.5 rounded-lg text-[11px] font-bold text-neutral-500 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26]">
                                                     {n}
                                                 </button>
                                             ))}
                                             <button onClick={() => setQty(Math.max(1, maxBuy))} disabled={maxBuy < 1}
-                                                className="min-h-[36px] px-2.5 rounded-lg text-[11px] font-bold text-neutral-500 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40">
+                                                className="min-h-[36px] px-2 sm:px-2.5 rounded-lg text-[11px] font-bold text-neutral-500 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40">
                                                 최대
                                             </button>
                                         </div>
@@ -289,7 +346,11 @@ export default function ReplayGamePage() {
                                         </button>
                                     </div>
 
-                                    <p className="text-[11px] text-neutral-400 dark:text-neutral-500 break-keep leading-[1.7]">
+                                    {/* 모바일은 한 줄만. 수수료·자동청산 규칙은 시작 화면에 적어 뒀다. */}
+                                    <p className="sm:hidden text-[10px] text-neutral-400 dark:text-neutral-500 text-center">
+                                        어느 쪽을 눌러도 하루가 지나갑니다 · 그날 종가로 체결
+                                    </p>
+                                    <p className="hidden sm:block text-[11px] text-neutral-400 dark:text-neutral-500 break-keep leading-[1.7]">
                                         어느 쪽을 눌러도 하루가 지나갑니다. 그날 종가로 체결되고,
                                         수수료는 매수·매도 각 0.015%, 매도 시 증권거래세 0.18%입니다.
                                         마지막 날에는 남은 주식이 자동으로 정리됩니다.
@@ -299,7 +360,7 @@ export default function ReplayGamePage() {
                         )}
 
                         {round.status === "done" && !isLoggedIn && (
-                            <div className="rounded-2xl border border-[#e3b34a]/40 bg-[#fdf6e9] dark:bg-[#1c1608] px-4 py-3 text-[13px] text-[#8a6206] dark:text-[#e3b34a] break-keep">
+                            <div className="shrink-0 rounded-2xl border border-[#e3b34a]/40 bg-[#fdf6e9] dark:bg-[#1c1608] px-4 py-2.5 text-[12px] sm:text-[13px] text-[#8a6206] dark:text-[#e3b34a] break-keep">
                                 <Link href="/login?callbackUrl=%2Fgame" className="underline font-bold">로그인</Link>
                                 하면 기록과 코인이 쌓입니다.
                             </div>
@@ -307,6 +368,18 @@ export default function ReplayGamePage() {
                     </>
                 )}
             </div>
+        </div>
+    );
+}
+
+// ─────────────────────────────────────────────────────────
+/** 모바일용 압축 지표 한 칸. 화면을 한 장으로 유지하려고 KpiCard 대신 쓴다. */
+function MiniStat({ label, value, sub, valueColor }: { label: string; value: string; sub: string; valueColor?: string }) {
+    return (
+        <div className="rounded-xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] px-2.5 py-1.5">
+            <p className="text-[9px] font-black uppercase tracking-wider text-neutral-400">{label}</p>
+            <p className={cn("text-[14px] font-black font-mono leading-tight truncate", valueColor ?? "text-neutral-900 dark:text-white")}>{value}</p>
+            <p className="text-[10px] text-neutral-400 truncate">{sub}</p>
         </div>
     );
 }
@@ -325,7 +398,8 @@ function StartScreen({ onStart, busy, isLoggedIn, coins, bestReturn, history }: 
                 <h1 className="text-2xl sm:text-3xl font-black text-neutral-900 dark:text-white break-keep">
                     어느 회사인지 모른 채,<br />60일을 살아보기
                 </h1>
-                <p className="text-[13px] sm:text-[15px] text-neutral-500 dark:text-neutral-400 mt-3 leading-[1.8] break-keep max-w-md">
+                {/* 아래 규칙 목록과 같은 말이라, 화면이 좁으면 접는다 */}
+                <p className="hidden sm:block text-[13px] sm:text-[15px] text-neutral-500 dark:text-neutral-400 mt-3 leading-[1.8] break-keep max-w-md">
                     종목명도 날짜도 가린 실제 과거 차트를 하루씩 넘기며 사고팝니다.
                     끝나면 성적과 정답을 함께 엽니다.
                 </p>
@@ -336,6 +410,8 @@ function StartScreen({ onStart, busy, isLoggedIn, coins, bestReturn, history }: 
                     {[
                         `가상 1,000만원으로 시작합니다.`,
                         `앞 ${CONTEXT_DAYS}일을 먼저 보고, 남은 ${TOTAL_DAYS - CONTEXT_DAYS}일을 하루씩 넘깁니다.`,
+                        // 판이 도는 중에는 화면이 좁아 이 규칙을 적을 자리가 없다 — 여기서 한 번 말한다.
+                        `체결은 그날 종가. 수수료 0.015%, 매도 거래세 0.18%. 마지막 날 자동 청산.`,
                         `그냥 사서 들고 있었을 때와 나란히 놓고 채점합니다.`,
                     ].map((line, i) => (
                         <li key={i} className="flex gap-3 break-keep">
@@ -355,12 +431,18 @@ function StartScreen({ onStart, busy, isLoggedIn, coins, bestReturn, history }: 
             </SectionPanel>
 
             {isLoggedIn && (
-                <div className="grid grid-cols-2 gap-3 sm:gap-4">
-                    <KpiCard label="코인" value={coins.toLocaleString()} sub="판을 이길 때마다 쌓입니다"
-                        icon={<Coins size={15} />} iconBg="bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500" />
-                    <KpiCard label="최고 수익률" value={bestReturn === null ? "—" : pct(bestReturn)} sub={`${history.length}판 완료`}
-                        icon={<TrendingUp size={15} />} iconBg="bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500" />
-                </div>
+                <>
+                    <div className="grid grid-cols-2 gap-2 sm:hidden">
+                        <MiniStat label="코인" value={coins.toLocaleString()} sub="이길 때마다 쌓입니다" />
+                        <MiniStat label="최고 수익률" value={bestReturn === null ? "—" : pct(bestReturn)} sub={`${history.length}판 완료`} />
+                    </div>
+                    <div className="hidden sm:grid grid-cols-2 gap-3 sm:gap-4">
+                        <KpiCard label="코인" value={coins.toLocaleString()} sub="판을 이길 때마다 쌓입니다"
+                            icon={<Coins size={15} />} iconBg="bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500" />
+                        <KpiCard label="최고 수익률" value={bestReturn === null ? "—" : pct(bestReturn)} sub={`${history.length}판 완료`}
+                            icon={<TrendingUp size={15} />} iconBg="bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500" />
+                    </div>
+                </>
             )}
 
             {history.length > 0 && (
@@ -399,30 +481,29 @@ function ResultBanner({ round }: { round: ReplayRound }) {
     const beat = mine > bh;
 
     return (
-        <SectionPanel className={cn("border-2", beat ? "border-[#e3b34a]/60" : "border-neutral-200 dark:border-[#35332e]")}>
-            <div className="flex flex-col gap-4">
+        <SectionPanel className={cn("shrink-0 border-2 p-3 sm:p-5", beat ? "border-[#e3b34a]/60" : "border-neutral-200 dark:border-[#35332e]")}>
+            <div className="flex flex-col gap-1.5 sm:gap-4">
                 <div className="flex items-baseline justify-between gap-3 flex-wrap">
                     <div>
-                        <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 mb-1">내 수익률</p>
-                        <p className={cn("text-3xl sm:text-4xl font-black font-mono", pnlValueColor(mine >= 0))}>{pct(mine)}</p>
+                        <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 sm:mb-1">내 수익률</p>
+                        <p className={cn("text-2xl sm:text-4xl font-black font-mono", pnlValueColor(mine >= 0))}>{pct(mine)}</p>
                     </div>
                     <div className="text-right">
-                        <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 mb-1">그냥 사서 들고 있었다면</p>
-                        <p className={cn("text-xl font-black font-mono", pnlValueColor(bh >= 0))}>{pct(bh)}</p>
+                        <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 sm:mb-1">그냥 사서 들고 있었다면</p>
+                        <p className={cn("text-lg sm:text-xl font-black font-mono", pnlValueColor(bh >= 0))}>{pct(bh)}</p>
                     </div>
                 </div>
 
-                <p className="text-[14px] font-bold break-keep text-neutral-700 dark:text-neutral-200">
+                <p className="text-[12px] sm:text-[14px] font-bold break-keep text-neutral-700 dark:text-neutral-200">
                     {beat
                         ? `그냥 들고 있는 것보다 ${(mine - bh).toFixed(2)}%p 더 벌었습니다.`
                         : `그냥 들고 있었으면 ${(bh - mine).toFixed(2)}%p 더 벌었습니다.`}
+                    {(round.coins_earned ?? 0) > 0 && (
+                        <span className="text-[#a1730a] dark:text-[#e3b34a] inline-flex items-center gap-1 ml-2">
+                            <Coins size={13} /> 코인 +{round.coins_earned}
+                        </span>
+                    )}
                 </p>
-
-                {(round.coins_earned ?? 0) > 0 && (
-                    <p className="text-[13px] text-[#a1730a] dark:text-[#e3b34a] font-bold inline-flex items-center gap-1.5">
-                        <Coins size={14} /> 코인 {round.coins_earned} 획득
-                    </p>
-                )}
             </div>
         </SectionPanel>
     );

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -172,6 +172,22 @@ export default function ReplayGamePage() {
 
     const maxBuy = price > 0 ? Math.floor((round?.cash ?? 0) / price) : 0;
 
+    // 사고판 지점을 차트에 찍는다. 빨강이 매수, 초록이 매도 — 버튼 색과 같다.
+    // 수량 라벨은 체결이 적을 때만 붙인다. 많아지면 서로 겹쳐 오히려 안 읽힌다.
+    const markers = useMemo(() => {
+        const orders = round?.orders ?? [];
+        const withLabel = orders.length <= 8;
+        return orders
+            .filter(o => o.day_index < visible.length)
+            .map(o => ({
+                x: visible[o.day_index].d.slice(4),
+                y: o.price,
+                color: o.side === "buy" ? "#ef4444" : "#16a34a",
+                label: withLabel ? `${o.side === "buy" ? "+" : "−"}${o.qty}` : undefined,
+                labelPosition: o.side === "buy" ? "bottom" : "top",
+            }));
+    }, [round, visible]);
+
     // 계좌 4칸. 모바일 압축 줄과 데스크톱 카드가 같은 값을 쓰도록 한 곳에서 만든다.
     const stats = round ? [
         {
@@ -283,6 +299,7 @@ export default function ReplayGamePage() {
                                 <div className="absolute inset-0">
                                     <LineChart
                                         height="100%"
+                                        markers={markers}
                                         legend_disable={round.qty < 1}
                                         category_array={visible.map(c => c.d.slice(4))}
                                         data_array={[

--- a/cf-idiotquant/components/LineChart.tsx
+++ b/cf-idiotquant/components/LineChart.tsx
@@ -9,6 +9,7 @@ import {
     YAxis,
     ResponsiveContainer,
     Legend,
+    ReferenceDot,
 } from "recharts";
 import { useTheme } from "next-themes";
 
@@ -92,9 +93,12 @@ export default function LineChart(props: any) {
     const isMiniMode = props.height <= 36 || props.show_yaxis_label === false;
 
     // 차트 외곽 마진 설정 (미니모드일 때는 패딩 공백 없이 영역을 꽉 채우도록 수치 극소화)
-    const chartMargin = isMiniMode 
+    // 마커 라벨은 점 바깥에 그려진다. 마지막 캔들에 찍힌 마커는 오른쪽 끝에 붙으므로
+    // 기본 마진(10)으로는 라벨이 잘린다 — 마커가 있을 때만 상/우 여백을 넓힌다.
+    const hasMarkers = !!props.markers?.length;
+    const chartMargin = isMiniMode
         ? { top: 2, right: 2, left: 2, bottom: 2 }
-        : { top: 10, right: 10, left: 0, bottom: 5 };
+        : { top: hasMarkers ? 18 : 10, right: hasMarkers ? 24 : 10, left: 0, bottom: 5 };
 
     return (
         <ResponsiveContainer width={props.width ?? "100%"} height={props.height ?? 120}>
@@ -184,6 +188,28 @@ export default function LineChart(props: any) {
                         />
                     );
                 })}
+
+                {/* 선택 옵션: 특정 지점에 점을 찍는다. x 는 category_array 의 값과 같아야 한다.
+                    (모의투자에서 매수·매도 시점을 표시하는 데 쓴다) */}
+                {props.markers?.map((m: any, i: number) => (
+                    <ReferenceDot
+                        key={`marker_${i}`}
+                        x={m.x}
+                        y={m.y}
+                        r={4}
+                        fill={m.color}
+                        stroke={mode === "dark" ? "#09090b" : "#ffffff"}
+                        strokeWidth={1.5}
+                        label={m.label ? {
+                            value: m.label,
+                            position: m.labelPosition ?? "top",
+                            fontSize: 9,
+                            fontWeight: 700,
+                            fontFamily: "var(--font-mono)",
+                            fill: m.color,
+                        } : undefined}
+                    />
+                ))}
             </AreaChart>
         </ResponsiveContainer>
     );

--- a/cf-idiotquant/lib/paper/localRound.ts
+++ b/cf-idiotquant/lib/paper/localRound.ts
@@ -7,7 +7,7 @@
 // 매매 규칙은 lib/paper/engine.ts, 판의 규칙은 lib/paper/round.ts 한 곳에서만 나온다.
 
 import { SEED, quoteBuy, quoteSell, applyBuy, applySell, type BuyQuote, type SellQuote } from "./engine";
-import { TOTAL_DAYS, CONTEXT_DAYS, buyAndHoldReturn, coinsFor, type Candle, type ReplayRound } from "./round";
+import { TOTAL_DAYS, CONTEXT_DAYS, buyAndHoldReturn, coinsFor, type Candle, type ReplayRound, type ReplayOrder } from "./round";
 import { getInquireDailyItemChartPrice } from "@/lib/features/koreaInvestment/koreaInvestmentAPI";
 
 const KEY = "iq:replay:v1";
@@ -58,6 +58,7 @@ export async function buildLocalRound(pool: { ticker: string; name: string }[]):
                 total_days: TOTAL_DAYS,
                 cash: SEED, seed: SEED, qty: 0, cost_basis: 0, realized: 0, fees_paid: 0,
                 status: "playing",
+                orders: [],
                 candles: full,           // 로컬은 전부 들고 있고 화면에서 cursor 까지만 그린다
                 ticker: pick.ticker, name: pick.name,
                 start_date: full[0].d, end_date: full[full.length - 1].d,
@@ -79,7 +80,8 @@ export function loadLocal(): ReplayRound | null {
         if (!raw) return null;
         const parsed = JSON.parse(raw) as ReplayRound;
         if (!Array.isArray(parsed?.candles) || typeof parsed?.cursor !== "number") return null;
-        return parsed;
+        // orders 를 넣기 전에 저장된 판이 남아 있을 수 있다
+        return { ...parsed, orders: Array.isArray(parsed.orders) ? parsed.orders : [] };
     } catch {
         return null;
     }
@@ -100,6 +102,7 @@ function finish(round: ReplayRound): ReplayRound {
     const lastPrice = round.candles[lastIdx]?.c ?? 0;
 
     let { cash, realized, fees_paid: fees, qty, cost_basis } = round;
+    const orders = [...round.orders];
     if (qty > 0 && lastPrice > 0) {
         const q = quoteSell({ price: lastPrice, qty, position: { ticker: round.ticker!, name: round.name, qty, cost_basis } });
         if (q.ok) {
@@ -107,6 +110,7 @@ function finish(round: ReplayRound): ReplayRound {
             cash += s.net;
             realized += s.realized;
             fees += s.fee;
+            orders.push({ day_index: lastIdx, side: "sell", qty, price: s.price });
             qty = 0;
             cost_basis = 0;
         }
@@ -119,6 +123,7 @@ function finish(round: ReplayRound): ReplayRound {
 
     const done: ReplayRound = {
         ...round, cash, realized, fees_paid: fees, qty: 0, cost_basis: 0,
+        orders,
         status: "done",
         final_return: finalReturn,
         bh_return: bhReturn,
@@ -147,6 +152,9 @@ export function advanceLocal(round: ReplayRound, trade?: { side: "buy" | "sell";
             : quoteSell({ price: today.c, qty: trade.qty, position });
         if (!q.ok) return { ok: false, error: q.error };
 
+        // 몇 번째 캔들에서 체결됐는지 — 차트에 찍을 자리다
+        const order: ReplayOrder = { day_index: round.cursor - 1, side: q.side, qty: q.qty, price: q.price };
+
         if (q.side === "buy") {
             const b = q as BuyQuote;
             const pos = applyBuy(position, b);
@@ -156,6 +164,7 @@ export function advanceLocal(round: ReplayRound, trade?: { side: "buy" | "sell";
             const pos = applySell(position, s);
             next = { ...next, cash: next.cash + s.net, realized: next.realized + s.realized, fees_paid: next.fees_paid + s.fee, ...pos };
         }
+        next = { ...next, orders: [...next.orders, order] };
     }
 
     const nextCursor = next.cursor + 1;

--- a/cf-idiotquant/lib/paper/round.ts
+++ b/cf-idiotquant/lib/paper/round.ts
@@ -15,8 +15,17 @@ export interface Candle {
     c: number;
 }
 
+/** 체결 하나. 차트에 매매 시점을 찍는 데 쓴다. day_index 는 몇 번째 캔들인지(0-based). */
+export interface ReplayOrder {
+    day_index: number;
+    side: "buy" | "sell";
+    qty: number;
+    price: number;
+}
+
 /** 서버 `_publicRound` 와 같은 모양. 진행 중에는 정답과 미래 캔들이 비어 있다. */
 export interface ReplayRound {
+    orders: ReplayOrder[];
     id: string;
     cursor: number;
     total_days: number;


### PR DESCRIPTION
## 왜

차트를 보고 버튼을 누르는 게 매일 60번 반복되는 동작인데, 그 둘이 같은 화면에 없었다. 390px 에서 문서 높이가 **1313px** (화면 844px) 이라 매수/매도 버튼은 늘 스크롤 아래에 있었다.

## 어떻게

판이 열려 있는 동안은 뷰포트 높이에 맞춘 flex 컬럼으로 두고, **남는 세로 공간을 차트가 가져간다.** 화면이 작으면 차트만 줄고 계좌·버튼은 그대로 남는다 — 판을 이어가는 데 필요한 건 그쪽이다. 픽셀을 손으로 맞추는 대신 이렇게 해야 기기 크기가 달라도 따라온다.

- 컨테이너 `h-[calc(100dvh-112px)]` — `layout.tsx` 의 `main` 이 상단 헤더 48 + 하단 탭 64 를 이미 비워 두므로 그만큼 뺀다. `vh` 가 아니라 `dvh` 라야 모바일 주소창이 접혔다 펴져도 어긋나지 않는다
- 모바일 전용 압축: 헤더 한 줄, `KpiCard` 대신 `MiniStat`, 수수료 설명은 시작 화면 규칙으로 이동. 네 칸의 값은 `stats` 배열 한 곳에서 온다
- `min-h-screen` 이 `main` 의 패딩과 겹쳐 **내용과 무관하게 항상 112px 스크롤되던 것**도 함께 정리
- 안전장치로 `overflow-y-auto` — 자리가 정말 모자라면 잘리는 대신 스크롤된다. 버튼이 화면 밖으로 사라지면 판을 못 이어간다

**넓은 화면(`sm` 이상)은 기존 레이아웃 그대로다.**

## 작업 중 발견해 고친 버그

320px 에서 **차트가 패널을 뚫고 나와 계좌 카드 위에 겹쳐 그려졌다.** 패널의 `min-h-0` 이 flex 로 하여금 패널을 제 내용보다 작게(79px vs 내용 120px) 줄이게 한 탓이다. 스크린샷으로 눈치채고 실제 박스 크기를 찍어 원인을 좁혔다.

## 측정 (상하단 고정 크롬 112px 제외)

| 기기 | 시작 | 진행 | 결과 |
|---|---|---|---|
| iPhone 5/SE1 320×568 | 115px 스크롤 | **93px 스크롤** | ✅ |
| iPhone SE 375×667 | ✅ | ✅ (1313→667) | ✅ |
| iPhone 14 390×844 | ✅ | ✅ (1313→844) | ✅ |
| Pixel 7 412×915 | ✅ | ✅ | ✅ |

320×568 은 판 화면이 93px 스크롤된다. 거기까지 맞추려면 계좌 표시나 버튼을 줄여야 해서 흔한 기기 쪽을 택했다. 잘리지는 않고 버튼도 전부 닿는다.

## 검증

- 브라우저에서 네 가지 기기 크기 × 시작/진행/결과 아홉 화면을 실제로 재고 스크린샷 확인
- 측정 스크립트에 검사 3종을 넣어 눈으로 안 놓치게 함 — **조작 버튼이 안전영역 밖으로 나가는지**, **안쪽 컨테이너가 몰래 스크롤되는지**, **차트가 패널을 벗어나는지**
- 한 판 완주 e2e(로그인·비로그인) 통과 — 진행 중 미래 캔들 노출 없음, 비로그인 서버 호출 0회
- 실패 응답 e2e 5종 통과
- 데스크톱 1280 / 태블릿 768 회귀 확인 — 차트 260px, 패널 이탈 0, 가로 넘침 0
- `npx tsc --noEmit` · `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_