### PR TITLE
feat(game): /game 을 내 운용사로 — 대시보드·분기 보고서·리서치 도구

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-// 블라인드 차트 리플레이 — 어느 종목인지, 언제인지 모르는 60 거래일을 하루씩 넘기며 사고판다.
+// 내 운용사 — 블라인드 차트 리플레이를 "분기 운용" 으로 감싼 게임.
+//
+// 한 판은 언제나 시드 1,000만원이라 실력만 잰다. 그 성적을 보고 고객이 돈을 맡기거나
+// 빼가고(AUM), 회사는 맡은 돈에서 보수를 받아 리서치 도구를 산다. 규칙은 lib/paper/firm.ts.
+//
+// 판 자체는 그대로다 — 어느 종목인지, 언제인지 모르는 60 거래일을 하루씩 넘기며 사고판다.
 //
 // 앞 20일은 컨텍스트로 한 번에 열어 준다(판단 근거가 있어야 한다). 나머지 40일은 하루씩.
 // 끝나면 수익률과 정답(종목명·기간)을 열고, 그냥 사서 들고 있었을 때와 나란히 놓는다.
@@ -13,7 +18,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { Play, Flag, TrendingUp, Coins, Wallet, RotateCcw, Eye } from "lucide-react";
+import { Play, Flag, TrendingUp, Coins, Wallet, RotateCcw, Eye, Building2, Lock, Check } from "lucide-react";
 
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { reqGetNcavDailyList, selectNcavDailyList } from "@/lib/features/algorithmTrade/algorithmTradeSlice";
@@ -21,7 +26,9 @@ import { reqGetNcavDailyList, selectNcavDailyList } from "@/lib/features/algorit
 import { avgPrice, quoteBuy } from "@/lib/paper/engine";
 import { CONTEXT_DAYS, TOTAL_DAYS, type ReplayRound, type ReplayHistoryItem } from "@/lib/paper/round";
 import { buildLocalRound, loadLocal, saveLocal, advanceLocal, giveUpLocal } from "@/lib/paper/localRound";
-import { getReplayState, startReplayRound, advanceReplayRound, giveUpReplayRound } from "@/lib/features/paper/replayAPI";
+import { getReplayState, startReplayRound, advanceReplayRound, giveUpReplayRound, buyTool } from "@/lib/features/paper/replayAPI";
+import { TOOLS, INITIAL_AUM, rankOf, fmtMoney, type Firm } from "@/lib/paper/firm";
+import { movingAverage, bollinger } from "@/lib/paper/indicators";
 
 import {
     fmtKrw, KpiCard, PnlIcon, pnlIconBg, pnlValueColor, pnlAccentColor,
@@ -49,8 +56,10 @@ export default function ReplayGamePage() {
 
     const [round, setRound] = useState<ReplayRound | null>(null);
     const [history, setHistory] = useState<ReplayHistoryItem[]>([]);
-    const [coins, setCoins] = useState(0);
+    const [firm, setFirm] = useState<Firm | null>(null);
     const [bestReturn, setBestReturn] = useState<number | null>(null);
+    // 산 도구 중 지금 켜 둔 것. 사자마자 켜진다.
+    const [activeTools, setActiveTools] = useState<string[]>([]);
     const [loading, setLoading] = useState(true);
     const [busy, setBusy] = useState(false);
     const [qty, setQty] = useState(10);
@@ -80,8 +89,9 @@ export default function ReplayGamePage() {
             if (res.success) {
                 setRound(res.round);
                 setHistory(res.history ?? []);
-                setCoins(res.wallet?.coins ?? 0);
+                setFirm(res.firm ?? null);
                 setBestReturn(res.wallet?.best_return ?? null);
+                setActiveTools(res.firm?.tools ?? []);
             }
             setLoading(false);
         });
@@ -119,7 +129,7 @@ export default function ReplayGamePage() {
                     const st = await getReplayState();
                     if (st.success) {
                         setHistory(st.history ?? []);
-                        setCoins(st.wallet?.coins ?? 0);
+                        setFirm(st.firm ?? null);
                         setBestReturn(st.wallet?.best_return ?? null);
                     }
                 }
@@ -142,7 +152,7 @@ export default function ReplayGamePage() {
                 if (!res.success) { addToast("error", res.error); return; }
                 setRound(res.round);
                 const st = await getReplayState();
-                if (st.success) { setHistory(st.history ?? []); setCoins(st.wallet?.coins ?? 0); setBestReturn(st.wallet?.best_return ?? null); }
+                if (st.success) { setHistory(st.history ?? []); setFirm(st.firm ?? null); setBestReturn(st.wallet?.best_return ?? null); }
             } else {
                 setRound(giveUpLocal(round));
             }
@@ -180,6 +190,43 @@ export default function ReplayGamePage() {
         while (n > 0 && !quoteBuy({ price, qty: n, cash }).ok) n--;
         return n;
     }, [price, round?.cash]);
+
+    const purchase = useCallback(async (toolId: string) => {
+        setBusy(true);
+        try {
+            const res = await buyTool(toolId);
+            if (!res.success) { addToast("error", res.error); return; }
+            setFirm(res.firm ?? null);
+            setActiveTools(res.firm?.tools ?? []);   // 사면 바로 켠다
+            addToast("success", "도구를 들였습니다. 다음 분기부터 차트에 나타납니다.");
+        } finally {
+            setBusy(false);
+        }
+    }, [addToast]);
+
+    const toggleTool = useCallback((id: string) => {
+        setActiveTools(prev => prev.includes(id) ? prev.filter(t => t !== id) : [...prev, id]);
+    }, []);
+
+    // 해금하고 켜 둔 리서치 도구를 가격 위에 겹쳐 그린다.
+    // 별도 영역을 만들지 않는 이유는 모바일에서 차트 높이를 더 쓸 수 없기 때문이다.
+    const overlays = useMemo(() => {
+        const owned = firm?.tools ?? [];
+        const on = (id: string) => owned.includes(id) && activeTools.includes(id);
+        const closes = visible.map(c => c.c);
+        const out: { name: string; data: (number | null)[]; color: string; dash?: string }[] = [];
+
+        if (on("ma")) {
+            out.push({ name: "5일선", data: movingAverage(closes, 5), color: "#f59e0b" });
+            out.push({ name: "20일선", data: movingAverage(closes, 20), color: "#8b5cf6" });
+        }
+        if (on("bb")) {
+            const b = bollinger(closes, 20, 2);
+            out.push({ name: "밴드상단", data: b.upper, color: "#94a3b8", dash: "3 3" });
+            out.push({ name: "밴드하단", data: b.lower, color: "#94a3b8", dash: "3 3" });
+        }
+        return out;
+    }, [firm?.tools, activeTools, visible]);
 
     // 사고판 지점을 차트에 찍는다. 빨강이 매수, 초록이 매도 — 버튼 색과 같다.
     // 수량 라벨은 체결이 적을 때만 붙인다. 많아지면 서로 겹쳐 오히려 안 읽힌다.
@@ -242,7 +289,13 @@ export default function ReplayGamePage() {
                     : "py-6 sm:py-10 pb-10 md:pb-24 gap-5",
             )}>
 
-                {!round && <StartScreen onStart={start} busy={busy} isLoggedIn={isLoggedIn} coins={coins} bestReturn={bestReturn} history={history} />}
+                {!round && (
+                    <FirmDashboard
+                        onStart={start} busy={busy} isLoggedIn={isLoggedIn}
+                        firm={firm} bestReturn={bestReturn} history={history}
+                        onBuy={purchase} activeTools={activeTools} onToggle={toggleTool}
+                    />
+                )}
 
                 {round && (
                     <>
@@ -250,13 +303,15 @@ export default function ReplayGamePage() {
                         <header className="flex items-center justify-between gap-3 shrink-0">
                             <div className="min-w-0">
                                 <p className="text-[10px] font-black uppercase tracking-[0.2em] text-[#a1730a] dark:text-[#e3b34a] sm:mb-1.5">
-                                    {round.status === "done" ? "Result" : `Day ${round.cursor - CONTEXT_DAYS + 1} / ${TOTAL_DAYS - CONTEXT_DAYS + 1}`}
+                                    {round.status === "done"
+                                        ? `${(firm?.quarters ?? 0) || 1}분기 보고서`
+                                        : `${(firm?.quarters ?? 0) + 1}분기 · Day ${round.cursor - CONTEXT_DAYS + 1}/${TOTAL_DAYS - CONTEXT_DAYS + 1}`}
                                 </p>
                                 <h1 className="hidden sm:block text-xl sm:text-2xl font-black text-neutral-900 dark:text-white break-keep">
-                                    {round.status === "done" ? "한 판 끝" : "이 회사, 지금 사시겠습니까?"}
+                                    {round.status === "done" ? "분기 운용 종료" : "이 회사, 지금 사시겠습니까?"}
                                 </h1>
                                 <p className="sm:hidden text-[15px] font-black text-neutral-900 dark:text-white leading-tight">
-                                    {round.status === "done" ? "한 판 끝" : "사시겠습니까?"}
+                                    {round.status === "done" ? "분기 종료" : "사시겠습니까?"}
                                 </p>
                             </div>
                             {round.status === "playing" ? (
@@ -267,12 +322,12 @@ export default function ReplayGamePage() {
                             ) : (
                                 <button onClick={reset}
                                     className="shrink-0 inline-flex items-center gap-1.5 min-h-[40px] px-3 rounded-xl text-xs font-black text-white bg-[#0d2a1a] dark:bg-[#e3b34a] dark:text-[#2a1c00] hover:opacity-90 transition-opacity">
-                                    <RotateCcw size={14} /> 한 판 더
+                                    <RotateCcw size={14} /> 다음 분기
                                 </button>
                             )}
                         </header>
 
-                        {round.status === "done" && <ResultBanner round={round} />}
+                        {round.status === "done" && <QuarterReport round={round} isLoggedIn={isLoggedIn} />}
 
                         {/* ── 차트 ──────────────────────────
                             남는 세로 공간을 전부 차트가 가져간다. 화면이 작으면 차트만 줄고
@@ -309,6 +364,7 @@ export default function ReplayGamePage() {
                                     <LineChart
                                         height="100%"
                                         markers={markers}
+                                        overlays={overlays}
                                         legend_disable={round.qty < 1}
                                         category_array={visible.map(c => c.d.slice(4))}
                                         data_array={[
@@ -394,7 +450,7 @@ export default function ReplayGamePage() {
                         {round.status === "done" && !isLoggedIn && (
                             <div className="shrink-0 rounded-2xl border border-[#e3b34a]/40 bg-[#fdf6e9] dark:bg-[#1c1608] px-4 py-2.5 text-[12px] sm:text-[13px] text-[#8a6206] dark:text-[#e3b34a] break-keep">
                                 <Link href="/login?callbackUrl=%2Fgame" className="underline font-bold">로그인</Link>
-                                하면 기록과 코인이 쌓입니다.
+                                하면 이 성적이 회사에 반영됩니다.
                             </div>
                         )}
                     </>
@@ -417,37 +473,56 @@ function MiniStat({ label, value, sub, valueColor }: { label: string; value: str
 }
 
 // ─────────────────────────────────────────────────────────
-function StartScreen({ onStart, busy, isLoggedIn, coins, bestReturn, history }: {
+/** 회사 대시보드 — 판이 없을 때. 시작 버튼까지 한 화면에 들어와야 한다. */
+function FirmDashboard({ onStart, busy, isLoggedIn, firm, bestReturn, history, onBuy, activeTools, onToggle }: {
     onStart: () => void; busy: boolean; isLoggedIn: boolean;
-    coins: number; bestReturn: number | null; history: ReplayHistoryItem[];
+    firm: Firm | null; bestReturn: number | null; history: ReplayHistoryItem[];
+    onBuy: (id: string) => void; activeTools: string[]; onToggle: (id: string) => void;
 }) {
+    const aum = firm?.aum ?? INITIAL_AUM;
+    const owned = firm?.tools ?? [];
+
     return (
         <>
             <header>
                 <p className="text-[10px] font-black uppercase tracking-[0.2em] text-[#a1730a] dark:text-[#e3b34a] mb-1.5">
-                    Blind Replay
+                    {isLoggedIn ? firm?.rank ?? rankOf(aum) : "체험 운용"}
                 </p>
-                <h1 className="text-2xl sm:text-3xl font-black text-neutral-900 dark:text-white break-keep">
-                    어느 회사인지 모른 채,<br />60일을 살아보기
+                <h1 className="text-xl sm:text-3xl font-black text-neutral-900 dark:text-white break-keep">
+                    {firm?.name ?? "내 운용사"}
                 </h1>
-                {/* 아래 규칙 목록과 같은 말이라, 화면이 좁으면 접는다 */}
+                {/* 아래 규칙·수치와 같은 말이라, 화면이 좁으면 접는다 */}
                 <p className="hidden sm:block text-[13px] sm:text-[15px] text-neutral-500 dark:text-neutral-400 mt-3 leading-[1.8] break-keep max-w-md">
-                    종목명도 날짜도 가린 실제 과거 차트를 하루씩 넘기며 사고팝니다.
-                    끝나면 성적과 정답을 함께 엽니다.
+                    분기마다 모델 포트폴리오 1,000만원으로 실력을 증명합니다.
+                    고객은 그 성적을 보고 돈을 맡기거나 뺍니다.
                 </p>
             </header>
 
-            <SectionPanel>
-                <ul className="flex flex-col gap-3 text-[14px] text-neutral-600 dark:text-neutral-300">
+            {isLoggedIn ? (
+                <div className="grid grid-cols-2 gap-2 sm:gap-4">
+                    <MiniStat label="고객 자금 AUM" value={fmtMoney(aum)} sub={firm?.rank ?? rankOf(aum)} />
+                    <MiniStat label="회사 자금" value={fmtMoney(firm?.cash ?? 0)} sub="누적 보수" />
+                    <MiniStat label="운용 분기" value={`${firm?.quarters ?? 0}분기`} sub={`${history.length}건 기록`} />
+                    <MiniStat label="최고 수익률" value={bestReturn === null ? "—" : pct(bestReturn)} sub="한 분기 최고" />
+                </div>
+            ) : (
+                <div className="rounded-2xl border border-[#e3b34a]/40 bg-[#fdf6e9] dark:bg-[#1c1608] px-4 py-3 text-[13px] text-[#8a6206] dark:text-[#e3b34a] break-keep">
+                    <Link href="/login?callbackUrl=%2Fgame" className="underline font-bold">로그인</Link>
+                    하면 내 운용사가 생기고, 성적이 고객 자금과 보수로 쌓입니다.
+                </div>
+            )}
+
+            <SectionPanel className="p-3 sm:p-5">
+                <ul className="flex flex-col gap-1.5 sm:gap-3 text-[12px] sm:text-[14px] leading-[1.5] sm:leading-normal text-neutral-600 dark:text-neutral-300">
                     {[
-                        `가상 1,000만원으로 시작합니다.`,
+                        `시드 1,000만원으로 60 거래일(한 분기)을 운용합니다.`,
                         `앞 ${CONTEXT_DAYS}일을 먼저 보고, 남은 ${TOTAL_DAYS - CONTEXT_DAYS}일을 하루씩 넘깁니다.`,
                         // 판이 도는 중에는 화면이 좁아 이 규칙을 적을 자리가 없다 — 여기서 한 번 말한다.
                         `체결은 그날 종가. 수수료 0.015%, 매도 거래세 0.18%. 마지막 날 자동 청산.`,
-                        `그냥 사서 들고 있었을 때와 나란히 놓고 채점합니다.`,
+                        `벤치마크(그냥 사서 들고 있기)와 견주어 고객 자금이 들고 납니다.`,
                     ].map((line, i) => (
                         <li key={i} className="flex gap-3 break-keep">
-                            <span className="font-mono text-[11px] font-black text-[#a1730a] dark:text-[#e3b34a] pt-1 shrink-0">
+                            <span className="font-mono text-[10px] sm:text-[11px] font-black text-[#a1730a] dark:text-[#e3b34a] pt-0.5 shrink-0">
                                 {String(i + 1).padStart(2, "0")}
                             </span>
                             <span>{line}</span>
@@ -456,34 +531,52 @@ function StartScreen({ onStart, busy, isLoggedIn, coins, bestReturn, history }: 
                 </ul>
 
                 <button onClick={onStart} disabled={busy}
-                    className="mt-6 w-full inline-flex items-center justify-center gap-2 min-h-[52px] rounded-xl bg-gradient-to-b from-[#f7dc8c] to-[#d9a52a] hover:from-[#ffe7a4] hover:to-[#e6b13a] text-[#2a1c00] font-black text-[15px] disabled:opacity-50 transition-all">
+                    className="mt-3 sm:mt-5 w-full inline-flex items-center justify-center gap-2 min-h-[52px] rounded-xl bg-gradient-to-b from-[#f7dc8c] to-[#d9a52a] hover:from-[#ffe7a4] hover:to-[#e6b13a] text-[#2a1c00] font-black text-[15px] disabled:opacity-50 transition-all">
                     <Play size={16} strokeWidth={2.6} />
-                    {busy ? "판을 만드는 중…" : "한 판 시작"}
+                    {busy ? "종목을 고르는 중…" : `${(firm?.quarters ?? 0) + 1}분기 운용 시작`}
                 </button>
             </SectionPanel>
 
             {isLoggedIn && (
-                <>
-                    <div className="grid grid-cols-2 gap-2 sm:hidden">
-                        <MiniStat label="코인" value={coins.toLocaleString()} sub="이길 때마다 쌓입니다" />
-                        <MiniStat label="최고 수익률" value={bestReturn === null ? "—" : pct(bestReturn)} sub={`${history.length}판 완료`} />
-                    </div>
-                    <div className="hidden sm:grid grid-cols-2 gap-3 sm:gap-4">
-                        <KpiCard label="코인" value={coins.toLocaleString()} sub="판을 이길 때마다 쌓입니다"
-                            icon={<Coins size={15} />} iconBg="bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500" />
-                        <KpiCard label="최고 수익률" value={bestReturn === null ? "—" : pct(bestReturn)} sub={`${history.length}판 완료`}
-                            icon={<TrendingUp size={15} />} iconBg="bg-neutral-100 dark:bg-[#2c2a26] text-neutral-500" />
-                    </div>
-                </>
+                <SectionPanel className="p-4 sm:p-5">
+                    <SectionHeader icon={<Building2 size={16} />} title="리서치실"
+                        subtitle={`회사 자금 ${fmtMoney(firm?.cash ?? 0)}원`} />
+                    <ul className="flex flex-col gap-2">
+                        {TOOLS.map(t => {
+                            const have = owned.includes(t.id);
+                            const on = activeTools.includes(t.id);
+                            return (
+                                <li key={t.id} className="flex items-center justify-between gap-3 rounded-xl border border-neutral-200 dark:border-[#35332e] px-3 py-2">
+                                    <div className="min-w-0">
+                                        <div className="text-[13px] font-black text-neutral-900 dark:text-white truncate">{t.name}</div>
+                                        <div className="text-[11px] text-neutral-400 truncate">{t.detail}</div>
+                                    </div>
+                                    {have ? (
+                                        <button onClick={() => onToggle(t.id)}
+                                            className={cn("shrink-0 inline-flex items-center gap-1 min-h-[36px] px-3 rounded-lg text-[11px] font-bold border transition-colors",
+                                                on ? "border-[#16a34a]/50 text-[#16a34a]" : "border-neutral-200 dark:border-[#35332e] text-neutral-400")}>
+                                            <Check size={12} /> {on ? "켜짐" : "꺼짐"}
+                                        </button>
+                                    ) : (
+                                        <button onClick={() => onBuy(t.id)} disabled={busy || (firm?.cash ?? 0) < t.price}
+                                            className="shrink-0 inline-flex items-center gap-1 min-h-[36px] px-3 rounded-lg text-[11px] font-bold text-neutral-600 dark:text-neutral-300 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40">
+                                            <Lock size={12} /> {fmtMoney(t.price)}
+                                        </button>
+                                    )}
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </SectionPanel>
             )}
 
             {history.length > 0 && (
-                <SectionPanel>
-                    <SectionHeader icon={<Flag size={16} />} title="지난 판" subtitle={`최근 ${history.length}판`} />
+                <SectionPanel className="p-4 sm:p-5">
+                    <SectionHeader icon={<Flag size={16} />} title="지난 분기" subtitle={`최근 ${history.length}분기`} />
                     <ul className="flex flex-col divide-y divide-neutral-100 dark:divide-[#2c2a26] text-sm">
                         {history.map(h => {
                             const win = (h.final_return ?? 0) >= 0;
-                            const beat = (h.final_return ?? 0) > (h.bh_return ?? 0);
+                            const flow = (h.aum_after ?? 0) - (h.aum_before ?? 0);
                             return (
                                 <li key={h.id} className="flex items-center justify-between gap-3 py-2.5">
                                     <div className="min-w-0">
@@ -493,7 +586,12 @@ function StartScreen({ onStart, busy, isLoggedIn, coins, bestReturn, history }: 
                                     <div className="text-right shrink-0">
                                         <div className={cn("font-mono text-xs font-black", pnlValueColor(win))}>{pct(h.final_return ?? 0)}</div>
                                         <div className="text-[11px] text-neutral-400">
-                                            그냥 보유 {pct(h.bh_return ?? 0)}{beat ? " · 이김" : ""}
+                                            벤치마크 {pct(h.bh_return ?? 0)}
+                                            {h.aum_after !== null && (
+                                                <span className={cn("ml-1 font-bold", pnlValueColor(flow >= 0))}>
+                                                    · 자금 {flow >= 0 ? "+" : "−"}{fmtMoney(Math.abs(flow))}
+                                                </span>
+                                            )}
                                         </div>
                                     </div>
                                 </li>
@@ -507,35 +605,56 @@ function StartScreen({ onStart, busy, isLoggedIn, coins, bestReturn, history }: 
 }
 
 // ─────────────────────────────────────────────────────────
-function ResultBanner({ round }: { round: ReplayRound }) {
+/** 분기 보고서 — 성적과 그것이 회사에 미친 결과를 나란히. */
+function QuarterReport({ round, isLoggedIn }: { round: ReplayRound; isLoggedIn: boolean }) {
     const mine = round.final_return ?? 0;
     const bh = round.bh_return ?? 0;
     const beat = mine > bh;
 
+    // 정산은 서버가 남긴 값을 그대로 쓴다 — 규칙이 바뀌어도 지난 기록은 그때 값이어야 한다.
+    const settled = round.aum_before !== null && round.aum_after !== null;
+    const flow = settled ? round.aum_after! - round.aum_before! : 0;
+    const flowPct = settled && round.aum_before! > 0 ? (flow / round.aum_before!) * 100 : 0;
+    const feeTotal = (round.fee_base ?? 0) + (round.fee_perf ?? 0);
+
     return (
         <SectionPanel className={cn("shrink-0 border-2 p-3 sm:p-5", beat ? "border-[#e3b34a]/60" : "border-neutral-200 dark:border-[#35332e]")}>
-            <div className="flex flex-col gap-1.5 sm:gap-4">
+            <div className="flex flex-col gap-1.5 sm:gap-3">
                 <div className="flex items-baseline justify-between gap-3 flex-wrap">
                     <div>
                         <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 sm:mb-1">내 수익률</p>
                         <p className={cn("text-2xl sm:text-4xl font-black font-mono", pnlValueColor(mine >= 0))}>{pct(mine)}</p>
                     </div>
                     <div className="text-right">
-                        <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 sm:mb-1">그냥 사서 들고 있었다면</p>
+                        <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 sm:mb-1">벤치마크</p>
                         <p className={cn("text-lg sm:text-xl font-black font-mono", pnlValueColor(bh >= 0))}>{pct(bh)}</p>
                     </div>
                 </div>
 
                 <p className="text-[12px] sm:text-[14px] font-bold break-keep text-neutral-700 dark:text-neutral-200">
                     {beat
-                        ? `그냥 들고 있는 것보다 ${(mine - bh).toFixed(2)}%p 더 벌었습니다.`
-                        : `그냥 들고 있었으면 ${(bh - mine).toFixed(2)}%p 더 벌었습니다.`}
-                    {(round.coins_earned ?? 0) > 0 && (
-                        <span className="text-[#a1730a] dark:text-[#e3b34a] inline-flex items-center gap-1 ml-2">
-                            <Coins size={13} /> 코인 +{round.coins_earned}
-                        </span>
-                    )}
+                        ? `벤치마크보다 ${(mine - bh).toFixed(2)}%p 더 벌었습니다.`
+                        : `벤치마크가 ${(bh - mine).toFixed(2)}%p 더 벌었습니다.`}
                 </p>
+
+                {settled ? (
+                    <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 text-[12px] sm:text-[13px] border-t border-neutral-100 dark:border-[#35332e] pt-1.5 sm:pt-3">
+                        <span className="text-neutral-500 dark:text-neutral-400">
+                            고객 자금{" "}
+                            <b className={pnlValueColor(flow >= 0)}>{flowPct >= 0 ? "+" : ""}{flowPct.toFixed(1)}%</b>
+                            {" → "}
+                            <b className="text-neutral-900 dark:text-white font-mono">{fmtMoney(round.aum_after!)}</b>
+                        </span>
+                        <span className="text-[#a1730a] dark:text-[#e3b34a] font-bold">
+                            보수 +{fmtMoney(feeTotal)}
+                            <span className="font-normal opacity-70"> (운용 {fmtMoney(round.fee_base ?? 0)} · 성과 {fmtMoney(round.fee_perf ?? 0)})</span>
+                        </span>
+                    </div>
+                ) : isLoggedIn ? null : (
+                    <p className="text-[11px] text-neutral-400 border-t border-neutral-100 dark:border-[#35332e] pt-1.5">
+                        체험 운용이라 회사에는 반영되지 않았습니다.
+                    </p>
+                )}
             </div>
         </SectionPanel>
     );

--- a/cf-idiotquant/components/LineChart.tsx
+++ b/cf-idiotquant/components/LineChart.tsx
@@ -80,14 +80,19 @@ export default function LineChart(props: any) {
     const data = useMemo(() => {
         const categories = props.category_array || [];
         const series = props.data_array || [];
+        const overlays = props.overlays || [];
         return categories.map((label: any, idx: number) => {
             const row: any = { label };
             series.forEach((s: any) => {
                 row[s.name] = s.data[idx] ?? null;
             });
+            // 보조지표 — 값이 없는 앞 구간은 null 로 두어 선이 바닥까지 떨어지지 않게 한다
+            overlays.forEach((o: any) => {
+                row[o.name] = o.data[idx] ?? null;
+            });
             return row;
         });
-    }, [props.data_array, props.category_array]);
+    }, [props.data_array, props.category_array, props.overlays]);
 
     // 상단 미니바 혹은 인라인 배치를 판단하는 플래그
     const isMiniMode = props.height <= 36 || props.show_yaxis_label === false;
@@ -188,6 +193,28 @@ export default function LineChart(props: any) {
                         />
                     );
                 })}
+
+                {/* 선택 옵션: 가격 위에 겹쳐 그리는 보조지표(이동평균선·볼린저밴드).
+                    별도 영역을 만들지 않고 겹치는 이유는 모바일에서 차트 높이를 더 못 쓰기
+                    때문이다. 면은 칠하지 않고 얇은 선만 남긴다. */}
+                {props.overlays?.map((o: any) => (
+                    <Area
+                        key={`ov_${o.name}`}
+                        type="monotone"
+                        dataKey={o.name}
+                        name={o.name}
+                        stroke={o.color}
+                        strokeWidth={1.2}
+                        strokeDasharray={o.dash}
+                        fill="none"
+                        fillOpacity={0}
+                        dot={false}
+                        activeDot={false}
+                        isAnimationActive={false}
+                        legendType="none"
+                        connectNulls={false}
+                    />
+                ))}
 
                 {/* 선택 옵션: 특정 지점에 점을 찍는다. x 는 category_array 의 값과 같아야 한다.
                     (모의투자에서 매수·매도 시점을 표시하는 데 쓴다) */}

--- a/cf-idiotquant/lib/features/paper/replayAPI.ts
+++ b/cf-idiotquant/lib/features/paper/replayAPI.ts
@@ -2,6 +2,7 @@
 // 비로그인은 lib/paper/localRound.ts 가 같은 모양을 브라우저 안에서 다룬다.
 
 import type { ReplayRound, ReplayHistoryItem } from "@/lib/paper/round";
+import type { Firm } from "@/lib/paper/firm";
 
 async function replayRequest(method: "GET" | "POST", body?: object) {
     try {
@@ -39,6 +40,7 @@ export type ReplayResponse =
         done?: boolean;
         history?: ReplayHistoryItem[];
         wallet?: { coins: number; best_streak: number; best_return: number | null };
+        firm?: Firm;
     }
     | { success: false; status: number; error: string };
 
@@ -58,3 +60,10 @@ export const advanceReplayRound = (roundId: string, trade?: { side: "buy" | "sel
 
 export const giveUpReplayRound = (roundId: string): Promise<ReplayResponse> =>
     replayRequest("POST", { action: "giveup", round_id: roundId });
+
+/** 리서치 도구 구매. 성공하면 갱신된 firm 이 온다. */
+export const buyTool = (toolId: string): Promise<ReplayResponse> =>
+    replayRequest("POST", { action: "buy-tool", tool_id: toolId });
+
+export const renameFirm = (name: string): Promise<ReplayResponse> =>
+    replayRequest("POST", { action: "rename-firm", name });

--- a/cf-idiotquant/lib/paper/firm.ts
+++ b/cf-idiotquant/lib/paper/firm.ts
@@ -1,0 +1,104 @@
+// 운용사 규칙 (클라이언트 판).
+//
+// 워커의 src/lib/firmRules.js 와 짝이다. 화면이 "이번 분기에 얼마 벌었다"를 보여 주려면
+// 서버와 같은 계산을 해야 해서, 상수나 식이 어긋나면 화면과 서버가 다른 숫자를 말한다.
+// 한쪽을 고치면 반드시 다른 쪽도 고칠 것.
+// (레포가 갈라져 있어 코드를 공유할 수 없어 감수하는 중복이다 — engine·round 와 같은 사정)
+//
+// ── 왜 시드는 고정인데 AUM 은 자라는가 ──────────────────────────────────
+// 한 판은 언제나 1,000만원짜리 모델 포트폴리오로 굴린다 — 실력만 재기 위해서다.
+// 고객은 그 성적(트랙레코드)을 보고 돈을 맡기고, 회사는 맡은 돈에서 보수를 받는다.
+// 성적은 실력, AUM 은 그 실력이 벌어들이는 것.
+
+export const INITIAL_AUM = 100_000_000;
+export const MIN_AUM = 10_000_000;
+
+const FLOW_MIN = -40;
+const FLOW_MAX = 50;
+const BASE_FEE_BP = 25;     // 연 1% ÷ 4분기
+const PERF_FEE_PCT = 10;    // 초과수익분의 10%
+
+const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
+
+export interface Firm {
+    name: string | null;
+    aum: number;
+    cash: number;
+    quarters: number;
+    tools: string[];
+    rank: string;
+}
+
+export interface Tool {
+    id: string;
+    name: string;
+    detail: string;
+    price: number;
+}
+
+/** 분기 성적 → 고객 자금 유출입률(%). 벤치마크 초과가 주된 동력, 절대 손실은 따로 벌을 받는다. */
+export function flowRate(finalReturn: number, bhReturn: number): number {
+    const excess = (Number(finalReturn) || 0) - (Number(bhReturn) || 0);
+    const loss = Math.min(Number(finalReturn) || 0, 0);
+    return clamp(excess * 3 + loss * 1.5, FLOW_MIN, FLOW_MAX);
+}
+
+export function nextAum(aum: number, finalReturn: number, bhReturn: number): number {
+    const base = Math.max(Number(aum) || 0, MIN_AUM);
+    return Math.max(Math.round(base * (1 + flowRate(finalReturn, bhReturn) / 100)), MIN_AUM);
+}
+
+export function baseFee(aum: number): number {
+    return Math.floor((Math.max(Number(aum) || 0, 0) * BASE_FEE_BP) / 10_000);
+}
+
+export function perfFee(aum: number, finalReturn: number, bhReturn: number): number {
+    const excess = (Number(finalReturn) || 0) - (Number(bhReturn) || 0);
+    if (!(excess > 0)) return 0;
+    return Math.floor((Math.max(Number(aum) || 0, 0) * excess * PERF_FEE_PCT) / 10_000);
+}
+
+const RANKS = [
+    { min: 100_000_000_000, name: "대형 자산운용사" },
+    { min: 10_000_000_000, name: "헤지펀드" },
+    { min: 1_000_000_000, name: "중형 운용사" },
+    { min: 100_000_000, name: "부티크 운용사" },
+    { min: 0, name: "1인 사무실" },
+];
+
+export function rankOf(aum: number): string {
+    const v = Number(aum) || 0;
+    return RANKS.find(r => v >= r.min)!.name;
+}
+
+export const TOOLS: Tool[] = [
+    { id: "ma", name: "이동평균선", detail: "5일·20일", price: 300_000 },
+    { id: "bb", name: "볼린저밴드", detail: "20일 · 2σ", price: 1_000_000 },
+];
+
+export function settleQuarter(aum: number, finalReturn: number, bhReturn: number) {
+    const before = Math.max(Number(aum) || 0, MIN_AUM);
+    const fee = baseFee(before);
+    const perf = perfFee(before, finalReturn, bhReturn);
+    const after = nextAum(before, finalReturn, bhReturn);
+    return {
+        aumBefore: before, aumAfter: after,
+        flowRate: flowRate(finalReturn, bhReturn),
+        feeBase: fee, feePerf: perf, feeTotal: fee + perf,
+        rankBefore: rankOf(before), rankAfter: rankOf(after),
+    };
+}
+
+/** 억·만 단위로 짧게. 모바일에서 ₩1,090,000,000 은 칸을 넘긴다. */
+export function fmtMoney(won: number): string {
+    const v = Math.round(Number(won) || 0);
+    const sign = v < 0 ? "-" : "";
+    const a = Math.abs(v);
+    if (a >= 100_000_000) {
+        const eok = Math.floor(a / 100_000_000);
+        const man = Math.floor((a % 100_000_000) / 10_000);
+        return `${sign}${eok}억${man ? ` ${man.toLocaleString()}만` : ""}`;
+    }
+    if (a >= 10_000) return `${sign}${Math.floor(a / 10_000).toLocaleString()}만`;
+    return `${sign}${a.toLocaleString()}`;
+}

--- a/cf-idiotquant/lib/paper/indicators.ts
+++ b/cf-idiotquant/lib/paper/indicators.ts
@@ -1,0 +1,32 @@
+// 리서치 도구가 그리는 선. 종가 배열만 받는 순수 함수다.
+//
+// 값이 없는 구간(앞쪽 period-1 개)은 null 로 둔다 — 0 을 넣으면 차트가 바닥까지 떨어진다.
+
+/** 단순이동평균. 앞쪽 period-1 개는 계산할 수 없어 null. */
+export function movingAverage(closes: number[], period: number): (number | null)[] {
+    const out: (number | null)[] = [];
+    let sum = 0;
+    for (let i = 0; i < closes.length; i++) {
+        sum += closes[i];
+        if (i >= period) sum -= closes[i - period];
+        out.push(i >= period - 1 ? Math.round(sum / period) : null);
+    }
+    return out;
+}
+
+/** 볼린저밴드 — 이동평균 ± 표준편차 × mult. */
+export function bollinger(closes: number[], period = 20, mult = 2): {
+    upper: (number | null)[]; lower: (number | null)[];
+} {
+    const upper: (number | null)[] = [];
+    const lower: (number | null)[] = [];
+    for (let i = 0; i < closes.length; i++) {
+        if (i < period - 1) { upper.push(null); lower.push(null); continue; }
+        const win = closes.slice(i - period + 1, i + 1);
+        const mean = win.reduce((a, b) => a + b, 0) / period;
+        const sd = Math.sqrt(win.reduce((a, b) => a + (b - mean) ** 2, 0) / period);
+        upper.push(Math.round(mean + sd * mult));
+        lower.push(Math.round(mean - sd * mult));
+    }
+    return { upper, lower };
+}

--- a/cf-idiotquant/lib/paper/localRound.ts
+++ b/cf-idiotquant/lib/paper/localRound.ts
@@ -7,7 +7,7 @@
 // 매매 규칙은 lib/paper/engine.ts, 판의 규칙은 lib/paper/round.ts 한 곳에서만 나온다.
 
 import { SEED, quoteBuy, quoteSell, applyBuy, applySell, type BuyQuote, type SellQuote } from "./engine";
-import { TOTAL_DAYS, CONTEXT_DAYS, buyAndHoldReturn, coinsFor, type Candle, type ReplayRound, type ReplayOrder } from "./round";
+import { TOTAL_DAYS, CONTEXT_DAYS, buyAndHoldReturn, type Candle, type ReplayRound, type ReplayOrder } from "./round";
 import { getInquireDailyItemChartPrice } from "@/lib/features/koreaInvestment/koreaInvestmentAPI";
 
 const KEY = "iq:replay:v1";
@@ -62,7 +62,9 @@ export async function buildLocalRound(pool: { ticker: string; name: string }[]):
                 candles: full,           // 로컬은 전부 들고 있고 화면에서 cursor 까지만 그린다
                 ticker: pick.ticker, name: pick.name,
                 start_date: full[0].d, end_date: full[full.length - 1].d,
-                final_return: null, bh_return: null, coins_earned: null,
+                final_return: null, bh_return: null,
+                // 체험 운용에는 회사가 없다 — 정산은 로그인해야 붙는다
+                aum_before: null, aum_after: null, fee_base: null, fee_perf: null,
             };
             saveLocal(round);
             return round;
@@ -81,7 +83,12 @@ export function loadLocal(): ReplayRound | null {
         const parsed = JSON.parse(raw) as ReplayRound;
         if (!Array.isArray(parsed?.candles) || typeof parsed?.cursor !== "number") return null;
         // orders 를 넣기 전에 저장된 판이 남아 있을 수 있다
-        return { ...parsed, orders: Array.isArray(parsed.orders) ? parsed.orders : [] };
+        return {
+            ...parsed,
+            orders: Array.isArray(parsed.orders) ? parsed.orders : [],
+            aum_before: parsed.aum_before ?? null, aum_after: parsed.aum_after ?? null,
+            fee_base: parsed.fee_base ?? null, fee_perf: parsed.fee_perf ?? null,
+        };
     } catch {
         return null;
     }
@@ -127,7 +134,6 @@ function finish(round: ReplayRound): ReplayRound {
         status: "done",
         final_return: finalReturn,
         bh_return: bhReturn,
-        coins_earned: coinsFor(finalReturn, bhReturn),  // 로컬은 표시만 하고 지갑에 넣지 않는다
     };
     saveLocal(done);
     return done;

--- a/cf-idiotquant/lib/paper/round.ts
+++ b/cf-idiotquant/lib/paper/round.ts
@@ -43,7 +43,12 @@ export interface ReplayRound {
     end_date: string | null;
     final_return: number | null;
     bh_return: number | null;
-    coins_earned: number | null;
+    // 분기 정산 — 끝난 판에만 있다. 규칙이 바뀌어도 지난 기록은 그때 값 그대로여야 해서
+    // 다시 계산하지 않고 서버가 남긴 값을 그대로 쓴다.
+    aum_before: number | null;
+    aum_after: number | null;
+    fee_base: number | null;
+    fee_perf: number | null;
 }
 
 export interface ReplayHistoryItem {
@@ -54,7 +59,10 @@ export interface ReplayHistoryItem {
     end_date: string | null;
     final_return: number | null;
     bh_return: number | null;
-    coins_earned: number | null;
+    aum_before: number | null;
+    aum_after: number | null;
+    fee_base: number | null;
+    fee_perf: number | null;
     created_at: number;
 }
 
@@ -66,11 +74,3 @@ export function buyAndHoldReturn(candles: Candle[]): number {
     return ((last - first) / first) * 100;
 }
 
-/** 수익률과 Buy & Hold 대비 성과로 코인을 준다. */
-export function coinsFor(finalReturn: number, bhReturn: number): number {
-    let coins = 0;
-    if (finalReturn >= 10) coins += 30;
-    else if (finalReturn >= 0) coins += 10;
-    if (finalReturn > bhReturn) coins += 20;
-    return coins;
-}


### PR DESCRIPTION
## 왜

판과 판 사이를 잇는 화면. 규칙과 정산은 워커 PR #95 에 있다.

**당신은 작은 운용사를 차렸다.** 분기마다 모델 포트폴리오 1,000만원으로 실력을 증명하고, 고객은 그 성적을 보고 돈을 맡기거나 뺀다. 회사는 맡은 돈에서 보수를 받아 리서치 도구를 산다.

## 화면 3개

**회사 대시보드** — 등급 · AUM · 회사 자금 · 운용 분기, `n분기 운용 시작`, 리서치실, 지난 분기 기록(수익률 · 벤치마크 · 자금 변화)

**운용 중** — 기존 화면 그대로. 헤더만 `3분기 · Day 5/41`

**분기 보고서** — 수익률/벤치마크에 이어 고객 자금 변화와 보수 내역
```
내 수익률 +0.04%          벤치마크 +4.33%
벤치마크가 4.28%p 더 벌었습니다.
고객 자금 -12.8% → 8,715만
보수 +25만 (운용 25만 · 성과 0)
```

## 만든 것

- **`lib/paper/firm.ts`** — 워커 `firmRules.js` 의 TS 짝. 화면이 정산을 보여 주려면 같은 계산을 해야 하고, 어긋나면 화면과 서버가 다른 숫자를 말한다
- **`lib/paper/indicators.ts`** — 이동평균·볼린저. 값이 없는 앞 구간은 `null` (0 을 넣으면 선이 바닥까지 떨어진다)
- **`LineChart` 에 `overlays` 옵션** — `markers` 와 같은 방식, 기존 호출부 불변. 별도 영역 대신 **가격 위에 겹쳐 그리는 이유는 모바일 한 화면을 못 깨기 때문**이다
- 보고서 숫자는 **서버가 남긴 값을 그대로** 쓴다 — 규칙이 바뀌어도 지난 기록은 그때 값이어야 한다
- **비로그인은 "체험 운용"** 으로 남긴다. 판은 그대로 굴러가고 회사에는 반영되지 않는다

## 검증

**규칙 대조 154건** — 워커 JS 와 프론트 TS 가 같은 값을 내는지 같은 입력을 양쪽에 넣어 비교. 상수 하나(`PERF_FEE_PCT`)를 바꾸면 40건이 어긋나는 걸 확인했다.

**브라우저 한 바퀴** (390×844):

| 단계 | 결과 |
|---|---|
| 대시보드 | 등급·AUM·시작 버튼·리서치실 ✅ |
| 분기 보고서 | 자금 −12.8%, 보수 25만이 **규칙 계산과 일치** ✅ |
| 대시보드 반영 | 분기 증가, 회사 자금 적립 ✅ |
| 도구 구매 | 2분기만에 46만 모아 30만짜리 구매 ✅ |
| 다음 분기 차트 | **5일선(주황)·20일선(보라)이 실제로 그려짐** ✅ |

**모바일 한 화면** — 운용·보고서는 375/390/412 모두 유지. 대시보드는 시작 버튼이 375 이상에서 노출된다(320×568 에서만 24px 접힘).

**회귀** — 마커 e2e(로그인·비로그인), 완주 e2e, 실패 응답 e2e 5종, 최대매수/전량매도, 데스크톱 1280 / 태블릿 768, `tsc --noEmit`, `npm run build`.

## 남은 것

`lib/features/deck/deckAPI.tsx` 는 카드게임 시절 죽은 코드인데 **내가 만든 게 아니라 손대지 않았다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_