### PR TITLE
fix(screener): 묶기가 모든 뷰에서 동작하게 + 등급 표시 전부 감춤

### DIFF
--- a/cf-idiotquant/app/(screener)/screener/components/GroupedResults.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/GroupedResults.tsx
@@ -8,7 +8,7 @@ import SectorSprite, { SECTOR_COLOR } from "./SectorSprite";
 /* 결과를 묶어 읽게 만드는 부분. 낱개 147행을 훑는 것보다 "이 전략 12개는 PBR 중위 0.4" 처럼
    덩어리로 읽는 편이 판단이 빠르다. */
 
-export type GroupMode = "none" | "sector" | "strategy" | "grade";
+export type GroupMode = "none" | "sector" | "strategy";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Item = Record<string, any>;
@@ -36,9 +36,9 @@ export interface Group {
 export function buildGroups(list: Item[], mode: GroupMode): Group[] | null {
     if (mode === "none") return null;
     const keyOf = (i: Item): string =>
-        mode === "sector"   ? (i.sector ?? i.industry ?? "기타")
-      : mode === "strategy" ? (STRATEGY_PRESETS_CLIENT.find(p => p.clientFilter?.(i))?.id ?? i.strategies?.[0] ?? "미분류")
-      : computeValueScore(i).medal;
+        mode === "sector"
+            ? (i.sector ?? i.industry ?? "기타")
+            : (STRATEGY_PRESETS_CLIENT.find(p => p.clientFilter?.(i))?.id ?? i.strategies?.[0] ?? "미분류");
 
     const map = new Map<string, Item[]>();
     for (const i of list) {
@@ -77,13 +77,15 @@ function Stat({ label, value, accent }: { label: string; value: string; accent?:
 }
 
 export function GroupedResults({
-    groups, open, onToggle, renderRow, hint,
+    groups, open, onToggle, renderRow, hint, bodyClassName = "pl-[30px]",
 }: {
     groups: Group[];
     open: Set<string>;
     onToggle: (key: string) => void;
     renderRow: (item: Item) => React.ReactNode;
     hint?: (g: Group) => string;
+    /** 그룹 본문 감싸개. 카드·비율 뷰는 격자라 그 격자 클래스를 그대로 넘긴다. */
+    bodyClassName?: string;
 }) {
     const hiddenCount = groups.filter(g => !open.has(g.key)).length;
 
@@ -115,7 +117,7 @@ export function GroupedResults({
                             <Stat label="ROE 중위" value={g.medRoe > 0 ? `${g.medRoe.toFixed(1)}%` : "—"} />
                             <Stat label="최고점" value={String(g.best)} accent />
                         </button>
-                        {isOpen && <div className="pl-[30px]">{g.rows.map(renderRow)}</div>}
+                        {isOpen && <div className={bodyClassName}>{g.rows.map(renderRow)}</div>}
                     </div>
                 );
             })}

--- a/cf-idiotquant/app/(screener)/screener/components/GroupedResults.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/GroupedResults.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { cn } from "@/lib/utils";
-import { computeValueScore } from "@/lib/utils/valueScore";
 import { STRATEGY_LABEL, STRATEGY_PRESETS_CLIENT } from "@/lib/constants/strategies";
 import SectorSprite, { SECTOR_COLOR } from "./SectorSprite";
 
@@ -30,7 +29,6 @@ export interface Group {
     rows: Item[];
     medPbr: number;
     medRoe: number;
-    best: number;
 }
 
 export function buildGroups(list: Item[], mode: GroupMode): Group[] | null {
@@ -55,7 +53,6 @@ export function buildGroups(list: Item[], mode: GroupMode): Group[] | null {
             rows,
             medPbr: median(rows.map(r => num(r.pbr))),
             medRoe: median(rows.map(r => roeOf(r))),
-            best: Math.max(...rows.map(r => computeValueScore(r).score)),
         }))
         .sort((a, b) => b.rows.length - a.rows.length);
 }
@@ -115,7 +112,6 @@ export function GroupedResults({
                             <span className="flex-1" />
                             <Stat label="PBR 중위" value={g.medPbr > 0 ? g.medPbr.toFixed(2) : "—"} />
                             <Stat label="ROE 중위" value={g.medRoe > 0 ? `${g.medRoe.toFixed(1)}%` : "—"} />
-                            <Stat label="최고점" value={String(g.best)} accent />
                         </button>
                         {isOpen && <div className={bodyClassName}>{g.rows.map(renderRow)}</div>}
                     </div>

--- a/cf-idiotquant/app/(screener)/screener/components/ResultSummary.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/ResultSummary.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { cn } from "@/lib/utils";
-import { computeValueScore } from "@/lib/utils/valueScore";
 import { STRATEGY_LABEL, STRATEGY_ACTIVE_CLS, STRATEGY_HEX, STRATEGY_PRESETS_CLIENT } from "@/lib/constants/strategies";
 
 /* 표 위 요약 — 147행을 스크롤하기 전에 "이 결과가 대체로 어떤 모양인지"를 먼저 준다. */
@@ -36,8 +35,9 @@ export function ResultSummary({ list }: { list: Item[] }) {
   const scatter = list.filter(i => num(i.pbr) > 0);
   const xMax = Math.max(p95(scatter.map(i => num(i.pbr))), 0.1);
   const yMax = Math.max(p95(scatter.map(i => roeOf(i))), 1);
+  // 점 크기는 일정하게 둔다. 예전에는 저평가 점수로 키웠는데, 등급 기준이 모호해 화면에서
+  // 감춘 이상 "왜 이 점이 큰가"를 설명할 수 없는 채로 눈길만 끄는 셈이었다.
   const dots = scatter.map(i => {
-    const score = computeValueScore(i).score;
     const strategy = STRATEGY_PRESETS_CLIENT.find(p => p.clientFilter?.(i))?.id ?? i.strategies?.[0];
     return {
       ticker: i.ticker,
@@ -46,26 +46,13 @@ export function ResultSummary({ list }: { list: Item[] }) {
       roe: roeOf(i),
       x: Math.min(num(i.pbr) / xMax, 1) * 100,
       y: Math.min(Math.max(roeOf(i), 0) / yMax, 1) * 100,
-      size: 7 + (score / 100) * 7,
+      size: 9,
       color: (strategy && STRATEGY_HEX[strategy]) || "#a3a3a3",
-      score,
     };
   });
-  const topDot = dots.reduce<(typeof dots)[number] | null>((a, d) => (!a || d.score > a.score ? d : a), null);
-
-  // ③ 등급 분포 — 메달 종류는 valueScore의 tier()가 정한다(여기서 구간을 다시 쓰지 않는다)
-  const byGrade = [...list.reduce((m, i) => {
-    const v = computeValueScore(i);
-    const cur = m.get(v.medal);
-    m.set(v.medal, { medal: v.medal, label: v.label, n: (cur?.n ?? 0) + 1, score: v.score });
-    return m;
-  }, new Map<string, { medal: string; label: string; n: number; score: number }>()).values()]
-    .sort((a, b) => b.score - a.score)
-    .slice(0, 4);
-  const maxGrade = Math.max(...byGrade.map(g => g.n), 1);
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-[1.05fr_1.25fr_0.9fr] gap-3 mb-4">
+    <div className="grid grid-cols-1 md:grid-cols-[1fr_1.4fr] gap-3 mb-4">
 
       <div className={CARD}>
         <p className={TITLE}>전략 분포</p>
@@ -94,20 +81,11 @@ export function ResultSummary({ list }: { list: Item[] }) {
           {dots.map(d => (
             <span
               key={d.ticker}
-              title={`${d.name} · PBR ${d.pbr.toFixed(2)} · ROE ${d.roe.toFixed(1)}% · 점수 ${d.score}`}
+              title={`${d.name} · PBR ${d.pbr.toFixed(2)} · ROE ${d.roe.toFixed(1)}%`}
               className="absolute rounded-full opacity-75 -translate-x-1/2 translate-y-1/2 ring-[1.5px] ring-white dark:ring-[#242320]"
               style={{ left: `${d.x}%`, bottom: `${d.y}%`, width: d.size, height: d.size, background: d.color }}
             />
           ))}
-          {/* 라벨은 자기 점 바로 위에 붙인다 — 위치를 클램프하면 가리키는 점과 떨어져 뜬다 */}
-          {topDot && (
-            <span
-              className="absolute -translate-x-1/2 whitespace-nowrap px-1.5 py-0.5 rounded-md bg-neutral-900 text-white text-[9.5px] font-bold pointer-events-none"
-              style={{ left: `${topDot.x}%`, bottom: `calc(${topDot.y}% + ${topDot.size / 2 + 4}px)` }}
-            >
-              최고점 {topDot.name} <span className="text-[#86efac] font-mono">{topDot.score}</span>
-            </span>
-          )}
         </div>
         <div className="flex justify-between mt-1.5 text-[9.5px] font-mono text-neutral-300 dark:text-neutral-600">
           <span>PBR 0 · ROE 0</span>
@@ -116,21 +94,6 @@ export function ResultSummary({ list }: { list: Item[] }) {
         </div>
       </div>
 
-      <div className={CARD}>
-        <p className={TITLE}>등급 분포</p>
-        <div className="flex flex-col gap-2">
-          {byGrade.map(g => (
-            <div key={g.medal} className="flex items-center gap-2">
-              <span className="text-[13px] shrink-0" aria-hidden>{g.medal}</span>
-              <span className="w-10 shrink-0 text-[10.5px] font-bold text-neutral-500 dark:text-neutral-400">{g.label}</span>
-              <span className="flex-1 h-[7px] rounded-full bg-[#f5f4f1] dark:bg-[#2c2b27] overflow-hidden">
-                <span className="block h-full rounded-full bg-[#16a34a] opacity-50" style={{ width: `${(g.n / maxGrade) * 100}%` }} />
-              </span>
-              <span className="w-8 shrink-0 text-right text-[10.5px] font-mono tabular-nums text-neutral-400">{g.n}</span>
-            </div>
-          ))}
-        </div>
-      </div>
     </div>
   );
 }

--- a/cf-idiotquant/app/(screener)/screener/components/StockGridCard.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/StockGridCard.tsx
@@ -3,7 +3,6 @@
 import { Heart, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { LiquidityBadge } from "./LiquidityBadge";
-import { ValueMedal } from "@/components/valueMedal";
 import { STRATEGY_LABEL, STRATEGY_BADGE, STRATEGY_HEX, STRATEGY_PRESETS_CLIENT } from "@/lib/constants/strategies";
 import SectorSprite, { SECTOR_COLOR } from "./SectorSprite";
 
@@ -83,7 +82,6 @@ export function StockGridCard({ item, onClick, isLiked, onToggleLike }: {
 
             <div className="p-4">
                 <div className="flex items-start gap-2 mb-3">
-                    <ValueMedal item={item} />
                     <div className="min-w-0 flex-1">
                         <p className="text-sm font-extrabold text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
                         <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">

--- a/cf-idiotquant/app/(screener)/screener/components/StockRatioRow.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/StockRatioRow.tsx
@@ -3,7 +3,6 @@
 import { Heart } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { LiquidityBadge } from "./LiquidityBadge";
-import { ValueMedal } from "@/components/valueMedal";
 import { ratioMetrics, barPct } from "./ratioMetrics";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -60,7 +59,6 @@ export function StockRatioRow({ item, onClick, isLiked, onToggleLike }: {
             className="cursor-pointer rounded-xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] p-4 hover:border-[#86efac] dark:hover:border-[#15803d]/60 hover:shadow-md transition-all"
         >
             <div className="flex items-start gap-2 mb-3">
-                <ValueMedal item={item} />
                 <div className="min-w-0 flex-1">
                     <p className="text-sm font-extrabold text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
                     <div className="flex items-center gap-1.5 mt-0.5 min-w-0">

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -16,10 +16,8 @@ import {
     reqGetMyLikes, reqToggleLike,
 } from "@/lib/features/stockLikes/stockLikesSlice";
 import { cn } from "@/lib/utils";
-import { computeValueScore } from "@/lib/utils/valueScore";
 import { CopyStockButtons, type CopyStock } from "@/components/copyStockButtons";
 import { PageHeader, PAGE_ACTION_CLS } from "@/components/pageHeader";
-import { ValueMedal } from "@/components/valueMedal";
 import { buildGroups, defaultOpenGroups, GroupedResults, type Group, type GroupMode } from "./components/GroupedResults";
 import { ResultSummary, TermStrip } from "./components/ResultSummary";
 import { StockGridCard } from "./components/StockGridCard";
@@ -36,7 +34,7 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 // 상수 & 타입
 // =========================================================================
 const DAILY_PAGE_SIZE = 30;
-type DiscoverySortKey = "value_score" | "ticker" | "ncav_ratio" | "per" | "pbr" | "roe" | "market_cap" | "last_price";
+type DiscoverySortKey = "ticker" | "ncav_ratio" | "per" | "pbr" | "roe" | "market_cap" | "last_price";
 type SortOrder = "asc" | "desc";
 
 // 밸류에이션 필터 프리셋 (0 = 미적용)
@@ -295,7 +293,6 @@ const TableRow = memo(function TableRow({ item, onClick, isLiked, onToggleLike, 
             onClick={() => onClick(item.ticker, item.name)}
         >
             <div className="min-w-0 flex items-center gap-2">
-                <ValueMedal item={item} />
                 <div className="min-w-0">
                     <p className="font-bold text-sm text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
                     <div className="flex items-center gap-1.5 mt-0.5 min-w-0">
@@ -399,7 +396,6 @@ const StockRowCard = memo(function StockRowCard({ item, onClick, isLiked, onTogg
             <div className="flex items-start justify-between gap-2 mb-4">
                 <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2 mb-1">
-                        <ValueMedal item={item} size="lg" />
                     </div>
                     <p className="font-bold text-base text-neutral-900 dark:text-white truncate leading-tight">{item.name}</p>
                     <div className="flex items-center gap-1.5 mt-0.5 flex-wrap">
@@ -559,7 +555,10 @@ function DrawerCheck({ checked, onChange, label, delta }: {
 // =========================================================================
 // 메인 스크리너
 // =========================================================================
-const VALID_SORT_KEYS: DiscoverySortKey[] = ["value_score", "ticker", "ncav_ratio", "per", "pbr", "roe", "market_cap", "last_price"];
+// 기본 정렬. 예전엔 저평가 점수순이었는데 등급·점수를 화면에서 감추면서 보이지 않는
+// 값으로 순서가 정해지게 돼, 목록에 실제로 보이는 NCAV 비율을 기준으로 바꿨다.
+const DEFAULT_SORT: DiscoverySortKey = "ncav_ratio";
+const VALID_SORT_KEYS: DiscoverySortKey[] = ["ticker", "ncav_ratio", "per", "pbr", "roe", "market_cap", "last_price"];
 
 function ScreenerContent() {
     const dispatch = useAppDispatch();
@@ -605,7 +604,7 @@ function ScreenerContent() {
     const [showGuide, setShowGuide] = useState(false);
     const [sortKey, setSortKey] = useState<DiscoverySortKey>(() => {
         const s = (searchParams.get('sort') ?? saved.sort) as DiscoverySortKey;
-        return VALID_SORT_KEYS.includes(s) ? s : 'value_score';
+        return VALID_SORT_KEYS.includes(s) ? s : DEFAULT_SORT;
     });
     const [sortOrder, setSortOrder] = useState<SortOrder>(() =>
         (searchParams.get('order') ?? saved.order) === 'asc' ? 'asc' : 'desc'
@@ -696,7 +695,7 @@ function ScreenerContent() {
             params.set('strategies', Array.from(activeStrategyIds).join(','));
         if (filterMode !== 'OR')
             params.set('mode', filterMode);
-        if (sortKey !== 'value_score')
+        if (sortKey !== DEFAULT_SORT)
             params.set('sort', sortKey);
         if (sortOrder !== 'desc')
             params.set('order', sortOrder);
@@ -735,7 +734,7 @@ function ScreenerContent() {
         const snapshot: Record<string, any> = {};
         if (activeStrategyIds.size > 0) snapshot.strategies = Array.from(activeStrategyIds);
         if (filterMode !== 'OR') snapshot.mode = filterMode;
-        if (sortKey !== 'value_score') snapshot.sort = sortKey;
+        if (sortKey !== DEFAULT_SORT) snapshot.sort = sortKey;
         if (sortOrder !== 'desc') snapshot.order = sortOrder;
         const excludeArr = [
             excludeHoldings ? 'holdings' : null,
@@ -884,11 +883,6 @@ function ScreenerContent() {
         const list = [...applyFilters(baseList, filters)];
 
         list.sort((a, b) => {
-            if (sortKey === "value_score") {
-                const sa = computeValueScore(a).score;
-                const sb = computeValueScore(b).score;
-                return sortOrder === "asc" ? sa - sb : sb - sa;
-            }
             if (sortKey === "ticker") {
                 return sortOrder === "asc"
                     ? (a.ticker ?? "").localeCompare(b.ticker ?? "")
@@ -1036,7 +1030,7 @@ function ScreenerContent() {
 
     const activeFilterCount = [excludeHoldings, excludeDeficit, excludePreferred, excludeHalted, excludeManaged, excludeDelisting, sectors.size > 0, markets.size > 0, maxW52Pos > 0, minTrAmt > 0, minMarketCap > 0, maxPbr > 0, maxPer > 0, minRoe > 0, minNcav > 0].filter(Boolean).length;
     const isAllActive = activeStrategyIds.size === 0;
-    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || excludePreferred || excludeHalted || excludeManaged || excludeDelisting || sectors.size > 0 || markets.size > 0 || maxW52Pos > 0 || minTrAmt > 0 || minMarketCap > 0 || maxPbr > 0 || maxPer > 0 || minRoe > 0 || minNcav > 0 || sortKey !== 'value_score' || sortOrder !== 'desc' || showLikedOnly;
+    const hasActiveFilters = activeStrategyIds.size > 0 || excludeHoldings || excludeDeficit || excludePreferred || excludeHalted || excludeManaged || excludeDelisting || sectors.size > 0 || markets.size > 0 || maxW52Pos > 0 || minTrAmt > 0 || minMarketCap > 0 || maxPbr > 0 || maxPer > 0 || minRoe > 0 || minNcav > 0 || sortKey !== DEFAULT_SORT || sortOrder !== 'desc' || showLikedOnly;
     const isFiltered = !showLikedOnly && filteredList.length !== ncavDailyList.list.length;
     // 업종 묶기는 응답에 sector/industry 가 있을 때만. 없으면 세그먼트에서 비활성.
     const hasSectorData = ncavDailyList.list.some((i: any) => i.sector ?? i.industry);
@@ -1140,7 +1134,7 @@ function ScreenerContent() {
         const p = new URLSearchParams(qs);
         setActiveStrategyIds(new Set((p.get('strategies') ?? '').split(',').filter(id => STRATEGY_PRESETS.some(s => s.id === id))));
         setFilterMode(p.get('mode') === 'AND' ? 'AND' : 'OR');
-        setSortKey(VALID_SORT_KEYS.includes(p.get('sort') as DiscoverySortKey) ? p.get('sort') as DiscoverySortKey : 'value_score');
+        setSortKey(VALID_SORT_KEYS.includes(p.get('sort') as DiscoverySortKey) ? p.get('sort') as DiscoverySortKey : DEFAULT_SORT);
         setSortOrder(p.get('order') === 'asc' ? 'asc' : 'desc');
         const ex = p.get('exclude')?.split(',') ?? [];
         setExcludeHoldings(ex.includes('holdings'));
@@ -1272,19 +1266,19 @@ function ScreenerContent() {
                             />
                         </div>
 
-                        {/* 정렬 — 점수순 (활성 시 반전) */}
+                        {/* 정렬 — NCAV 비율순 (활성 시 반전) */}
                         <button
-                            onClick={() => { setSortKey("value_score"); setSortOrder("desc"); setDisplayCount(DAILY_PAGE_SIZE); }}
-                            title="저평가 점수 높은 순으로 정렬 (NCAV·PBR·PER·ROE 종합)"
+                            onClick={() => { setSortKey(DEFAULT_SORT); setSortOrder(sortKey === DEFAULT_SORT && sortOrder === "desc" ? "asc" : "desc"); setDisplayCount(DAILY_PAGE_SIZE); }}
+                            title="NCAV 비율 높은 순으로 정렬 (순유동자산 ÷ 시가총액)"
                             className={cn(
                                 "shrink-0 flex items-center gap-1.5 px-3 py-2 rounded-[10px] text-xs font-bold border transition-all whitespace-nowrap",
-                                sortKey === "value_score"
+                                sortKey === DEFAULT_SORT
                                     ? "bg-neutral-900 dark:bg-white border-neutral-900 dark:border-white text-white dark:text-neutral-900"
                                     : "border-neutral-200 dark:border-[#3a3834] text-neutral-600 dark:text-neutral-400 hover:border-neutral-300 bg-white dark:bg-[#242320]"
                             )}
                         >
-                            점수순
-                            <span className="font-mono text-[10px]">{sortKey === "value_score" && sortOrder === "asc" ? "↑" : "↓"}</span>
+                            NCAV순
+                            <span className="font-mono text-[10px]">{sortKey === DEFAULT_SORT && sortOrder === "asc" ? "↑" : "↓"}</span>
                         </button>
 
                         {/* 필터 — 열림은 다른 툴바 토글과 같은 '단색 채움'으로 표시한다.

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -20,7 +20,7 @@ import { computeValueScore } from "@/lib/utils/valueScore";
 import { CopyStockButtons, type CopyStock } from "@/components/copyStockButtons";
 import { PageHeader, PAGE_ACTION_CLS } from "@/components/pageHeader";
 import { ValueMedal } from "@/components/valueMedal";
-import { buildGroups, defaultOpenGroups, GroupedResults, type GroupMode } from "./components/GroupedResults";
+import { buildGroups, defaultOpenGroups, GroupedResults, type Group, type GroupMode } from "./components/GroupedResults";
 import { ResultSummary, TermStrip } from "./components/ResultSummary";
 import { StockGridCard } from "./components/StockGridCard";
 import { StockRatioRow } from "./components/StockRatioRow";
@@ -90,6 +90,8 @@ const VIEW_MODE_TITLE: Record<ViewMode, string> = {
     ratio: "비율로 보기 — 유동자산·부채총계·시가총액을 같은 축에서 비교",
 };
 const DEFAULT_VIEW: ViewMode = 'ratio';
+// 묶었을 때 카드·비율 뷰의 그룹 본문 — 격자 뷰라 격자 클래스를 그대로 넘긴다.
+const GRID_BODY = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 p-3';
 // URL·localStorage 어디서 읽든 같은 규칙으로 해석한다. 한 곳만 고치면 복원 경로에서 어긋난다.
 const parseViewMode = (v: string | null | undefined): ViewMode =>
     (['table', 'card', 'ratio'] as ViewMode[]).includes(v as ViewMode) ? (v as ViewMode) : DEFAULT_VIEW;
@@ -657,7 +659,7 @@ function ScreenerContent() {
     // 묶어 보기 / 뷰 모드 — 기본값이 none·table 이라 배포 직후 동작은 그대로다
     const [groupMode, setGroupMode] = useState<GroupMode>(() => {
         const v = (searchParams.get('group') ?? saved.group) as GroupMode;
-        return (['sector', 'strategy', 'grade'] as GroupMode[]).includes(v) ? v : 'none';
+        return (['sector', 'strategy'] as GroupMode[]).includes(v) ? v : 'none';
     });
     const [viewMode, setViewMode] = useState<ViewMode>(
         () => parseViewMode(searchParams.get('view') ?? saved.view)
@@ -926,7 +928,25 @@ function ScreenerContent() {
     // 묶어 보기는 전체 결과를 대상으로 한다 — 페이지를 넘길 때마다 그룹 개수가 변하면
     // "이 전략에 12개"라는 숫자를 믿을 수 없다. 대신 상위 2개 그룹만 펼쳐 DOM을 작게 유지한다.
     const groups = useMemo(() => buildGroups(filteredList, groupMode), [filteredList, groupMode]);
-    useEffect(() => { setOpenGroups(defaultOpenGroups(buildGroups(filteredList, groupMode))); }, [groupMode]); // eslint-disable-line react-hooks/exhaustive-deps
+    // 그룹 구성이 달라지면 펼침 상태를 다시 잡는다. groupMode 만 보면 필터를 바꿔 그룹이
+    // 통째로 바뀌었을 때 옛 키가 남아 "전부 접힘"이 된다.
+    const groupSignature = (groups ?? []).map(g => g.key).join('|');
+    useEffect(() => { setOpenGroups(defaultOpenGroups(groups)); }, [groupSignature]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // 묶기는 뷰 모드와 무관하게 같은 동작이라 props 를 한 번만 만든다 —
+    // 예전에는 데스크톱 표에만 붙어 있어서 기본 뷰(비율)와 폰에서는 눌러도 아무 일이 없었다.
+    const groupedProps = {
+        groups: groups ?? [],
+        open: openGroups,
+        onToggle: (key: string) => setOpenGroups(prev => {
+            const next = new Set(prev);
+            if (!next.delete(key)) next.add(key);
+            return next;
+        }),
+        hint: (g: Group) => groupMode === 'strategy'
+            ? (STRATEGY_PRESETS.find(p => p.id === g.key)?.formula ?? '')
+            : '',
+    };
 
     const visibleList = filteredList.slice(0, displayCount);
     const hasMore = !groups && filteredList.length > displayCount;
@@ -1915,7 +1935,6 @@ function ScreenerContent() {
                                     { id: 'none',     label: '안 묶기' },
                                     { id: 'sector',   label: '업종', disabled: !hasSectorData },
                                     { id: 'strategy', label: '전략' },
-                                    { id: 'grade',    label: '등급' },
                                 ] as { id: GroupMode; label: string; disabled?: boolean }[]).map(o => (
                                     <button
                                         key={o.id}
@@ -1945,17 +1964,35 @@ function ScreenerContent() {
                         <ResultSummary list={filteredList} />
 
                         {viewMode === 'ratio' ? (
-                            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                                {visibleList.map((item: any) => (
-                                    <StockRatioRow key={item.ticker} item={item} onClick={handleStockClick} isLiked={likedTickers.has(item.name)} onToggleLike={handleToggleLike} />
-                                ))}
-                            </div>
+                            groups ? (
+                                <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] overflow-hidden shadow-sm">
+                                    <GroupedResults {...groupedProps} bodyClassName={GRID_BODY}
+                                        renderRow={(item: any) => (
+                                            <StockRatioRow key={item.ticker} item={item} onClick={handleStockClick} isLiked={likedTickers.has(item.name)} onToggleLike={handleToggleLike} />
+                                        )} />
+                                </div>
+                            ) : (
+                                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                                    {visibleList.map((item: any) => (
+                                        <StockRatioRow key={item.ticker} item={item} onClick={handleStockClick} isLiked={likedTickers.has(item.name)} onToggleLike={handleToggleLike} />
+                                    ))}
+                                </div>
+                            )
                         ) : viewMode === 'card' ? (
-                            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-                                {visibleList.map((item: any) => (
-                                    <StockGridCard key={item.ticker} item={item} onClick={handleStockClick} isLiked={likedTickers.has(item.name)} onToggleLike={handleToggleLike} />
-                                ))}
-                            </div>
+                            groups ? (
+                                <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] overflow-hidden shadow-sm">
+                                    <GroupedResults {...groupedProps} bodyClassName={GRID_BODY}
+                                        renderRow={(item: any) => (
+                                            <StockGridCard key={item.ticker} item={item} onClick={handleStockClick} isLiked={likedTickers.has(item.name)} onToggleLike={handleToggleLike} />
+                                        )} />
+                                </div>
+                            ) : (
+                                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                                    {visibleList.map((item: any) => (
+                                        <StockGridCard key={item.ticker} item={item} onClick={handleStockClick} isLiked={likedTickers.has(item.name)} onToggleLike={handleToggleLike} />
+                                    ))}
+                                </div>
+                            )
                         ) : (
                         <>
                         {/* 데스크탑 테이블 */}
@@ -1971,17 +2008,7 @@ function ScreenerContent() {
                                     <div />
                                 </div>
                                 {groups ? (
-                                    <GroupedResults
-                                        groups={groups}
-                                        open={openGroups}
-                                        onToggle={key => setOpenGroups(prev => {
-                                            const next = new Set(prev);
-                                            if (!next.delete(key)) next.add(key);
-                                            return next;
-                                        })}
-                                        hint={g => groupMode === 'strategy'
-                                            ? (STRATEGY_PRESETS.find(p => p.id === g.key)?.formula ?? '')
-                                            : ''}
+                                    <GroupedResults {...groupedProps}
                                         renderRow={(item: any) => (
                                             <TableRow key={item.ticker} item={item} onClick={handleStockClick} isLiked={likedTickers.has(item.name)} onToggleLike={handleToggleLike} highlight={metricHighlight} />
                                         )}
@@ -1996,11 +2023,23 @@ function ScreenerContent() {
                             </div>
                         </div>
 
-                        {/* 모바일 카드 */}
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 md:hidden">
-                            {visibleList.map((item: any) => (
-                                <StockRowCard key={item.ticker} item={item} onClick={handleStockClick} isLiked={likedTickers.has(item.name)} onToggleLike={handleToggleLike} highlight={metricHighlight} />
-                            ))}
+                        {/* 모바일 카드 — 데스크톱 표와 같은 묶기를 여기서도 해 준다.
+                            예전에는 이 블록이 묶기를 무시해, 폰에서는 버튼을 눌러도 아무 일이 없었다. */}
+                        <div className="md:hidden">
+                            {groups ? (
+                                <div className="bg-white dark:bg-[#242320] rounded-2xl border border-neutral-200 dark:border-[#35332e] overflow-hidden shadow-sm">
+                                    <GroupedResults {...groupedProps} bodyClassName="grid grid-cols-1 sm:grid-cols-2 gap-3 p-3"
+                                        renderRow={(item: any) => (
+                                            <StockRowCard key={item.ticker} item={item} onClick={handleStockClick} isLiked={likedTickers.has(item.name)} onToggleLike={handleToggleLike} highlight={metricHighlight} />
+                                        )} />
+                                </div>
+                            ) : (
+                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                    {visibleList.map((item: any) => (
+                                        <StockRowCard key={item.ticker} item={item} onClick={handleStockClick} isLiked={likedTickers.has(item.name)} onToggleLike={handleToggleLike} highlight={metricHighlight} />
+                                    ))}
+                                </div>
+                            )}
                         </div>
                         </>
                         )}


### PR DESCRIPTION
커밋 두 개다. ①이 원래 요청, ②는 "등급 분류 기준이 모호하니 일단 전부 가려 달라"는 후속.

---

## ① 묶기가 모든 뷰에서 동작하게

묶기(업종/전략)가 **데스크톱 표 블록에만** 걸려 있었다. 기본 뷰가 `ratio`(비율)이라 **페이지를 열고 업종·전략을 눌러도 아무 일이 일어나지 않았고**, 폰에서는 표 뷰에서도 마찬가지였다 — `md:hidden` 모바일 카드 블록이 묶기를 무시하고 목록을 그대로 그렸다.

고치기 전 브라우저로 재현:

| 뷰 | 묶기 |
|---|---|
| 비율 **(기본)** | ❌ |
| 카드 | ❌ |
| 표 (데스크톱) | ✅ |
| 표 (폰) | ❌ |

**고친 것**
- `GroupedResults` 에 `bodyClassName` 추가 — 카드·비율 뷰는 격자라 그룹 본문에 격자 클래스를 그대로 넘긴다
- 비율·카드·모바일 세 분기에 묶기를 붙이고, props 를 `groupedProps` 하나로 모아 네 곳이 같은 동작을 하게 했다
- **펼침 상태 버그도 함께**: `useEffect` 가 `groupMode` 만 보고 있어 필터를 바꿔 그룹 구성이 달라지면 옛 키가 남아 **전부 접힌 채로** 보였다. 그룹 키 목록을 보고 다시 잡는다

---

## ② 등급·점수 표시 전부 감춤

분류 기준(👑 전설 / 🏆 보물 / 💎 다이아 …)이 모호해 화면에서 내렸다. **"일단은"이므로 지우지 않고 렌더만 뗐다** — `computeValueScore` 와 `ValueMedal` 컴포넌트는 그대로 있고, 랜딩의 "오늘의 상위 발굴"은 계속 쓴다. 되돌리기 쉽다.

**감춘 곳**
- 메달 pill 4곳 (표 행 · 모바일 카드 · 카드 뷰 · 비율 뷰)
- 등급 분포 카드 (요약 3칸 → 2칸)
- 그룹 헤더의 "최고점"
- 묶기의 `등급` 옵션 — 그룹 키가 `medal` 이라 헤더가 이모지 하나(`👑`)로만 떠서 읽을 수도 없었다
- 산점도: 점 크기를 점수로 키우던 것과 "최고점 ○○ 87" 라벨. 등급을 감춘 마당에 **"왜 이 점이 큰가"를 설명할 수 없는 채로 눈길만 끌었다**

**정렬 — 짚고 갈 부분**

기본 정렬이 **"점수순"** 이었다. 점수를 감추면 보이지 않는 값으로 순서가 정해지므로, 목록에 실제로 보이는 **NCAV 비율순**으로 바꿨다(스캔 API 도 `ncav_ratio desc` 로 내려준다). 버튼도 `NCAV순`. 예전 `?sort=value_score` · `?group=grade` 링크는 허용값 검사에서 빠져 기본값으로 떨어진다.

---

## 검증

**묶기** — 업종이 셋으로 갈리는 12종목으로 네 뷰 전부:
```
[비율] [카드] [표] [표(폰)]  그룹 3 · 합계 12/12 · 업종명 일치 · 상위 2개 펼침(8행) · 헤더 클릭 시 접힘
```

**등급** — 네 뷰에서 메달 이모지+점수 pill, 등급 문구, `title` 속성까지 훑어 흔적 0.

**정렬** — 기본이 NCAV 내림차순이고 버튼을 누르면 오름차순으로 뒤집히는지 행 순서로 확인.

그 외: 예전 `?group=grade` / `?sort=value_score` 링크가 오류 없이 기본값이 되는지, 전략 그룹 헤더에 공식 힌트가 붙는지, `tsc --noEmit`, `npm run build`.

### 검사에서 두 번 오탐이 났고, 둘 다 검사 쪽이 틀렸다

- 그룹 헤더가 "있는지"만 보면 **숨어 있는 데스크톱 블록** 때문에 폰이 ✅ 로 나온다. 보이는 것만 세도록 고치니 폰이 ❌ 로 잡혔고 그게 진짜 버그였다
- 남은 `🥇` 를 등급 잔재로 오탐했는데 **페이지 아이콘(종목 발굴)** 이었다. 그건 등급이 아니라 그대로 뒀다

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P