### PR TITLE
revert(screener): 업종 분포를 묶기 버튼 위 띠 하나로 통합

### DIFF
--- a/cf-idiotquant/app/(screener)/screener/components/ResultSummary.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/ResultSummary.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import { STRATEGY_LABEL, STRATEGY_HEX, STRATEGY_PRESETS_CLIENT } from "@/lib/constants/strategies";
-import type { GroupMode } from "./GroupedResults";
+import { cn } from "@/lib/utils";
+import { STRATEGY_LABEL, STRATEGY_ACTIVE_CLS, STRATEGY_HEX, STRATEGY_PRESETS_CLIENT } from "@/lib/constants/strategies";
 
 /* 표 위 요약 — 147행을 스크롤하기 전에 "이 결과가 대체로 어떤 모양인지"를 먼저 준다. */
 
@@ -10,7 +10,6 @@ import type { GroupMode } from "./GroupedResults";
 type Item = Record<string, any>;
 const num = (v: unknown) => { const n = Number(v); return isNaN(n) ? 0 : n; };
 const roeOf = (i: Item) => (num(i.bps) > 0 ? (num(i.eps) / num(i.bps)) * 100 : 0);
-const sectorOf = (i: Item) => String(i.sector ?? i.industry ?? "").trim();
 // 95분위 — 축 상한용. 최댓값을 쓰면 이상치 하나가 나머지를 전부 원점으로 밀어붙인다.
 const p95 = (xs: number[]) => {
   const v = xs.filter(x => x > 0).sort((a, b) => a - b);
@@ -20,52 +19,16 @@ const p95 = (xs: number[]) => {
 const CARD = "rounded-xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] px-[15px] py-3.5";
 const TITLE = "text-[10px] font-extrabold uppercase tracking-[0.08em] text-neutral-400 mb-2.5";
 
-const OTHER_HEX = "#a3a3a3";
-// 업종은 종류가 많고 결과마다 달라 전략처럼 고정 색표를 둘 수 없다. 개수 순위로 색을 준다 —
-// 이 카드 자체가 범례라서 순위 색으로 충분하다. 새 색을 만들지 않고 전략 색표를 빌려 쓴다.
-const RANK_HEX = [STRATEGY_HEX.ncav, STRATEGY_HEX.low_pbr, STRATEGY_HEX.low_per, STRATEGY_HEX.s_rim, STRATEGY_HEX.magic_formula];
-// 상위 5개 + '그 외' — 위쪽 업종 분포 띠와 자르는 지점을 맞춘다. 다르게 자르면 같은 화면에서
-// '그 외'가 5개와 3개로 어긋나 읽는 사람이 둘 중 뭘 믿어야 할지 알 수 없다.
-const SECTOR_TOP = RANK_HEX.length;
-
-/** ① 카드 한 줄. color 는 산점도 점 색과 같은 값이어야 한다 — 이 카드가 곧 범례다. */
-type DistRow = { key: string; label: string; n: number; color: string };
-
-function strategyDist(list: Item[]) {
-  const rows: DistRow[] = STRATEGY_PRESETS_CLIENT
-    .map(p => ({ key: p.id, label: STRATEGY_LABEL[p.id] ?? p.id, n: list.filter(i => p.clientFilter?.(i)).length, color: STRATEGY_HEX[p.id] ?? OTHER_HEX }))
-    .filter(s => s.n > 0)
-    .sort((a, b) => b.n - a.n);   // 이 카드가 산점도 색의 범례라서 자르지 않는다
-  const colorOf = (i: Item) => {
-    const id = STRATEGY_PRESETS_CLIENT.find(p => p.clientFilter?.(i))?.id ?? i.strategies?.[0];
-    return (id && STRATEGY_HEX[id]) || OTHER_HEX;
-  };
-  return { title: "전략 분포", legend: "색 = 전략", rows, colorOf };
-}
-
-function sectorDist(list: Item[]) {
-  const counts = new Map<string, number>();
-  for (const i of list) {
-    const s = sectorOf(i);
-    if (s) counts.set(s, (counts.get(s) ?? 0) + 1);
-  }
-  if (counts.size === 0) return null;   // 업종이 없는 응답이면 전략 분포로 되돌린다
-  const sorted = [...counts.entries()].sort((a, b) => b[1] - a[1]);
-  // 업종은 스무 개가 넘을 수 있어 상위만 색을 주고 나머지는 '그 외'로 접는다.
-  // 전략과 달리 다 펼치면 카드가 표보다 길어진다.
-  const color = new Map(sorted.slice(0, SECTOR_TOP).map(([name], idx) => [name, RANK_HEX[idx]]));
-  const rows: DistRow[] = sorted.slice(0, SECTOR_TOP).map(([label, n]) => ({ key: label, label, n, color: color.get(label)! }));
-  const rest = sorted.slice(SECTOR_TOP).reduce((a, [, n]) => a + n, 0);
-  if (rest > 0) rows.push({ key: "__other", label: "그 외", n: rest, color: OTHER_HEX });
-  return { title: "업종 분포", legend: "색 = 업종", rows, colorOf: (i: Item) => color.get(sectorOf(i)) ?? OTHER_HEX };
-}
-
-export function ResultSummary({ list, groupMode = "none" }: { list: Item[]; groupMode?: GroupMode }) {
+export function ResultSummary({ list }: { list: Item[] }) {
   if (list.length === 0) return null;
 
-  // ① 분포 — 묶기가 '업종'이면 업종별로, 아니면 전략별로 센다.
-  const dist = (groupMode === "sector" ? sectorDist(list) : null) ?? strategyDist(list);
-  const maxN = Math.max(...dist.rows.map(r => r.n), 1);
+  // ① 전략 분포 — 업종 분포는 묶기 버튼 위 띠가 맡는다(집중도 경고까지 거기 붙어 있다).
+  //    여기서 또 세면 같은 화면에 '업종 분포'가 두 번 뜬다. 한 번 그렇게 만들었다가 되돌렸다.
+  const byStrategy = STRATEGY_PRESETS_CLIENT
+    .map(p => ({ id: p.id, label: STRATEGY_LABEL[p.id] ?? p.id, n: list.filter(i => p.clientFilter?.(i)).length }))
+    .filter(s => s.n > 0)
+    .sort((a, b) => b.n - a.n);   // 이 카드가 산점도 색의 범례라서 자르지 않는다
+  const maxStrategy = Math.max(...byStrategy.map(s => s.n), 1);
 
   // ② 산점도 — 축 상한을 데이터에서 뽑는다. 고정 범위(PBR 1.0 / ROE 20%)를 쓰면 저평가
   //    모집단이 전부 좌하단 구석에 뭉쳐 아무것도 구분되지 않는다. 이상치 하나가 축을 잡아먹지
@@ -75,30 +38,33 @@ export function ResultSummary({ list, groupMode = "none" }: { list: Item[]; grou
   const yMax = Math.max(p95(scatter.map(i => roeOf(i))), 1);
   // 점 크기는 일정하게 둔다. 예전에는 저평가 점수로 키웠는데, 등급 기준이 모호해 화면에서
   // 감춘 이상 "왜 이 점이 큰가"를 설명할 수 없는 채로 눈길만 끄는 셈이었다.
-  const dots = scatter.map(i => ({
-    ticker: i.ticker,
-    name: i.name,
-    pbr: num(i.pbr),
-    roe: roeOf(i),
-    x: Math.min(num(i.pbr) / xMax, 1) * 100,
-    y: Math.min(Math.max(roeOf(i), 0) / yMax, 1) * 100,
-    size: 9,
-    color: dist.colorOf(i),
-  }));
+  const dots = scatter.map(i => {
+    const strategy = STRATEGY_PRESETS_CLIENT.find(p => p.clientFilter?.(i))?.id ?? i.strategies?.[0];
+    return {
+      ticker: i.ticker,
+      name: i.name,
+      pbr: num(i.pbr),
+      roe: roeOf(i),
+      x: Math.min(num(i.pbr) / xMax, 1) * 100,
+      y: Math.min(Math.max(roeOf(i), 0) / yMax, 1) * 100,
+      size: 9,
+      color: (strategy && STRATEGY_HEX[strategy]) || "#a3a3a3",
+    };
+  });
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-[1fr_1.4fr] gap-3 mb-4">
 
       <div className={CARD}>
-        <p className={TITLE}>{dist.title}</p>
+        <p className={TITLE}>전략 분포</p>
         <div className="flex flex-col gap-2">
-          {dist.rows.map(r => (
-            <div key={r.key} className="flex items-center gap-2">
-              <span title={r.label} className="w-[62px] shrink-0 text-[10.5px] font-bold text-neutral-500 dark:text-neutral-400 truncate">{r.label}</span>
+          {byStrategy.map(s => (
+            <div key={s.id} className="flex items-center gap-2">
+              <span className="w-14 shrink-0 text-[10.5px] font-bold text-neutral-500 dark:text-neutral-400 truncate">{s.label}</span>
               <span className="flex-1 h-[7px] rounded-full bg-[#f5f4f1] dark:bg-[#2c2b27] overflow-hidden">
-                <span className="block h-full rounded-full" style={{ width: `${(r.n / maxN) * 100}%`, background: r.color }} />
+                <span className={cn("block h-full rounded-full", STRATEGY_ACTIVE_CLS[s.id])} style={{ width: `${(s.n / maxStrategy) * 100}%` }} />
               </span>
-              <span className="w-8 shrink-0 text-right text-[10.5px] font-mono tabular-nums text-neutral-400">{r.n}</span>
+              <span className="w-8 shrink-0 text-right text-[10.5px] font-mono tabular-nums text-neutral-400">{s.n}</span>
             </div>
           ))}
         </div>
@@ -112,7 +78,7 @@ export function ResultSummary({ list, groupMode = "none" }: { list: Item[]; grou
           {[25, 50, 75].map(v => (
             <div key={v} className="absolute inset-x-0 border-t border-dashed border-[#f2f0ec] dark:border-[#2c2b27]" style={{ bottom: `${v}%` }} />
           ))}
-          {/* 색은 왼쪽 카드와 같은 기준(전략 또는 업종). 같은 색을 쓰므로 그 카드가 곧 범례다. */}
+          {/* 색 = 전략. 왼쪽 '전략 분포' 카드가 같은 색을 쓰므로 그게 곧 범례다. */}
           {dots.map(d => (
             <span
               key={d.ticker}
@@ -124,7 +90,7 @@ export function ResultSummary({ list, groupMode = "none" }: { list: Item[]; grou
         </div>
         <div className="flex justify-between mt-1.5 text-[9.5px] font-mono text-neutral-300 dark:text-neutral-600">
           <span>PBR 0 · ROE 0</span>
-          <span className="font-sans">{dist.legend}</span>
+          <span className="font-sans">색 = 전략</span>
           <span>PBR {xMax.toFixed(2)} · ROE {yMax.toFixed(0)}%</span>
         </div>
       </div>

--- a/cf-idiotquant/app/(screener)/screener/page.tsx
+++ b/cf-idiotquant/app/(screener)/screener/page.tsx
@@ -1955,7 +1955,7 @@ function ScreenerContent() {
 
                         {/* 숫자를 읽는 법 + 결과가 대체로 어떤 모양인지 — 스크롤 전에 먼저 준다 */}
                         <TermStrip />
-                        <ResultSummary list={filteredList} groupMode={groupMode} />
+                        <ResultSummary list={filteredList} />
 
                         {viewMode === 'ratio' ? (
                             groups ? (


### PR DESCRIPTION
## 무엇을

#691 을 되돌린다. 묶기 = 업종 일 때 요약 카드 ①을 업종 분포로 바꿨더니, **그 위 띠가 이미 같은 분포를 보여 주고 있어 한 화면에 `업종 분포`가 두 번** 떴다. 표시는 묶기 버튼 위 띠 하나로 통합한다.

## 왜 띠 쪽을 남기나

띠에는 `상위 3개 업종(…)이 64%를 차지합니다` 집중도 경고가 붙어 있고, 묶기 상태와 무관하게 항상 보인다. 카드는 묶기 = 업종 일 때만 나타나던 쪽이다.

## 되돌린 범위

- 요약 카드 ① → 다시 **항상 전략 분포**
- 산점도 점 색·하단 문구 → 다시 **전략 기준** (`색 = 전략`). 카드가 곧 산점도의 범례라 둘은 짝으로 움직인다
- `ResultSummary` 의 `groupMode` prop 제거

카드 주석에 "업종 분포는 묶기 버튼 위 띠가 맡는다"는 이유를 남겼다 — 원래 주석이 "스캔 응답에 업종 필드가 없어 전략으로 대체"라고 사실과 다르게 적혀 있어서, 그대로 두면 다음에 또 같은 카드를 만들게 된다.

## 검증

브라우저 실측 (업종 8개 · 33종목), 묶기 세 상태 모두:

- 화면의 `업종 분포` 제목이 **정확히 1개** (띠만)
- 요약 카드는 항상 `전략 분포`, 산점도 범례는 `색 = 전략`
- 띠의 집중도 경고 유지

회귀: 묶기 동작(4뷰) · 정렬 · 옛 링크(`?group=grade`) · 전략 공식 힌트 · `tsc --noEmit` · `npm run build` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_