### PR TITLE
feat(screener): 묶기가 '업종'이면 요약을 업종 분포로

### DIFF
--- a/cf-idiotquant/app/(screener)/screener/components/ResultSummary.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/ResultSummary.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { cn } from "@/lib/utils";
-import { STRATEGY_LABEL, STRATEGY_ACTIVE_CLS, STRATEGY_HEX, STRATEGY_PRESETS_CLIENT } from "@/lib/constants/strategies";
+import { STRATEGY_LABEL, STRATEGY_HEX, STRATEGY_PRESETS_CLIENT } from "@/lib/constants/strategies";
+import type { GroupMode } from "./GroupedResults";
 
 /* 표 위 요약 — 147행을 스크롤하기 전에 "이 결과가 대체로 어떤 모양인지"를 먼저 준다. */
 
@@ -10,6 +10,7 @@ import { STRATEGY_LABEL, STRATEGY_ACTIVE_CLS, STRATEGY_HEX, STRATEGY_PRESETS_CLI
 type Item = Record<string, any>;
 const num = (v: unknown) => { const n = Number(v); return isNaN(n) ? 0 : n; };
 const roeOf = (i: Item) => (num(i.bps) > 0 ? (num(i.eps) / num(i.bps)) * 100 : 0);
+const sectorOf = (i: Item) => String(i.sector ?? i.industry ?? "").trim();
 // 95분위 — 축 상한용. 최댓값을 쓰면 이상치 하나가 나머지를 전부 원점으로 밀어붙인다.
 const p95 = (xs: number[]) => {
   const v = xs.filter(x => x > 0).sort((a, b) => a - b);
@@ -19,15 +20,52 @@ const p95 = (xs: number[]) => {
 const CARD = "rounded-xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] px-[15px] py-3.5";
 const TITLE = "text-[10px] font-extrabold uppercase tracking-[0.08em] text-neutral-400 mb-2.5";
 
-export function ResultSummary({ list }: { list: Item[] }) {
-  if (list.length === 0) return null;
+const OTHER_HEX = "#a3a3a3";
+// 업종은 종류가 많고 결과마다 달라 전략처럼 고정 색표를 둘 수 없다. 개수 순위로 색을 준다 —
+// 이 카드 자체가 범례라서 순위 색으로 충분하다. 새 색을 만들지 않고 전략 색표를 빌려 쓴다.
+const RANK_HEX = [STRATEGY_HEX.ncav, STRATEGY_HEX.low_pbr, STRATEGY_HEX.low_per, STRATEGY_HEX.s_rim, STRATEGY_HEX.magic_formula];
+// 상위 5개 + '그 외' — 위쪽 업종 분포 띠와 자르는 지점을 맞춘다. 다르게 자르면 같은 화면에서
+// '그 외'가 5개와 3개로 어긋나 읽는 사람이 둘 중 뭘 믿어야 할지 알 수 없다.
+const SECTOR_TOP = RANK_HEX.length;
 
-  // ① 전략 분포 — 설계는 업종 분포였으나 스캔 응답에 업종 필드가 없어 전략으로 대체
-  const byStrategy = STRATEGY_PRESETS_CLIENT
-    .map(p => ({ id: p.id, label: STRATEGY_LABEL[p.id] ?? p.id, n: list.filter(i => p.clientFilter?.(i)).length }))
+/** ① 카드 한 줄. color 는 산점도 점 색과 같은 값이어야 한다 — 이 카드가 곧 범례다. */
+type DistRow = { key: string; label: string; n: number; color: string };
+
+function strategyDist(list: Item[]) {
+  const rows: DistRow[] = STRATEGY_PRESETS_CLIENT
+    .map(p => ({ key: p.id, label: STRATEGY_LABEL[p.id] ?? p.id, n: list.filter(i => p.clientFilter?.(i)).length, color: STRATEGY_HEX[p.id] ?? OTHER_HEX }))
     .filter(s => s.n > 0)
     .sort((a, b) => b.n - a.n);   // 이 카드가 산점도 색의 범례라서 자르지 않는다
-  const maxStrategy = Math.max(...byStrategy.map(s => s.n), 1);
+  const colorOf = (i: Item) => {
+    const id = STRATEGY_PRESETS_CLIENT.find(p => p.clientFilter?.(i))?.id ?? i.strategies?.[0];
+    return (id && STRATEGY_HEX[id]) || OTHER_HEX;
+  };
+  return { title: "전략 분포", legend: "색 = 전략", rows, colorOf };
+}
+
+function sectorDist(list: Item[]) {
+  const counts = new Map<string, number>();
+  for (const i of list) {
+    const s = sectorOf(i);
+    if (s) counts.set(s, (counts.get(s) ?? 0) + 1);
+  }
+  if (counts.size === 0) return null;   // 업종이 없는 응답이면 전략 분포로 되돌린다
+  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+  // 업종은 스무 개가 넘을 수 있어 상위만 색을 주고 나머지는 '그 외'로 접는다.
+  // 전략과 달리 다 펼치면 카드가 표보다 길어진다.
+  const color = new Map(sorted.slice(0, SECTOR_TOP).map(([name], idx) => [name, RANK_HEX[idx]]));
+  const rows: DistRow[] = sorted.slice(0, SECTOR_TOP).map(([label, n]) => ({ key: label, label, n, color: color.get(label)! }));
+  const rest = sorted.slice(SECTOR_TOP).reduce((a, [, n]) => a + n, 0);
+  if (rest > 0) rows.push({ key: "__other", label: "그 외", n: rest, color: OTHER_HEX });
+  return { title: "업종 분포", legend: "색 = 업종", rows, colorOf: (i: Item) => color.get(sectorOf(i)) ?? OTHER_HEX };
+}
+
+export function ResultSummary({ list, groupMode = "none" }: { list: Item[]; groupMode?: GroupMode }) {
+  if (list.length === 0) return null;
+
+  // ① 분포 — 묶기가 '업종'이면 업종별로, 아니면 전략별로 센다.
+  const dist = (groupMode === "sector" ? sectorDist(list) : null) ?? strategyDist(list);
+  const maxN = Math.max(...dist.rows.map(r => r.n), 1);
 
   // ② 산점도 — 축 상한을 데이터에서 뽑는다. 고정 범위(PBR 1.0 / ROE 20%)를 쓰면 저평가
   //    모집단이 전부 좌하단 구석에 뭉쳐 아무것도 구분되지 않는다. 이상치 하나가 축을 잡아먹지
@@ -37,33 +75,30 @@ export function ResultSummary({ list }: { list: Item[] }) {
   const yMax = Math.max(p95(scatter.map(i => roeOf(i))), 1);
   // 점 크기는 일정하게 둔다. 예전에는 저평가 점수로 키웠는데, 등급 기준이 모호해 화면에서
   // 감춘 이상 "왜 이 점이 큰가"를 설명할 수 없는 채로 눈길만 끄는 셈이었다.
-  const dots = scatter.map(i => {
-    const strategy = STRATEGY_PRESETS_CLIENT.find(p => p.clientFilter?.(i))?.id ?? i.strategies?.[0];
-    return {
-      ticker: i.ticker,
-      name: i.name,
-      pbr: num(i.pbr),
-      roe: roeOf(i),
-      x: Math.min(num(i.pbr) / xMax, 1) * 100,
-      y: Math.min(Math.max(roeOf(i), 0) / yMax, 1) * 100,
-      size: 9,
-      color: (strategy && STRATEGY_HEX[strategy]) || "#a3a3a3",
-    };
-  });
+  const dots = scatter.map(i => ({
+    ticker: i.ticker,
+    name: i.name,
+    pbr: num(i.pbr),
+    roe: roeOf(i),
+    x: Math.min(num(i.pbr) / xMax, 1) * 100,
+    y: Math.min(Math.max(roeOf(i), 0) / yMax, 1) * 100,
+    size: 9,
+    color: dist.colorOf(i),
+  }));
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-[1fr_1.4fr] gap-3 mb-4">
 
       <div className={CARD}>
-        <p className={TITLE}>전략 분포</p>
+        <p className={TITLE}>{dist.title}</p>
         <div className="flex flex-col gap-2">
-          {byStrategy.map(s => (
-            <div key={s.id} className="flex items-center gap-2">
-              <span className="w-14 shrink-0 text-[10.5px] font-bold text-neutral-500 dark:text-neutral-400 truncate">{s.label}</span>
+          {dist.rows.map(r => (
+            <div key={r.key} className="flex items-center gap-2">
+              <span title={r.label} className="w-[62px] shrink-0 text-[10.5px] font-bold text-neutral-500 dark:text-neutral-400 truncate">{r.label}</span>
               <span className="flex-1 h-[7px] rounded-full bg-[#f5f4f1] dark:bg-[#2c2b27] overflow-hidden">
-                <span className={cn("block h-full rounded-full", STRATEGY_ACTIVE_CLS[s.id])} style={{ width: `${(s.n / maxStrategy) * 100}%` }} />
+                <span className="block h-full rounded-full" style={{ width: `${(r.n / maxN) * 100}%`, background: r.color }} />
               </span>
-              <span className="w-8 shrink-0 text-right text-[10.5px] font-mono tabular-nums text-neutral-400">{s.n}</span>
+              <span className="w-8 shrink-0 text-right text-[10.5px] font-mono tabular-nums text-neutral-400">{r.n}</span>
             </div>
           ))}
         </div>
@@ -77,7 +112,7 @@ export function ResultSummary({ list }: { list: Item[] }) {
           {[25, 50, 75].map(v => (
             <div key={v} className="absolute inset-x-0 border-t border-dashed border-[#f2f0ec] dark:border-[#2c2b27]" style={{ bottom: `${v}%` }} />
           ))}
-          {/* 색 = 전략. 왼쪽 '전략 분포' 카드가 같은 색을 쓰므로 그게 곧 범례다. */}
+          {/* 색은 왼쪽 카드와 같은 기준(전략 또는 업종). 같은 색을 쓰므로 그 카드가 곧 범례다. */}
           {dots.map(d => (
             <span
               key={d.ticker}
@@ -89,7 +124,7 @@ export function ResultSummary({ list }: { list: Item[] }) {
         </div>
         <div className="flex justify-between mt-1.5 text-[9.5px] font-mono text-neutral-300 dark:text-neutral-600">
           <span>PBR 0 · ROE 0</span>
-          <span className="font-sans">색 = 전략</span>
+          <span className="font-sans">{dist.legend}</span>
           <span>PBR {xMax.toFixed(2)} · ROE {yMax.toFixed(0)}%</span>
         </div>
       </div>

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -1955,7 +1955,7 @@ function ScreenerContent() {
 
                         {/* 숫자를 읽는 법 + 결과가 대체로 어떤 모양인지 — 스크롤 전에 먼저 준다 */}
                         <TermStrip />
-                        <ResultSummary list={filteredList} />
+                        <ResultSummary list={filteredList} groupMode={groupMode} />
 
                         {viewMode === 'ratio' ? (
                             groups ? (


### PR DESCRIPTION
## 무엇을

스크리너에서 **묶기 = 업종**을 고르면 결과 위 요약 카드 ①이 `전략 분포` 대신 **`업종 분포`** 를 센다. `안 묶기` / `전략` 에서는 지금까지처럼 전략 분포.

## 왜 산점도 색까지 같이 바꿨나

오른쪽 산점도(`싼 정도 × 버는 정도`)는 별도 범례가 없고, 코드 주석에 적힌 대로 **왼쪽 카드가 곧 범례**다(같은 색을 쓴다). 카드만 업종으로 바꾸면 한 화면에서 "초록 막대 = 철강·금속"과 "초록 점 = NCAV"가 동시에 서서 잘못 읽힌다. 그래서 점 색과 하단 문구(`색 = 전략` ↔ `색 = 업종`)도 카드 기준을 따라간다.

## 세부

- 업종은 종류가 많아 **상위 5개 + '그 외'** 로 접는다. 전략처럼 다 펼치면 카드가 목록보다 길어진다.
- 자르는 지점을 **위쪽 업종 분포 띠와 같게(상위 5)** 맞췄다. 다르게 자르면 같은 화면에 `그 외 5`와 `그 외 3`이 동시에 떠서 어느 쪽을 믿어야 할지 알 수 없다.
- 업종 색은 새로 만들지 않고 전략 색표(`STRATEGY_HEX`)를 개수 순위로 빌려 쓴다.
- 응답에 업종이 하나도 없으면 조용히 **전략 분포로 되돌아간다**.
- 막대 색을 Tailwind 클래스(`STRATEGY_ACTIVE_CLS`) 대신 hex 인라인으로 바꿨다 — 점과 같은 값을 쓰기 위해서고, 두 색표는 같은 색이라 화면은 그대로다.

## 검증

브라우저에서 업종 8개(9·7·5·4·3·2·2·1종목)를 넣고 실측 — 전부 통과:

- 묶기 전환에 따라 제목·범례가 `전략 분포/색 = 전략` ↔ `업종 분포/색 = 업종` 으로 바뀜
- 카드 각 줄의 업종명·개수가 **그룹 헤더의 개수와 일치**, 합계 = 전체 33
- 점 색 6종이 모두 막대 색에 있고, **색깔별 점 개수가 업종별 개수와 정확히 일치**
- 한 화면의 `그 외` 값이 [5, 5] 로 어긋나지 않음
- 전략/안 묶기로 되돌리면 점 색과 줄이 원래대로

이빨 확인: `groupMode` 전달을 지우면 18건 실패.

회귀: 등급 감춤(4뷰) · 묶기 동작(4뷰) · 정렬 · 옛 링크(`?group=grade`, `?sort=value_score`) · 업종명 라벨 잘림(390/1280, 0건) · `tsc --noEmit` · `npm run build` 모두 통과.

## 알려진 점

묶기 = 업종 일 때 **`업종 분포`가 화면에 두 번** 나온다 — 위쪽 띠(집중도 경고 포함)와 이 카드. 숫자는 맞춰 뒀지만 중복은 남아 있다. 띠를 접거나 이 상태에서 숨기는 건 별도 판단이 필요해 이번엔 건드리지 않았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_