### PR TITLE
feat(game): 매매 습관 표시 — 보고서 한 줄 + 대시보드 카드

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -18,13 +18,13 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
-import { Play, Flag, TrendingUp, Coins, Wallet, RotateCcw, Eye, Building2, Lock, Check } from "lucide-react";
+import { Play, Flag, TrendingUp, Coins, Wallet, RotateCcw, Eye, Building2, Lock, Check, Activity } from "lucide-react";
 
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { reqGetNcavDailyList, selectNcavDailyList } from "@/lib/features/algorithmTrade/algorithmTradeSlice";
 
 import { avgPrice, quoteBuy } from "@/lib/paper/engine";
-import { CONTEXT_DAYS, TOTAL_DAYS, type ReplayRound, type ReplayHistoryItem } from "@/lib/paper/round";
+import { CONTEXT_DAYS, TOTAL_DAYS, type ReplayRound, type ReplayHistoryItem, type RoundHabits, type HabitSummary } from "@/lib/paper/round";
 import { buildLocalRound, loadLocal, saveLocal, advanceLocal, giveUpLocal } from "@/lib/paper/localRound";
 import { getReplayState, startReplayRound, advanceReplayRound, giveUpReplayRound, buyTool } from "@/lib/features/paper/replayAPI";
 import { TOOLS, INITIAL_AUM, rankOf, fmtMoney, type Firm } from "@/lib/paper/firm";
@@ -57,6 +57,7 @@ export default function ReplayGamePage() {
     const [round, setRound] = useState<ReplayRound | null>(null);
     const [history, setHistory] = useState<ReplayHistoryItem[]>([]);
     const [firm, setFirm] = useState<Firm | null>(null);
+    const [habits, setHabits] = useState<HabitSummary | null>(null);
     const [bestReturn, setBestReturn] = useState<number | null>(null);
     // 산 도구 중 지금 켜 둔 것. 사자마자 켜진다.
     const [activeTools, setActiveTools] = useState<string[]>([]);
@@ -90,6 +91,7 @@ export default function ReplayGamePage() {
                 setRound(res.round);
                 setHistory(res.history ?? []);
                 setFirm(res.firm ?? null);
+                setHabits(res.habits ?? null);
                 setBestReturn(res.wallet?.best_return ?? null);
                 setActiveTools(res.firm?.tools ?? []);
             }
@@ -130,6 +132,7 @@ export default function ReplayGamePage() {
                     if (st.success) {
                         setHistory(st.history ?? []);
                         setFirm(st.firm ?? null);
+                        setHabits(st.habits ?? null);
                         setBestReturn(st.wallet?.best_return ?? null);
                     }
                 }
@@ -152,7 +155,7 @@ export default function ReplayGamePage() {
                 if (!res.success) { addToast("error", res.error); return; }
                 setRound(res.round);
                 const st = await getReplayState();
-                if (st.success) { setHistory(st.history ?? []); setFirm(st.firm ?? null); setBestReturn(st.wallet?.best_return ?? null); }
+                if (st.success) { setHistory(st.history ?? []); setFirm(st.firm ?? null); setHabits(st.habits ?? null); setBestReturn(st.wallet?.best_return ?? null); }
             } else {
                 setRound(giveUpLocal(round));
             }
@@ -292,7 +295,7 @@ export default function ReplayGamePage() {
                 {!round && (
                     <FirmDashboard
                         onStart={start} busy={busy} isLoggedIn={isLoggedIn}
-                        firm={firm} bestReturn={bestReturn} history={history}
+                        firm={firm} bestReturn={bestReturn} history={history} habits={habits}
                         onBuy={purchase} activeTools={activeTools} onToggle={toggleTool}
                     />
                 )}
@@ -359,7 +362,7 @@ export default function ReplayGamePage() {
                                 크기를 붙들고 있어 칸이 줄어도 그대로 그린다 — 320px 에서 차트가 패널을
                                 뚫고 나와 계좌 카드 위에 겹쳐 그려졌다. absolute inset-0 으로 실제 픽셀
                                 상자를 주면 줄어드는 쪽도 따라온다. */}
-                            <div className="relative flex-1 min-h-[120px] sm:min-h-[260px] overflow-hidden">
+                            <div className="relative flex-1 min-h-[100px] sm:min-h-[260px] overflow-hidden">
                                 <div className="absolute inset-0">
                                     <LineChart
                                         height="100%"
@@ -461,6 +464,37 @@ export default function ReplayGamePage() {
 }
 
 // ─────────────────────────────────────────────────────────
+/**
+ * 이번 분기 매매를 한 줄로. 말할 수 없는 값(null)은 아예 빼서 문장을 짧게 만든다 —
+ * "오른 뒤 매수 —%" 처럼 빈 칸을 보여 주면 읽는 사람이 의미를 지어낸다.
+ */
+function habitLine(h: RoundHabits): string {
+    // 조각은 셋까지 — 넷이면 375px 에서 두 줄로 접혀 결과 화면이 한 장을 넘긴다.
+    // 관망 비율은 대시보드 습관 카드에 있다.
+    const parts = [`체결 ${h.trades}회`];
+    if (h.holdDays !== null) parts.push(`평균 ${h.holdDays}일 보유`);
+    if (h.chaseRatio !== null) parts.push(`오른 뒤 매수 ${h.chaseRatio}%`);
+    return parts.join(" · ");
+}
+
+/** 습관 한 줄. 표본이 없으면 그 줄만 "아직 알 수 없음" 으로 둔다 — 카드를 통째로 숨기지 않는다. */
+function HabitRow({ label, value, note }: { label: string; value: string | null; note?: string }) {
+    return (
+        <li className="flex items-baseline gap-2">
+            <span className="w-8 shrink-0 text-[10px] font-black uppercase tracking-wider text-neutral-400">{label}</span>
+            {value !== null ? (
+                <>
+                    <span className="font-bold text-neutral-900 dark:text-white">{value}</span>
+                    {note && <span className="text-[11px] text-neutral-400 truncate">{note}</span>}
+                </>
+            ) : (
+                <span className="text-neutral-400">아직 알 수 없음{note ? ` — ${note}` : ""}</span>
+            )}
+        </li>
+    );
+}
+
+// ─────────────────────────────────────────────────────────
 /** 모바일용 압축 지표 한 칸. 화면을 한 장으로 유지하려고 KpiCard 대신 쓴다. */
 function MiniStat({ label, value, sub, valueColor }: { label: string; value: string; sub: string; valueColor?: string }) {
     return (
@@ -474,9 +508,10 @@ function MiniStat({ label, value, sub, valueColor }: { label: string; value: str
 
 // ─────────────────────────────────────────────────────────
 /** 회사 대시보드 — 판이 없을 때. 시작 버튼까지 한 화면에 들어와야 한다. */
-function FirmDashboard({ onStart, busy, isLoggedIn, firm, bestReturn, history, onBuy, activeTools, onToggle }: {
+function FirmDashboard({ onStart, busy, isLoggedIn, firm, bestReturn, history, habits, onBuy, activeTools, onToggle }: {
     onStart: () => void; busy: boolean; isLoggedIn: boolean;
     firm: Firm | null; bestReturn: number | null; history: ReplayHistoryItem[];
+    habits: HabitSummary | null;
     onBuy: (id: string) => void; activeTools: string[]; onToggle: (id: string) => void;
 }) {
     const aum = firm?.aum ?? INITIAL_AUM;
@@ -570,6 +605,32 @@ function FirmDashboard({ onStart, busy, isLoggedIn, firm, bestReturn, history, o
                 </SectionPanel>
             )}
 
+            {habits && habits.trades > 0 && (
+                <SectionPanel className="p-4 sm:p-5">
+                    <SectionHeader icon={<Activity size={16} />} title="매매 습관"
+                        subtitle={`${habits.quarters}분기 · 체결 ${habits.trades}회`} />
+                    <ul className="flex flex-col gap-1.5 text-[12px] sm:text-[13px]">
+                        <HabitRow label="보유"
+                            value={habits.holdDays !== null ? `평균 ${habits.holdDays}일` : null}
+                            note={habits.turnover !== null ? `회전율 ${habits.turnover}회` : undefined} />
+                        <HabitRow label="진입"
+                            value={habits.chaseRatio !== null ? `오른 뒤 매수 ${habits.chaseRatio}%` : null}
+                            note={habits.entryTrend !== null ? `직전 5일 ${pct(habits.entryTrend)}` : undefined} />
+                        <HabitRow label="처분"
+                            value={habits.disposition !== null ? `이익 ${habits.gainHoldDays}일 / 손실 ${habits.lossHoldDays}일` : null}
+                            note={habits.disposition !== null
+                                ? (habits.disposition > 0 ? "이익을 빨리 실현하는 편" : habits.disposition < 0 ? "손실을 빨리 정리하는 편" : "양쪽이 비슷")
+                                : "이익·손실 매도가 둘 다 있어야 볼 수 있습니다"} />
+                        <HabitRow label="투입"
+                            value={habits.biteShare !== null ? `한 번에 ${habits.biteShare}%` : null}
+                            note={habits.watchRatio !== null ? `관망 ${habits.watchRatio}%` : undefined} />
+                    </ul>
+                    <p className="mt-3 text-[10px] text-neutral-400 break-keep leading-[1.6]">
+                        이 게임에서 관찰된 값입니다. 표본이 적으면 다음 분기에 크게 달라질 수 있습니다.
+                    </p>
+                </SectionPanel>
+            )}
+
             {history.length > 0 && (
                 <SectionPanel className="p-4 sm:p-5">
                     <SectionHeader icon={<Flag size={16} />} title="지난 분기" subtitle={`최근 ${history.length}분기`} />
@@ -636,6 +697,12 @@ function QuarterReport({ round, isLoggedIn }: { round: ReplayRound; isLoggedIn: 
                         ? `벤치마크보다 ${(mine - bh).toFixed(2)}%p 더 벌었습니다.`
                         : `벤치마크가 ${(bh - mine).toFixed(2)}%p 더 벌었습니다.`}
                 </p>
+
+                {round.habits && round.habits.trades > 0 && (
+                    <p className="text-[11px] sm:text-[12px] text-neutral-400 dark:text-neutral-500 break-keep">
+                        {habitLine(round.habits)}
+                    </p>
+                )}
 
                 {settled ? (
                     <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 text-[12px] sm:text-[13px] border-t border-neutral-100 dark:border-[#35332e] pt-1.5 sm:pt-3">

--- a/cf-idiotquant/lib/features/paper/replayAPI.ts
+++ b/cf-idiotquant/lib/features/paper/replayAPI.ts
@@ -1,7 +1,7 @@
 // 리플레이 라운드 API — 로그인 사용자 (백엔드 /user/replay).
 // 비로그인은 lib/paper/localRound.ts 가 같은 모양을 브라우저 안에서 다룬다.
 
-import type { ReplayRound, ReplayHistoryItem } from "@/lib/paper/round";
+import type { ReplayRound, ReplayHistoryItem, HabitSummary } from "@/lib/paper/round";
 import type { Firm } from "@/lib/paper/firm";
 
 async function replayRequest(method: "GET" | "POST", body?: object) {
@@ -41,6 +41,7 @@ export type ReplayResponse =
         history?: ReplayHistoryItem[];
         wallet?: { coins: number; best_streak: number; best_return: number | null };
         firm?: Firm;
+        habits?: HabitSummary | null;
     }
     | { success: false; status: number; error: string };
 

--- a/cf-idiotquant/lib/paper/localRound.ts
+++ b/cf-idiotquant/lib/paper/localRound.ts
@@ -65,6 +65,7 @@ export async function buildLocalRound(pool: { ticker: string; name: string }[]):
                 final_return: null, bh_return: null,
                 // 체험 운용에는 회사가 없다 — 정산은 로그인해야 붙는다
                 aum_before: null, aum_after: null, fee_base: null, fee_perf: null,
+                habits: null,   // 체험 운용은 서버가 없어 습관도 안 붙는다
             };
             saveLocal(round);
             return round;
@@ -88,6 +89,7 @@ export function loadLocal(): ReplayRound | null {
             orders: Array.isArray(parsed.orders) ? parsed.orders : [],
             aum_before: parsed.aum_before ?? null, aum_after: parsed.aum_after ?? null,
             fee_base: parsed.fee_base ?? null, fee_perf: parsed.fee_perf ?? null,
+            habits: parsed.habits ?? null,
         };
     } catch {
         return null;

--- a/cf-idiotquant/lib/paper/round.ts
+++ b/cf-idiotquant/lib/paper/round.ts
@@ -21,6 +21,37 @@ export interface ReplayOrder {
     side: "buy" | "sell";
     qty: number;
     price: number;
+    auto?: number;   // 1 = 마지막 날 강제 청산 (플레이어가 누른 게 아니다)
+}
+
+/**
+ * 매매 습관 — 판에서 관찰된 사실. 계산은 워커(src/lib/habits.js)에서만 하고 여기는 받아
+ * 그리기만 한다. 프론트에 규칙 사본을 또 만들지 않으려는 선택이다.
+ *
+ * null 인 값은 "표본이 없어 말할 수 없다"는 뜻이다 — 0 으로 바꿔 그리면 안 된다.
+ */
+export interface RoundHabits {
+    trades: number;
+    buys: number;
+    sells: number;
+    closedLots: number;
+    tradableDays: number;
+    turnover: number | null;
+    holdDays: number | null;
+    entryTrend: number | null;
+    chaseRatio: number | null;
+    gainHoldDays: number | null;
+    lossHoldDays: number | null;
+    disposition: number | null;
+    biteShare: number | null;
+    maxExposure: number;
+    watchRatio: number | null;
+}
+
+/** 여러 분기를 합친 습관. 기록이 없으면 서버가 null 을 준다. */
+export interface HabitSummary extends Omit<RoundHabits, "buys" | "sells" | "maxExposure"> {
+    quarters: number;
+    maxExposure: number | null;
 }
 
 /** 서버 `_publicRound` 와 같은 모양. 진행 중에는 정답과 미래 캔들이 비어 있다. */
@@ -49,6 +80,7 @@ export interface ReplayRound {
     aum_after: number | null;
     fee_base: number | null;
     fee_perf: number | null;
+    habits: RoundHabits | null;
 }
 
 export interface ReplayHistoryItem {
@@ -63,6 +95,7 @@ export interface ReplayHistoryItem {
     aum_after: number | null;
     fee_base: number | null;
     fee_perf: number | null;
+    habits: RoundHabits | null;
     created_at: number;
 }
 


### PR DESCRIPTION
## 왜

"모의투자 과정으로 내 투자 성향을 알 수 있나"에서 나온 기능. **"성향 진단"이 아니라 "매매 습관"** 으로 간다 — 한 판에 체결 두세 건으로 유형을 단정하면 근거 없는 확신이다. 관찰된 사실만 보여 준다.

계산은 워커가 하고(워커 PR #96) **여기는 받아 그리기만 한다.** 프론트에 규칙 사본을 또 만들지 않으려는 선택이라 이 PR 에는 계산이 없다.

## 화면

**분기 보고서** — 한 줄
```
체결 4회 · 평균 7일 보유 · 오른 뒤 매수 75%
```
조각은 셋까지다. 넷이면 375px 에서 두 줄로 접혀 결과 화면이 한 장을 넘긴다.

**대시보드** — 네 줄 카드
```
매매 습관 (2분기 · 체결 4회)
  보유   평균 6.5일        회전율 0.1회
  진입   오른 뒤 매수 50%   직전 5일 +0.30%
  처분   이익 3일 / 손실 10일   이익을 빨리 실현하는 편
  투입   한 번에 12.4%      관망 88.9%
```

**표본이 모자란 줄만** "아직 알 수 없음"으로 두고 카드를 통째로 숨기지 않는다. `null` 값은 문장에서 아예 빼거나 그렇게 적는다 — "오른 뒤 매수 —%" 처럼 빈 칸을 보여 주면 읽는 사람이 의미를 지어낸다.

체험 운용(비로그인)에는 습관이 안 붙는다.

## 한 화면 유지

습관 한 줄이 늘면서 **375 결과 화면이 19px 넘쳤다.** 좁을 때만 걸리는 차트 바닥값을 `120→100` 으로 낮춰 회수했다(넓은 화면은 `flex-1` 이라 무관). 375·390·412 진행·결과 모두 다시 한 화면이다.

대시보드는 문서가 길어졌지만 **시작 버튼은 375 이상에서 계속 노출**된다 — 습관·기록은 그 아래로 스크롤한다는 게 원래 설계다.

## 검증

**일부러 다르게 플레이한 두 판이 다르게 읽히는지**가 핵심이라, 상승 구간과 하락 구간에서 각각 매매하는 판을 실제로 돌렸다.

| | 1판 (상승 구간 매수) | 2판 (하락 구간 매수) |
|---|---|---|
| 추격 비율 | **100%** | **0%** |
| 평균 보유 | 3일 | 10일 |

- 화면 숫자가 워커 규칙 계산과 **글자까지 일치**하는지 대조 (보고서 한 줄, 누적 4줄)
- 1분기(이익만)에는 처분효과가 "아직 알 수 없음", 2분기(손실 추가)에 열리는지
- 320/375/390/412 × 대시보드·진행·결과 측정 (버튼 가림·안쪽 스크롤·차트 이탈 검사 포함)
- 회귀: 마커 e2e 양쪽, 완주 e2e, 실패 응답 5종, 최대매수/전량매도, 운용사 한 바퀴, 규칙 대조 154건, 데스크톱 1280/768, `tsc --noEmit`, `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_