### PR TITLE
fix(game): 최대 버튼을 매수·매도 각각으로 나누고 수수료를 반영

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -18,7 +18,7 @@ import { Play, Flag, TrendingUp, Coins, Wallet, RotateCcw, Eye } from "lucide-re
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { reqGetNcavDailyList, selectNcavDailyList } from "@/lib/features/algorithmTrade/algorithmTradeSlice";
 
-import { avgPrice } from "@/lib/paper/engine";
+import { avgPrice, quoteBuy } from "@/lib/paper/engine";
 import { CONTEXT_DAYS, TOTAL_DAYS, type ReplayRound, type ReplayHistoryItem } from "@/lib/paper/round";
 import { buildLocalRound, loadLocal, saveLocal, advanceLocal, giveUpLocal } from "@/lib/paper/localRound";
 import { getReplayState, startReplayRound, advanceReplayRound, giveUpReplayRound } from "@/lib/features/paper/replayAPI";
@@ -170,7 +170,16 @@ export default function ReplayGamePage() {
     const totalRate = round?.seed ? (totalPnl / round.seed) * 100 : 0;
     const avg = round ? avgPrice({ qty: round.qty, cost_basis: round.cost_basis }) : 0;
 
-    const maxBuy = price > 0 ? Math.floor((round?.cash ?? 0) / price) : 0;
+    // cash / price 만으로는 수수료가 빠진다 — 현금이 가격으로 딱 나누어떨어지면
+    // 최대매수를 누르고 사기를 눌렀을 때 "현금이 부족합니다"로 거절당한다.
+    // 실제 견적(quoteBuy)으로 확인해 들어가는 수량까지 줄인다. 한두 번이면 끝난다.
+    const maxBuy = useMemo(() => {
+        const cash = round?.cash ?? 0;
+        if (price <= 0) return 0;
+        let n = Math.floor(cash / price);
+        while (n > 0 && !quoteBuy({ price, qty: n, cash }).ok) n--;
+        return n;
+    }, [price, round?.cash]);
 
     // 사고판 지점을 차트에 찍는다. 빨강이 매수, 초록이 매도 — 버튼 색과 같다.
     // 수량 라벨은 체결이 적을 때만 붙인다. 많아지면 서로 겹쳐 오히려 안 읽힌다.
@@ -339,9 +348,15 @@ export default function ReplayGamePage() {
                                                     {n}
                                                 </button>
                                             ))}
+                                            {/* 수량 칸 하나를 사기·팔기가 같이 쓰므로 "최대"도 한쪽만
+                                                가리킬 수 없다. 현금 기준과 보유 기준을 따로 둔다. */}
                                             <button onClick={() => setQty(Math.max(1, maxBuy))} disabled={maxBuy < 1}
-                                                className="min-h-[36px] px-2 sm:px-2.5 rounded-lg text-[11px] font-bold text-neutral-500 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40">
-                                                최대
+                                                className="min-h-[36px] px-1.5 sm:px-2.5 rounded-lg text-[10px] sm:text-[11px] font-bold whitespace-nowrap text-red-500/90 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40">
+                                                최대매수
+                                            </button>
+                                            <button onClick={() => setQty(round.qty)} disabled={round.qty < 1}
+                                                className="min-h-[36px] px-1.5 sm:px-2.5 rounded-lg text-[10px] sm:text-[11px] font-bold whitespace-nowrap text-[#16a34a] border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40">
+                                                전량매도
                                             </button>
                                         </div>
                                     </div>


### PR DESCRIPTION
## 왜

수량 칸 하나를 사기·팔기가 같이 쓰는데 `최대` 는 `floor(cash / price)` 만 봤다. 주식을 들고 있어도 **전량 매도 수량을 넣을 방법이 없었다.** 버튼 하나가 두 뜻을 가질 수 없어 둘로 나눈다.

| 버튼 | 기준 | 색 | 비활성 조건 |
|---|---|---|---|
| 최대매수 | 현금 | 빨강 (사기와 동일) | 한 주도 못 살 때 |
| 전량매도 | 보유 | 초록 (팔기와 동일) | 보유 0 |

## 겸사겸사 고친 버그

`floor(cash / price)` 는 **수수료를 빼먹는다.** 현금이 가격으로 딱 나누어떨어지면 — 예컨대 시드 1,000만 / 종가 10,000 — 1000주가 들어가고, 대금 10,000,000 + 수수료 1,500 이 현금을 넘어 누르자마자 `현금이 부족합니다` 로 거절당했다.

브라우저에서 그 판을 만들어 재현한 뒤, 실제 견적(`quoteBuy`)으로 확인해 들어가는 수량까지 줄이도록 고쳤다. 매매 규칙을 한 곳(`lib/paper/engine.ts`)에서만 가져오므로 수수료율이 바뀌어도 따라온다. 루프는 한두 번이면 끝난다.

```
고치기 전: 1000주 → 대금 10,000,000 + 수수료 1,500 / 현금 10,000,000 → ❌ 거절
고친 후:    999주 → 대금  9,990,000 + 수수료 1,498 / 현금 10,000,000 → ✅ 체결
```

## 검증

브라우저에서:

- 보유 0 일 때 전량매도 비활성 · 최대매수 = `floor(cash/price)`
- 100주 보유 시 전량매도가 100, 최대매수는 **줄어든 현금 기준**으로 다시 계산
- 전량매도 수량으로 실제로 팔면 보유가 0 이 되는지
- 수수료 경계 판에서 최대매수 → 사기가 거절 없이 체결되는지
- 375/390 에서 한 줄로 들어가고 버튼 라벨이 안 접히는지 (`whitespace-nowrap`, 모바일만 10px)

회귀: 모바일 한 화면(320/375/390/412), 매매 마커 e2e(로그인·비로그인), 한 판 완주 e2e, 데스크톱 1280 / 태블릿 768, `tsc --noEmit`, `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_