### PR TITLE
feat(screener): 업종 아이콘 21종 추가 + 폰에서 한 단계 작게

### DIFF
--- a/cf-idiotquant/app/(screener)/screener/components/GroupedResults.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/GroupedResults.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import { STRATEGY_LABEL, STRATEGY_PRESETS_CLIENT } from "@/lib/constants/strategies";
-import SectorSprite, { SECTOR_COLOR } from "./SectorSprite";
+import SectorSprite, { sectorAccent } from "./SectorSprite";
 
 /* 결과를 묶어 읽게 만드는 부분. 낱개 147행을 훑는 것보다 "이 전략 12개는 PBR 중위 0.4" 처럼
    덩어리로 읽는 편이 판단이 빠르다. */
@@ -97,9 +97,11 @@ export function GroupedResults({
                             className="w-full flex items-center gap-2.5 px-[18px] py-2.5 bg-[#fbfbf9] dark:bg-[#1f1e1b] border-b border-neutral-100 dark:border-[#35332e] hover:bg-[#f5f4f1] dark:hover:bg-[#2c2b27] transition-colors text-left"
                         >
                             <span className={cn("text-[10px] text-neutral-400 transition-transform shrink-0", !isOpen && "-rotate-90")}>▾</span>
+                            {/* 폰에서는 한 줄에 이름·개수까지 들어가야 해서 아이콘을 한 단계 줄인다.
+                                20×14 격자 비율(1.4)은 유지해야 도트가 정수 배로 떨어진다. */}
                             {g.sector && (
-                                <span className="w-[42px] h-[30px] shrink-0 rounded-[5px] overflow-hidden border border-neutral-200 dark:border-[#35332e]">
-                                    <SectorSprite sector={g.sector} color={SECTOR_COLOR[g.sector]} />
+                                <span className="w-[30px] h-[21px] sm:w-[42px] sm:h-[30px] shrink-0 rounded-[5px] overflow-hidden border border-neutral-200 dark:border-[#35332e]">
+                                    <SectorSprite sector={g.sector} color={sectorAccent(g.sector)} />
                                 </span>
                             )}
                             <span className="text-[12.5px] font-extrabold text-neutral-900 dark:text-neutral-100 shrink-0">{g.label}</span>

--- a/cf-idiotquant/app/(screener)/screener/components/SectorSprite.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/SectorSprite.tsx
@@ -7,13 +7,64 @@ import { useEffect, useRef } from "react";
 
 const GW = 20, GH = 14;
 
-export const SECTOR_COLOR: Record<string, string> = {
-    "철강·금속": "#16a34a",
-    "전기·전자": "#0369a1",
-    "기계·장비": "#c2410c",
-    "화학": "#6d28d9",
-    "운수·창고": "#0f766e",
+/** 스프라이트 한 종류당 강조색 하나. 키는 그림 이름이지 업종명이 아니다 — 이름 표기가
+    흔들려도(가운뎃점·"업" 접미사·코스피/코스닥 차이) 같은 그림·같은 색이 나오게 하려고
+    `spriteKeyFor` 를 거쳐 찾는다. */
+export const SECTOR_COLOR: Record<string, string> = {    "철강·금속": "#16a34a", "전기·전자": "#0369a1", "기계·장비": "#c2410c",
+    "화학": "#6d28d9", "운수·창고": "#0f766e",
+    "의약품": "#e11d48", "음식료품": "#ea580c", "섬유·의복": "#db2777",
+    "종이·목재": "#a16207", "건설업": "#d97706", "유통업": "#0d9488",
+    "금융업": "#1d4ed8", "증권": "#15803d", "보험": "#4338ca",
+    "통신업": "#4f46e5", "전기·가스": "#ca8a04", "서비스업": "#0891b2",
+    "IT·소프트웨어": "#0284c7", "반도체": "#7c3aed", "운송장비·부품": "#475569",
+    "의료·정밀기기": "#be123c", "비금속광물": "#8a5a3b", "오락·문화": "#c026d3",
+    "부동산": "#4d7c0f", "기타제조": "#525252", "출판·매체": "#92400e",
 };
+
+// 업종명은 KIS 가 주는 대로(bstp_kor_isnm) 들어와 표기가 일정하지 않다. 정확히 일치할 때만
+// 그림을 붙이면 대부분 기본 구로 떨어지므로 낱말로 고른다. 위에서부터 먼저 걸리는 것이 이긴다.
+const SPRITE_KEYWORDS: [string, string[]][] = [
+    ["철강·금속", ["철강", "금속", "비철"]],
+    ["전기·전자", ["전기전자", "전기·전자", "전자부품", "IT부품", "전자"]],
+    ["기계·장비", ["기계", "장비", "정보기기"]],
+    ["화학", ["화학", "석유", "고무", "플라스틱"]],
+    ["운수·창고", ["운수창고", "운수·창고", "운송", "창고", "물류", "해운", "항공"]],
+    ["의약품", ["의약", "제약", "바이오", "생물"]],
+    ["음식료품", ["음식료", "식품", "담배", "농업", "어업", "축산"]],
+    ["섬유·의복", ["섬유", "의복", "의류", "패션", "신발"]],
+    ["종이·목재", ["종이", "목재", "펄프", "가구"]],
+    ["건설업", ["건설", "토목", "엔지니어링"]],
+    ["유통업", ["유통", "도매", "소매", "무역", "백화점"]],
+    ["금융업", ["금융", "은행", "지주", "저축"]],
+    ["증권", ["증권", "투자"]],
+    ["보험", ["보험"]],
+    ["통신업", ["통신", "방송", "미디어"]],
+    ["전기·가스", ["전기가스", "전기·가스", "가스", "전력", "에너지"]],
+    ["서비스업", ["서비스"]],
+    ["IT·소프트웨어", ["소프트웨어", "인터넷", "컴퓨터", "디지털", "게임", "IT"]],
+    ["반도체", ["반도체", "웨이퍼", "디스플레이"]],
+    ["운송장비·부품", ["운송장비", "운수장비", "자동차", "조선", "차부품"]],
+    ["의료·정밀기기", ["의료", "정밀", "기기"]],
+    ["비금속광물", ["비금속", "광물", "시멘트", "요업", "광업"]],
+    ["오락·문화", ["오락", "문화", "레저", "여행", "엔터"]],
+    ["부동산", ["부동산", "임대", "리츠"]],
+    ["기타제조", ["제조"]],
+    ["출판·매체", ["출판", "매체", "인쇄", "교육"]],
+];
+
+/** 업종명 → 스프라이트 키. 걸리는 낱말이 없으면 null(기본 구). */
+export function spriteKeyFor(sector?: string): string | null {
+    const s = String(sector ?? "").replace(/[\s·.\-()]/g, "");
+    if (!s) return null;
+    for (const [key, words] of SPRITE_KEYWORDS) {
+        if (words.some(w => s.includes(w.replace(/[\s·.\-]/g, "")))) return key;
+    }
+    return null;
+}
+
+/** 업종 강조색. 표기가 달라도 같은 색이 나오도록 스프라이트 키를 거친다. */
+export const sectorAccent = (sector?: string): string | undefined =>
+    SECTOR_COLOR[spriteKeyFor(sector) ?? ""];
 
 type Pal = Record<"A" | "L" | "D" | "K" | "N" | "H" | "S" | "O", string>;
 
@@ -118,6 +169,189 @@ const SPRITE: Record<string, (g: Grid, p: Pal) => void> = {
         box(5, 2, 9, true); box(2, 7, 7, false); box(11, 7, 7, false);
         g.rect(2, 11, 16, 1, p.O); g.rect(4, 12, 12, 1, p.O);
     },
+
+    "의약품": (g, p) => {                          // 캡슐 + 알약
+        g.disc(6, 5, 3, p.A); g.rect(6, 2, 4, 7, p.A);
+        g.disc(13, 5, 3, p.N); g.rect(10, 2, 4, 7, p.N);
+        g.rect(6, 2, 4, 1, p.L); g.disc(4.4, 3.6, 1.3, p.L);
+        g.rect(10, 2, 4, 1, p.H); g.disc(14.6, 3.6, 1.2, p.H);
+        g.rect(6, 8, 4, 1, p.D); g.rect(10, 8, 4, 1, p.S);
+        g.line(10, 2, 10, 8, p.K);
+        g.rect(4, 11, 1, 2, p.A); g.rect(9, 11, 1, 2, p.A);
+        g.rect(5, 11, 4, 1, p.L); g.rect(5, 12, 4, 1, p.A); g.rect(5, 13, 4, 1, p.D);
+        g.rect(12, 11, 1, 2, p.N); g.rect(17, 11, 1, 2, p.N);
+        g.rect(13, 11, 4, 1, p.H); g.rect(13, 12, 4, 1, p.N); g.rect(13, 13, 4, 1, p.S);
+    },
+    "음식료품": (g, p) => {                        // 캔 + 사과
+        g.rect(3, 2, 6, 1, p.L); g.rect(3, 3, 6, 9, p.A); g.rect(3, 12, 6, 1, p.D);
+        g.rect(2, 3, 1, 9, p.K); g.rect(9, 3, 1, 9, p.K);
+        g.rect(3, 6, 6, 3, p.H); g.rect(4, 7, 4, 1, p.S);
+        g.disc(14.5, 9, 3.5, p.N); g.disc(13, 7.4, 1.4, p.H);
+        g.rect(14, 4, 1, 2, p.O); g.rect(15, 4, 2, 1, p.S); g.rect(16, 3, 1, 1, p.S);
+        g.rect(11, 12, 7, 1, p.O);
+    },
+    "섬유·의복": (g, p) => {                       // 티셔츠
+        g.rect(6, 2, 8, 1, p.L);
+        g.rect(2, 3, 4, 1, p.L); g.rect(2, 4, 4, 3, p.A); g.rect(2, 7, 4, 1, p.D);
+        g.rect(14, 3, 4, 1, p.L); g.rect(14, 4, 4, 3, p.A); g.rect(14, 7, 4, 1, p.D);
+        g.rect(6, 3, 8, 9, p.A); g.rect(6, 12, 8, 1, p.D);
+        g.rect(5, 3, 1, 10, p.K); g.rect(14, 3, 1, 10, p.K);
+        g.rect(8, 2, 4, 1, p.K); g.rect(9, 3, 2, 1, p.K);
+        g.rect(7, 5, 1, 6, p.L); g.rect(12, 5, 1, 6, p.D);
+    },
+    "종이·목재": (g, p) => {                       // 통나무 단면
+        g.disc(5, 4, 3.2, p.A); g.ring(5, 4, 2, 1.4, p.L); g.disc(5, 4, 0.6, p.L);
+        g.disc(13, 4, 3.2, p.N); g.ring(13, 4, 2, 1.4, p.H); g.disc(13, 4, 0.6, p.H);
+        g.disc(9, 10, 3.4, p.N); g.ring(9, 10, 2.1, 1.5, p.H); g.disc(9, 10, 0.6, p.H);
+        g.rect(2, 13, 16, 1, p.O);
+        g.rect(15, 9, 4, 1, p.S); g.rect(15, 10, 4, 2, p.N); g.rect(15, 12, 4, 1, p.O);
+    },
+    "건설업": (g, p) => {                          // 타워 크레인
+        g.rect(2, 2, 17, 1, p.L); g.rect(2, 3, 17, 1, p.A);
+        for (let x = 3; x < 19; x += 3) g.rect(x, 4, 1, 1, p.K);
+        g.rect(5, 4, 3, 1, p.L); g.rect(5, 5, 3, 8, p.A);
+        g.rect(4, 5, 1, 8, p.K); g.rect(8, 5, 1, 8, p.K);
+        for (let y = 6; y < 13; y += 2) g.rect(5, y, 3, 1, p.D);
+        g.rect(3, 13, 8, 1, p.O);
+        g.line(15, 4, 15, 8, p.O);
+        g.rect(14, 8, 3, 1, p.H); g.rect(14, 9, 3, 2, p.N); g.rect(14, 11, 3, 1, p.S);
+    },
+    "유통업": (g, p) => {                          // 쇼핑카트
+        g.line(1, 3, 4, 3, p.O); g.line(4, 3, 5, 5, p.O);
+        g.rect(5, 4, 13, 1, p.L); g.rect(5, 5, 13, 3, p.A); g.rect(6, 8, 11, 1, p.D);
+        g.rect(7, 9, 9, 1, p.K);
+        for (let x = 8; x < 17; x += 3) g.rect(x, 5, 1, 3, p.K);
+        g.disc(8, 12, 1.6, p.N); g.disc(8, 12, 0.6, p.O);
+        g.disc(15, 12, 1.6, p.N); g.disc(15, 12, 0.6, p.O);
+    },
+    "금융업": (g, p) => {                          // 기둥 건물
+        for (let i = 0; i < 6; i++) g.rect(4 + i, 2 + i, 12 - i * 2, 1, i === 0 ? p.L : p.A);
+        g.rect(2, 5, 16, 1, p.L); g.rect(2, 6, 16, 1, p.A);
+        [3, 7, 11, 15].forEach(x => {
+            g.rect(x, 7, 2, 1, p.L); g.rect(x, 8, 2, 3, p.A); g.rect(x, 11, 2, 1, p.D);
+        });
+        g.rect(2, 12, 16, 1, p.H); g.rect(2, 13, 16, 1, p.S);
+    },
+    "증권": (g, p) => {                            // 촛대 차트
+        const candle = (x: number, top: number, h: number, up: boolean) => {
+            g.line(x + 1, top - 2, x + 1, top + h + 1, p.O);
+            g.rect(x, top, 3, 1, up ? p.L : p.H);
+            g.rect(x, top + 1, 3, h - 1, up ? p.A : p.N);
+            g.rect(x, top + h, 3, 1, up ? p.D : p.S);
+        };
+        candle(3, 7, 4, false); candle(8, 4, 5, true); candle(13, 6, 4, true);
+        g.rect(1, 13, 18, 1, p.O);
+    },
+    "보험": (g, p) => {                            // 방패
+        g.rect(5, 2, 10, 1, p.L);
+        g.rect(5, 3, 10, 5, p.A);
+        g.rect(6, 8, 8, 2, p.A);
+        g.rect(7, 10, 6, 1, p.D);
+        g.rect(8, 11, 4, 1, p.D);
+        g.rect(9, 12, 2, 1, p.K);
+        g.rect(4, 3, 1, 5, p.K); g.rect(15, 3, 1, 5, p.K);
+        g.rect(9, 4, 2, 6, p.H); g.rect(7, 6, 6, 2, p.H);
+    },
+    "통신업": (g, p) => {                          // 안테나 + 전파
+        g.ring(10, 4, 4.4, 3.6, p.N); g.ring(10, 4, 7, 6.2, p.S);
+        g.line(6, 13, 9.4, 3, p.A); g.line(13, 13, 9.6, 3, p.A);
+        g.rect(8, 6, 4, 1, p.D); g.rect(7, 9, 6, 1, p.D);
+        g.rect(9, 1, 2, 3, p.L);
+        g.rect(5, 13, 10, 1, p.O);
+    },
+    "전기·가스": (g, p) => {                       // 송전탑 + 번개
+        g.line(2, 13, 5.5, 2, p.N); g.line(9, 13, 5.5, 2, p.N);
+        g.rect(3, 6, 6, 1, p.S); g.rect(2, 9, 8, 1, p.S);
+        g.rect(1, 4, 3, 1, p.S); g.rect(7, 4, 3, 1, p.S);
+        g.rect(5, 1, 2, 1, p.H);
+        g.rect(15, 2, 3, 1, p.L); g.rect(14, 3, 3, 1, p.A);
+        g.rect(13, 4, 3, 1, p.A); g.rect(12, 5, 4, 1, p.A);
+        g.rect(13, 6, 5, 1, p.L); g.rect(13, 7, 3, 1, p.A);
+        g.rect(12, 8, 3, 1, p.A); g.rect(11, 9, 3, 1, p.D); g.rect(11, 10, 2, 1, p.D);
+        g.rect(1, 13, 18, 1, p.O);
+    },
+    "서비스업": (g, p) => {                        // 안내 벨
+        g.rect(9, 1, 2, 4, p.L);
+        g.disc(10, 9, 5, p.A); g.rect(5, 9, 11, 2, p.A);
+        g.disc(7.6, 6.6, 1.8, p.L);
+        g.rect(4, 10, 13, 1, p.D);
+        g.rect(2, 11, 17, 1, p.H); g.rect(2, 12, 17, 1, p.N); g.rect(2, 13, 17, 1, p.S);
+    },
+    "IT·소프트웨어": (g, p) => {                    // 모니터 + 코드
+        g.rect(2, 2, 16, 1, p.L); g.rect(2, 3, 16, 7, p.A); g.rect(2, 10, 16, 1, p.D);
+        g.rect(3, 4, 14, 5, p.K);
+        g.line(7, 5, 5, 6.5, p.L); g.line(5, 6.5, 7, 8, p.L);
+        g.line(13, 5, 15, 6.5, p.L); g.line(15, 6.5, 13, 8, p.L);
+        g.line(11, 5, 9, 8, p.H);
+        g.rect(8, 11, 4, 1, p.N); g.rect(5, 12, 10, 1, p.H); g.rect(5, 13, 10, 1, p.S);
+    },
+    "반도체": (g, p) => {                          // 웨이퍼
+        g.disc(10, 7, 6.2, p.A);
+        g.ring(10, 7, 6.2, 5.3, p.L);
+        for (let x = 5; x <= 15; x += 3) g.line(x, 1, x, 13, p.D);
+        for (let y = 3; y <= 12; y += 3) g.line(3, y, 17, y, p.D);
+        g.disc(7, 4, 1.5, p.L);
+        g.rect(9, 12, 3, 1, p.K); g.rect(10, 13, 1, 1, p.K);
+    },
+    "운송장비·부품": (g, p) => {                    // 자동차
+        g.rect(6, 3, 8, 1, p.L); g.rect(5, 4, 10, 2, p.A);
+        g.rect(2, 6, 16, 1, p.L); g.rect(2, 7, 16, 3, p.A); g.rect(2, 10, 16, 1, p.D);
+        g.rect(6, 4, 3, 2, p.H); g.rect(11, 4, 3, 2, p.H);
+        g.rect(1, 8, 1, 1, p.H); g.rect(18, 8, 1, 1, p.H);
+        g.disc(6, 11, 2.2, p.O); g.disc(6, 11, 0.9, p.N);
+        g.disc(14, 11, 2.2, p.O); g.disc(14, 11, 0.9, p.N);
+        g.rect(2, 13, 16, 1, p.S);
+    },
+    "의료·정밀기기": (g, p) => {                    // 계기 + 십자
+        g.disc(8, 7, 6, p.N); g.ring(8, 7, 6, 5, p.S);
+        g.rect(6, 3, 4, 9, p.A); g.rect(3, 5, 10, 4, p.A);
+        g.rect(6, 3, 4, 1, p.L); g.rect(3, 5, 3, 1, p.L); g.rect(10, 5, 3, 1, p.L);
+        g.rect(6, 11, 4, 1, p.D); g.rect(3, 8, 3, 1, p.D); g.rect(10, 8, 3, 1, p.D);
+        g.rect(16, 3, 3, 1, p.H); g.rect(16, 4, 3, 7, p.N); g.rect(16, 11, 3, 1, p.S);
+        for (let y = 5; y < 11; y += 2) g.rect(16, y, 2, 1, p.O);
+    },
+    "비금속광물": (g, p) => {                      // 벽돌
+        const brick = (x: number, y: number, w: number, accent: boolean) => {
+            g.rect(x, y, w, 1, accent ? p.L : p.H);
+            g.rect(x, y + 1, w, 1, accent ? p.A : p.N);
+            g.rect(x, y + 2, w, 1, accent ? p.D : p.S);
+        };
+        brick(2, 2, 7, true); brick(10, 2, 7, false);
+        brick(2, 6, 3, false); brick(6, 6, 7, true); brick(14, 6, 4, false);
+        brick(2, 10, 7, false); brick(10, 10, 7, true);
+        g.rect(1, 13, 18, 1, p.O);
+    },
+    "오락·문화": (g, p) => {                       // 필름 릴 + 필름
+        g.disc(6, 7, 5.4, p.A); g.ring(6, 7, 5.4, 4.5, p.L);
+        g.disc(6, 7, 1.5, p.K);
+        [[6, 3.6], [6, 10.4], [2.6, 7], [9.4, 7]].forEach(([x, y]) => g.disc(x, y, 1.3, p.K));
+        g.rect(12, 3, 7, 1, p.S); g.rect(12, 4, 7, 6, p.N); g.rect(12, 10, 7, 1, p.S);
+        for (let y = 4; y < 10; y += 2) { g.rect(12, y, 1, 1, p.O); g.rect(18, y, 1, 1, p.O); }
+        g.rect(14, 5, 3, 4, p.H);
+    },
+    "부동산": (g, p) => {                          // 집
+        for (let i = 0; i < 5; i++) g.rect(5 - i + 1, 2 + i, 8 + i * 2, 1, i === 0 ? p.L : p.A);
+        g.rect(3, 7, 14, 1, p.D);
+        g.rect(4, 8, 12, 1, p.H); g.rect(4, 9, 12, 4, p.N); g.rect(4, 13, 12, 1, p.S);
+        g.rect(8, 10, 4, 4, p.K); g.rect(8, 10, 4, 1, p.D);
+        g.rect(5, 10, 2, 2, p.H); g.rect(13, 10, 2, 2, p.H);
+    },
+    "기타제조": (g, p) => {                        // 공장
+        g.rect(3, 6, 1, 1, p.L); g.rect(3, 7, 1, 2, p.A);
+        g.rect(6, 4, 2, 1, p.L); g.rect(6, 5, 2, 4, p.A);
+        g.rect(10, 6, 2, 1, p.L); g.rect(10, 7, 2, 2, p.A);
+        g.disc(7, 2, 1.4, p.N); g.disc(9.6, 1.2, 1, p.H); g.disc(4.4, 2.4, 0.9, p.H);
+        g.rect(2, 9, 16, 1, p.L); g.rect(2, 10, 16, 3, p.A); g.rect(2, 13, 16, 1, p.K);
+        [4, 8, 12, 16].forEach(x => g.rect(x, 11, 2, 2, p.K));
+        g.rect(14, 5, 4, 1, p.H); g.rect(14, 6, 4, 3, p.N); g.rect(14, 9, 4, 1, p.S);
+    },
+    "출판·매체": (g, p) => {                       // 펼친 책
+        g.rect(2, 3, 8, 1, p.H); g.rect(2, 4, 8, 8, p.N); g.rect(2, 12, 8, 1, p.S);
+        g.rect(10, 3, 8, 1, p.H); g.rect(10, 4, 8, 8, p.N); g.rect(10, 12, 8, 1, p.S);
+        g.rect(9, 2, 2, 1, p.L); g.rect(9, 3, 2, 10, p.A); g.rect(9, 13, 2, 1, p.D);
+        [5, 7, 9].forEach(y => { g.rect(4, y, 5, 1, p.S); g.rect(11, y, 5, 1, p.S); });
+        g.rect(1, 4, 1, 8, p.O); g.rect(18, 4, 1, 8, p.O);
+    },
     _default: (g, p) => {
         g.disc(10, 7, 4.6, p.A);
         g.disc(8.4, 5.4, 2.1, p.L);
@@ -170,10 +404,11 @@ export default function SectorSprite({
             bg.addColorStop(0, "#ffffff"); bg.addColorStop(1, tint);
             ctx.fillStyle = bg; ctx.fillRect(0, 0, cv.width, cv.height);
 
-            const p = palette(color || SECTOR_COLOR[sector ?? ""] || "#16a34a");
+            const spriteKey = spriteKeyFor(sector);
+            const p = palette(color || SECTOR_COLOR[spriteKey ?? ""] || "#16a34a");
             const g = makeGrid();
             if (mode === "chart") chartSprite(g, p, data);
-            else (SPRITE[sector ?? ""] || SPRITE._default)(g, p);
+            else (SPRITE[spriteKey ?? ""] || SPRITE._default)(g, p);
 
             const block = Math.max(1, Math.floor(Math.min(cv.width / GW, cv.height / GH)));
             const ox = Math.round((cv.width - GW * block) / 2);

--- a/cf-idiotquant/app/(screener)/screener/components/StockGridCard.tsx
+++ b/cf-idiotquant/app/(screener)/screener/components/StockGridCard.tsx
@@ -4,7 +4,7 @@ import { Heart, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { LiquidityBadge } from "./LiquidityBadge";
 import { STRATEGY_LABEL, STRATEGY_BADGE, STRATEGY_HEX, STRATEGY_PRESETS_CLIENT } from "@/lib/constants/strategies";
-import SectorSprite, { SECTOR_COLOR } from "./SectorSprite";
+import SectorSprite, { sectorAccent } from "./SectorSprite";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Item = Record<string, any>;
@@ -71,7 +71,7 @@ export function StockGridCard({ item, onClick, isLiked, onToggleLike }: {
             <div className="relative h-[72px] border-b border-neutral-100 dark:border-[#35332e]">
                 <SectorSprite
                     sector={sector}
-                    color={sector ? SECTOR_COLOR[sector] : (strategy ? STRATEGY_HEX[strategy] : "#16a34a")}
+                    color={sectorAccent(sector) ?? (strategy ? STRATEGY_HEX[strategy] : "#16a34a")}
                 />
                 {(sector || strategy) && (
                     <span className="absolute left-2 top-2 px-1.5 py-0.5 rounded bg-white/80 dark:bg-black/50 text-[9.5px] font-bold text-neutral-600 dark:text-neutral-300">


### PR DESCRIPTION
## 무엇을

업종으로 묶었을 때 그룹 머리에 붙는 도트 아이콘이 **다섯 종류**(철강·금속 / 전기·전자 / 기계·장비 / 화학 / 운수·창고)뿐이라 나머지 업종은 전부 같은 **기본 구(球)** 로 떨어졌다. 같은 20×14 격자 · 같은 3단 명암(위 하이라이트 · 본체 · 아래 그늘)으로 **21종**을 더 그렸다.

의약품 · 음식료품 · 섬유·의복 · 종이·목재 · 건설업 · 유통업 · 금융업 · 증권 · 보험 · 통신업 · 전기·가스 · 서비스업 · IT·소프트웨어 · 반도체 · 운송장비·부품 · 의료·정밀기기 · 비금속광물 · 오락·문화 · 부동산 · 기타제조 · 출판·매체

## 이름이 흔들려도 붙게

업종명은 KIS 가 주는 대로(`bstp_kor_isnm`) 들어와 표기가 일정하지 않다 — 가운뎃점 유무, `업` 접미사, 코스피/코스닥 표기 차이. 이름이 정확히 같을 때만 그림을 붙이면 대부분 다시 기본 구가 되므로 **낱말로 고른다**(`spriteKeyFor`). 강조색도 같은 키를 거쳐 찾는다(`sectorAccent`) — 표기가 달라도 같은 그림·같은 색이 나온다. 걸리는 낱말이 없으면 **지금처럼 기본 구**.

## 모바일 크기

그룹 머리 아이콘은 폰에서 **30×21**, `sm` 이상에서 42×30. 격자 비율 1.4 를 유지해야 20×14 도트가 정수 배로 떨어져 선명하다.

## 검증

브라우저 실측 (1280 / 390), 표기가 섞인 업종 12종(`의약품`, `금융업`, `전기·가스`, `소프트웨어`, `운수장비`, `기타서비스`, `비금속광물` …)으로:

- 12개 그룹의 **캔버스 픽셀 지문이 전부 서로 다름** — 하나라도 같으면 기본 구로 떨어진 것이므로, 이 검사가 "그림이 실제로 붙었나"를 본다
- 아이콘 바깥 칸 크기 데스크톱 **42×30** / 모바일 **30×21**, 그룹마다 동일

회귀: 묶기 동작(4뷰) · 등급 감춤(4뷰) · 옛 링크 · 결과 분포 두 띠 · 산점도 축 눈금 · `tsc --noEmit` · `npm run build` 통과.

## 남은 것

- 카드 뷰 상단의 업종 배너(72px)는 손대지 않았다 — 아이콘이 아니라 카드의 머리 이미지라 판단.
- 실제 운영 DB의 업종명 목록을 볼 수 없어, 낱말에 안 걸리는 업종이 남아 있을 수 있다. 그 경우 기본 구가 나오고 화면은 깨지지 않는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P

---
_Generated by [Claude Code](https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P)_