### PR TITLE
feat(game): 분기 운용 개선안 8개 전부 적용 (화면)

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -23,7 +23,7 @@ import { Play, Flag, TrendingUp, Coins, Wallet, RotateCcw, Eye, Building2, Lock,
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { reqGetNcavDailyList, selectNcavDailyList } from "@/lib/features/algorithmTrade/algorithmTradeSlice";
 
-import { avgPrice, quoteBuy } from "@/lib/paper/engine";
+import { avgPrice, quoteBuy, quoteSell, applyBuy, applySell } from "@/lib/paper/engine";
 import { CONTEXT_DAYS, TOTAL_DAYS, type ReplayRound, type ReplayHistoryItem, type RoundHabits, type HabitSummary } from "@/lib/paper/round";
 import { buildLocalRound, loadLocal, saveLocal, advanceLocal, giveUpLocal } from "@/lib/paper/localRound";
 import { getReplayState, startReplayRound, advanceReplayRound, giveUpReplayRound, buyTool } from "@/lib/features/paper/replayAPI";
@@ -183,6 +183,22 @@ export default function ReplayGamePage() {
     const totalRate = round?.seed ? (totalPnl / round.seed) * 100 : 0;
     const avg = round ? avgPrice({ qty: round.qty, cost_basis: round.cost_basis }) : 0;
 
+    // ── 벤치마크 ─────────────────────────────────────────────
+    // 분기 정산의 성과보수는 "그냥 사서 들고 있었을 때"와의 차이로 매긴다(firm.ts 의 settleQuarter).
+    // 그 잣대를 끝나고서야 보여 줄 이유가 없다 — 40일 내내 "잘하고 있나"에 답이 없던 자리다.
+    //
+    // 재는 시작점은 캔들 0번이 아니라 거래를 시작하는 날(컨텍스트 마지막 날)이다.
+    // 워커의 _finish 가 candles.slice(CONTEXT_DAYS - 1) 로 재므로, 여기서 0번부터 재면
+    // 화면의 숫자와 정산이 다른 잣대를 쓰게 된다.
+    const benchBase = round?.candles?.[CONTEXT_DAYS - 1]?.c ?? 0;
+    const bhRate = benchBase > 0 && price > 0 ? ((price - benchBase) / benchBase) * 100 : 0;
+    const edge = totalRate - bhRate;                                   // %p. 양수면 그냥 들고 있는 것보다 낫다
+    const tradedDays = round ? Math.max(0, round.cursor - CONTEXT_DAYS) : 0;
+    // 첫 며칠은 차이가 크게 요동쳐 읽을 값이 못 된다. 닷새 지나고부터 말한다.
+    const benchNote = round && round.status === "playing" && tradedDays >= 5 && benchBase > 0
+        ? `그냥 들고 ${pct(bhRate)} · 나 ${pct(totalRate)} (${edge >= 0 ? "+" : ""}${edge.toFixed(1)}%p)`
+        : null;
+
     // cash / price 만으로는 수수료가 빠진다 — 현금이 가격으로 딱 나누어떨어지면
     // 최대매수를 누르고 사기를 눌렀을 때 "현금이 부족합니다"로 거절당한다.
     // 실제 견적(quoteBuy)으로 확인해 들어가는 수량까지 줄인다. 한두 번이면 끝난다.
@@ -217,7 +233,7 @@ export default function ReplayGamePage() {
         const owned = firm?.tools ?? [];
         const on = (id: string) => owned.includes(id) && activeTools.includes(id);
         const closes = visible.map(c => c.c);
-        const out: { name: string; data: (number | null)[]; color: string; dash?: string }[] = [];
+        const out: { name: string; data: (number | null)[]; color: string; dash?: string; legend?: boolean }[] = [];
 
         if (on("ma")) {
             out.push({ name: "5일선", data: movingAverage(closes, 5), color: "#f59e0b" });
@@ -228,8 +244,41 @@ export default function ReplayGamePage() {
             out.push({ name: "밴드상단", data: b.upper, color: "#94a3b8", dash: "3 3" });
             out.push({ name: "밴드하단", data: b.lower, color: "#94a3b8", dash: "3 3" });
         }
+
+        // 내 자산 곡선. 가격선이 곧 "그냥 사서 들고 있었을 때"라 비교 상대는 이미 화면에 있고,
+        // 없던 건 내 쪽이었다. 같은 축에 얹으려고 시드를 거래 시작가로 환산한다 —
+        // 두 선이 같은 점에서 출발하므로 벌어진 만큼이 그대로 초과 성과다.
+        //
+        // 값은 체결 기록으로 되짚는다. 진행 중 응답에는 지난 날의 잔고가 없고, 수수료를 빼면
+        // 곡선이 실제 계좌와 어긋난다. 규칙 사본을 새로 만들지 않으려고 engine 의 견적을 그대로 쓴다.
+        if (round && benchBase > 0) {
+            // orders 가 없는 응답(예전 워커·부분 응답)에도 화면이 살아 있어야 한다.
+            // 마커 쪽이 이미 같은 이유로 ?? [] 를 쓰고 있다.
+            const byDay = new Map<number, typeof round.orders>();
+            for (const o of round.orders ?? []) {
+                const a = byDay.get(o.day_index);
+                if (a) a.push(o); else byDay.set(o.day_index, [o]);
+            }
+            let cash = round.seed;
+            let pos = { ticker: "", name: null as string | null, qty: 0, cost_basis: 0 };
+            const mine: (number | null)[] = [];
+            visible.forEach((c, i) => {
+                for (const o of byDay.get(i) ?? []) {
+                    if (o.side === "buy") {
+                        const q = quoteBuy({ price: o.price, qty: o.qty, cash });
+                        if (q.ok) { cash -= q.total; pos = { ...pos, ...applyBuy(pos, q) }; }
+                    } else {
+                        const q = quoteSell({ price: o.price, qty: o.qty, position: pos });
+                        if (q.ok) { cash += q.net; pos = { ...pos, ...applySell(pos, q) }; }
+                    }
+                }
+                // 거래 시작 전에는 비교할 것이 없어 비워 둔다
+                mine.push(i >= CONTEXT_DAYS - 1 ? Math.round((cash + pos.qty * c.c) / round.seed * benchBase) : null);
+            });
+            out.unshift({ name: "내 성과", data: mine, color: "#0ea5e9", legend: true });
+        }
         return out;
-    }, [firm?.tools, activeTools, visible]);
+    }, [firm?.tools, activeTools, visible, round, benchBase]);
 
     // 사고판 지점을 차트에 찍는다. 빨강이 매수, 초록이 매도 — 버튼 색과 같다.
     // 수량 라벨은 체결이 적을 때만 붙인다. 많아지면 서로 겹쳐 오히려 안 읽힌다.
@@ -343,10 +392,14 @@ export default function ReplayGamePage() {
                                 <h2 className="text-[13px] font-black text-neutral-900 dark:text-neutral-100 shrink-0">
                                     {round.status === "done" ? (round.name ?? "차트") : "블라인드 차트"}
                                 </h2>
-                                <p className="text-[10px] text-neutral-400 truncate">
+                                {/* 진행 중에는 이 자리를 벤치마크 비교가 쓴다 — 종목·시기 안내는
+                                    한 번 읽으면 되는 문장이고, 이쪽은 매일 달라진다. */}
+                                <p className={cn("text-[10px] truncate", benchNote ? "font-bold" : "text-neutral-400")}>
                                     {round.status === "done"
-                                        ? `${round.ticker} · ${fmtDate(round.start_date)}~${fmtDate(round.end_date)}`
-                                        : "종목·시기는 끝나야 열립니다"}
+                                        ? <span className="text-neutral-400">{`${round.ticker} · ${fmtDate(round.start_date)}~${fmtDate(round.end_date)}`}</span>
+                                        : benchNote
+                                            ? <span className={edge >= 0 ? "text-[#16a34a]" : "text-red-500"}>{benchNote}</span>
+                                            : <span className="text-neutral-400">종목·시기는 끝나야 열립니다</span>}
                                 </p>
                             </div>
                             <div className="hidden sm:block">
@@ -355,7 +408,7 @@ export default function ReplayGamePage() {
                                     title={round.status === "done" ? (round.name ?? "차트") : "블라인드 차트"}
                                     subtitle={round.status === "done"
                                         ? `${round.ticker} · ${fmtDate(round.start_date)} ~ ${fmtDate(round.end_date)}`
-                                        : "종목명과 시기는 끝나야 열립니다"}
+                                        : benchNote ?? "종목명과 시기는 끝나야 열립니다"}
                                 />
                             </div>
                             {/* recharts 의 ResponsiveContainer 는 부모 높이가 flex 로 정해지면 한 번 잰

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -29,6 +29,7 @@ import { buildLocalRound, loadLocal, saveLocal, advanceLocal, giveUpLocal } from
 import { getReplayState, startReplayRound, advanceReplayRound, giveUpReplayRound, buyTool } from "@/lib/features/paper/replayAPI";
 import { TOOLS, INITIAL_AUM, rankOf, fmtMoney, type Firm } from "@/lib/paper/firm";
 import { movingAverage, bollinger } from "@/lib/paper/indicators";
+import SectorSprite, { sectorAccent } from "@/app/(screener)/screener/components/SectorSprite";
 
 import {
     fmtKrw, KpiCard, PnlIcon, pnlIconBg, pnlValueColor, pnlAccentColor,
@@ -42,6 +43,16 @@ const LineChart = dynamic(() => import("@/components/LineChart"), {
     ssr: false,
     loading: () => <div className="h-full min-h-[120px] rounded-2xl bg-neutral-100 dark:bg-[#242320] animate-pulse" />,
 });
+
+// 판의 성격. id 는 워커 src/lib/scenario.js 와 같아야 한다 — 규칙은 서버에만 있고
+// 여기는 이름만 안다(습관과 같은 방식이다).
+const SCENARIOS: { id: string; label: string; hint: string }[] = [
+    { id: "plunge", label: "급락 뒤", hint: "고점에서 크게 빠진 자리" },
+    { id: "range", label: "지루한 횡보", hint: "위아래로 별로 안 움직인 구간" },
+    { id: "peak", label: "고점 근처", hint: "최근 고점 가까이 붙어 있는 자리" },
+];
+const scenarioLabel = (id?: string | null) =>
+    id === "mixed" ? "보통" : (SCENARIOS.find(s => s.id === id)?.label ?? null);
 
 // 여러 날 건너뛰기를 멈추는 문턱. 이만큼 움직인 날은 지나치면 손쓸 수 없다.
 const JUMP_STOP_PCT = 7;
@@ -104,11 +115,11 @@ export default function ReplayGamePage() {
         return () => { cancelled = true; };
     }, [isLoggedIn, status]);
 
-    const start = useCallback(async () => {
+    const start = useCallback(async (scenario?: string | null) => {
         setBusy(true);
         try {
             if (isLoggedIn) {
-                const res = await startReplayRound();
+                const res = await startReplayRound(scenario);
                 if (!res.success) { addToast("error", res.error); return; }
                 setRound(res.round);
             } else {
@@ -428,8 +439,17 @@ export default function ReplayGamePage() {
                             라야 내용 높이가 바닥이 되고, 자리가 정말 모자라면 바깥이 스크롤된다. */}
                         <SectionPanel className="flex-1 flex flex-col p-3 sm:p-5">
                             <div className="sm:hidden flex items-baseline justify-between gap-2 mb-1.5 shrink-0">
-                                <h2 className="text-[13px] font-black text-neutral-900 dark:text-neutral-100 shrink-0">
+                                <h2 className="text-[13px] font-black text-neutral-900 dark:text-neutral-100 shrink-0 flex items-center gap-1.5">
                                     {round.status === "done" ? (round.name ?? "차트") : "블라인드 차트"}
+                                    {/* 업종만 열어 준다 — 가격 말고 붙잡을 것 하나(개선안 ⑤) */}
+                                    {round.sector && (
+                                        <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-neutral-100 dark:bg-[#2c2a26] text-[10px] font-bold text-neutral-500 dark:text-neutral-400">
+                                            <span className="w-[17px] h-[12px] rounded-[3px] overflow-hidden shrink-0">
+                                                <SectorSprite sector={round.sector} color={sectorAccent(round.sector)} />
+                                            </span>
+                                            {round.sector}
+                                        </span>
+                                    )}
                                 </h2>
                                 {/* 진행 중에는 이 자리를 벤치마크 비교가 쓴다 — 종목·시기 안내는
                                     한 번 읽으면 되는 문장이고, 이쪽은 매일 달라진다. */}
@@ -443,6 +463,15 @@ export default function ReplayGamePage() {
                             </div>
                             <div className="hidden sm:block">
                                 <SectionHeader
+                                    badge={round.sector ? (
+                                        <span className="inline-flex items-center gap-1.5 px-2 py-1 rounded-lg bg-neutral-100 dark:bg-[#2c2a26] text-[11px] font-bold text-neutral-600 dark:text-neutral-300">
+                                            <span className="w-[24px] h-[17px] rounded-[3px] overflow-hidden shrink-0">
+                                                <SectorSprite sector={round.sector} color={sectorAccent(round.sector)} />
+                                            </span>
+                                            {round.sector}
+                                            {scenarioLabel(round.scenario) && <span className="opacity-60">· {scenarioLabel(round.scenario)}</span>}
+                                        </span>
+                                    ) : undefined}
                                     icon={<TrendingUp size={16} />}
                                     title={round.status === "done" ? (round.name ?? "차트") : "블라인드 차트"}
                                     subtitle={round.status === "done"
@@ -616,13 +645,15 @@ function MiniStat({ label, value, sub, valueColor }: { label: string; value: str
 // ─────────────────────────────────────────────────────────
 /** 회사 대시보드 — 판이 없을 때. 시작 버튼까지 한 화면에 들어와야 한다. */
 function FirmDashboard({ onStart, busy, isLoggedIn, firm, bestReturn, history, habits, onBuy, activeTools, onToggle }: {
-    onStart: () => void; busy: boolean; isLoggedIn: boolean;
+    onStart: (scenario?: string | null) => void; busy: boolean; isLoggedIn: boolean;
     firm: Firm | null; bestReturn: number | null; history: ReplayHistoryItem[];
     habits: HabitSummary | null;
     onBuy: (id: string) => void; activeTools: string[]; onToggle: (id: string) => void;
 }) {
     const aum = firm?.aum ?? INITIAL_AUM;
     const owned = firm?.tools ?? [];
+    // 고른 판 성격. null 이면 아무 자리나.
+    const [want, setWant] = useState<string | null>(null);
 
     return (
         <>
@@ -672,8 +703,38 @@ function FirmDashboard({ onStart, busy, isLoggedIn, firm, bestReturn, history, h
                     ))}
                 </ul>
 
-                <button onClick={onStart} disabled={busy}
-                    className="mt-3 sm:mt-5 w-full inline-flex items-center justify-center gap-2 min-h-[52px] rounded-xl bg-gradient-to-b from-[#f7dc8c] to-[#d9a52a] hover:from-[#ffe7a4] hover:to-[#e6b13a] text-[#2a1c00] font-black text-[15px] disabled:opacity-50 transition-all">
+                {/* 판 고르기 — 무작위만 있으면 배움이 안 쌓인다. 같은 성격의 판을 여러 번 겪어야
+                    "나는 급락 뒤에 너무 빨리 산다" 같은 습관이 드러난다(개선안 ⑦).
+                    성격은 서버가 컨텍스트 구간만 보고 붙이므로 정답이 새지 않는다. */}
+                {isLoggedIn && (
+                    <div className="mt-3 sm:mt-5">
+                        <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 mb-1.5">어떤 자리에서 시작할까요</p>
+                        <div className="flex gap-1.5 flex-wrap">
+                            <button onClick={() => setWant(null)} disabled={busy}
+                                className={cn("min-h-[36px] px-3 rounded-lg text-[11.5px] font-bold border transition-colors disabled:opacity-40",
+                                    want === null
+                                        ? "bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 border-neutral-900 dark:border-white"
+                                        : "text-neutral-500 dark:text-neutral-400 border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26]")}>
+                                아무 자리나
+                            </button>
+                            {SCENARIOS.map(sc => (
+                                <button key={sc.id} onClick={() => setWant(sc.id)} disabled={busy} title={sc.hint}
+                                    className={cn("min-h-[36px] px-3 rounded-lg text-[11.5px] font-bold border transition-colors disabled:opacity-40",
+                                        want === sc.id
+                                            ? "bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 border-neutral-900 dark:border-white"
+                                            : "text-neutral-500 dark:text-neutral-400 border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26]")}>
+                                    {sc.label}
+                                </button>
+                            ))}
+                        </div>
+                        <p className="mt-1.5 text-[10.5px] text-neutral-400 dark:text-neutral-500 break-keep">
+                            고른 자리가 안 나오면 만들어진 판으로 시작합니다. 실제로 어떤 자리였는지는 차트 옆에 적힙니다.
+                        </p>
+                    </div>
+                )}
+
+                <button onClick={() => onStart(want)} disabled={busy}
+                    className="mt-2.5 sm:mt-4 w-full inline-flex items-center justify-center gap-2 min-h-[52px] rounded-xl bg-gradient-to-b from-[#f7dc8c] to-[#d9a52a] hover:from-[#ffe7a4] hover:to-[#e6b13a] text-[#2a1c00] font-black text-[15px] disabled:opacity-50 transition-all">
                     <Play size={16} strokeWidth={2.6} />
                     {busy ? "종목을 고르는 중…" : `${(firm?.quarters ?? 0) + 1}분기 운용 시작`}
                 </button>

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -150,13 +150,13 @@ export default function ReplayGamePage() {
     // 어느 판에서 출발하는지 인자로 받는다 — 여러 날 건너뛰기가 앞선 응답을 이어받아야 해서,
     // 클로저에 잡힌 옛 round 로는 비로그인 경로(advanceLocal)가 같은 날을 반복한다.
     const advanceFrom = useCallback(async (
-        from: ReplayRound, trade?: { side: "buy" | "sell"; qty: number } | null,
+        from: ReplayRound, trade?: { side: "buy" | "sell"; qty: number } | null, carry?: boolean,
     ): Promise<ReplayRound | null> => {
         if (from.status !== "playing") return null;
         setBusy(true);
         try {
             if (isLoggedIn) {
-                const res = await advanceReplayRound(from.id, trade);
+                const res = await advanceReplayRound(from.id, trade, carry);
                 if (!res.success) { addToast("error", res.error); return null; }
                 setRound(res.round);
                 if (res.done) {
@@ -179,9 +179,9 @@ export default function ReplayGamePage() {
         }
     }, [isLoggedIn, addToast]);
 
-    const advance = useCallback(async (trade?: { side: "buy" | "sell"; qty: number } | null) => {
+    const advance = useCallback(async (trade?: { side: "buy" | "sell"; qty: number } | null, carry?: boolean) => {
         if (!round) return;
-        await advanceFrom(round, trade);
+        await advanceFrom(round, trade, carry);
     }, [round, advanceFrom]);
 
     // 여러 날 한 번에 넘기기. 아무 일도 없는 날의 클릭을 없애되, 큰 폭으로 움직인 날에는
@@ -252,6 +252,9 @@ export default function ReplayGamePage() {
     const bhRate = benchBase > 0 && price > 0 ? ((price - benchBase) / benchBase) * 100 : 0;
     const edge = totalRate - bhRate;                                   // %p. 양수면 그냥 들고 있는 것보다 낫다
     const tradedDays = round ? Math.max(0, round.cursor - CONTEXT_DAYS) : 0;
+    // 마지막 날에 보유가 남아 있으면 다음 분기로 넘길 수 있다. 회사가 있어야 이어진다.
+    const canCarry = !!round && isLoggedIn && round.status === "playing"
+        && round.cursor >= TOTAL_DAYS && round.qty > 0;
     // 첫 며칠은 차이가 크게 요동쳐 읽을 값이 못 된다. 닷새 지나고부터 말한다.
     const benchNote = round && round.status === "playing" && tradedDays >= 5 && benchBase > 0
         ? `그냥 들고 ${pct(bhRate)} · 나 ${pct(totalRate)} (${edge >= 0 ? "+" : ""}${edge.toFixed(1)}%p)`
@@ -586,10 +589,20 @@ export default function ReplayGamePage() {
                                             className="min-h-[52px] rounded-xl text-[15px] font-black text-white bg-red-500 hover:bg-red-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
                                             사기
                                         </button>
-                                        <button onClick={() => advance(null)} disabled={busy}
-                                            className="min-h-[52px] rounded-xl text-[15px] font-black text-neutral-700 dark:text-neutral-200 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40 transition-colors">
-                                            관망
-                                        </button>
+                                        {/* 마지막 날에는 관망 자리가 '들고 가기'가 된다 — 41일 안에 반드시
+                                            정리해야 하는 규칙이 길게 보는 전략을 무조건 불리하게 만들었다(개선안 ⑧).
+                                            넘긴 보유는 넘길 때 종가로 다시 산 셈이 되고, 다음 분기도 시드는 그대로다. */}
+                                        {canCarry ? (
+                                            <button onClick={() => advance(null, true)} disabled={busy}
+                                                className="min-h-[52px] rounded-xl text-[13.5px] font-black text-[#a1730a] dark:text-[#e3b34a] border border-[#e3b34a]/50 hover:bg-[#faf1dc] dark:hover:bg-[#2a2211] disabled:opacity-40 transition-colors">
+                                                들고 가기
+                                            </button>
+                                        ) : (
+                                            <button onClick={() => advance(null)} disabled={busy}
+                                                className="min-h-[52px] rounded-xl text-[15px] font-black text-neutral-700 dark:text-neutral-200 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40 transition-colors">
+                                                관망
+                                            </button>
+                                        )}
                                         <button onClick={() => advance({ side: "sell", qty })} disabled={busy || round.qty < 1}
                                             className="min-h-[52px] rounded-xl text-[15px] font-black text-[#16a34a] border border-[#16a34a]/40 hover:bg-[#f0fdf4] dark:hover:bg-[#052e16]/40 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
                                             팔기
@@ -791,10 +804,22 @@ function FirmDashboard({ onStart, busy, isLoggedIn, firm, bestReturn, history, h
                     ))}
                 </ul>
 
+                {firm?.carry && (
+                    <div className="mt-3 sm:mt-4 rounded-xl border border-[#e3b34a]/50 bg-[#faf1dc] dark:bg-[#2a2211] px-3.5 py-2.5">
+                        <p className="text-[11.5px] sm:text-[12.5px] font-bold text-[#a1730a] dark:text-[#e3b34a] break-keep">
+                            지난 분기에서 {firm.carry.qty}주를 들고 왔습니다 (주당 {fmtKrw(firm.carry.price)}
+                            {firm.carry.sector ? ` · ${firm.carry.sector}` : ""}). 같은 회사로 이어서 시작합니다.
+                        </p>
+                        <p className="mt-1 text-[10.5px] text-[#a1730a]/80 dark:text-[#e3b34a]/70 break-keep">
+                            시드는 이번에도 1,000만원입니다 — 그중 일부가 이미 그 회사에 들어가 있습니다.
+                        </p>
+                    </div>
+                )}
+
                 {/* 판 고르기 — 무작위만 있으면 배움이 안 쌓인다. 같은 성격의 판을 여러 번 겪어야
                     "나는 급락 뒤에 너무 빨리 산다" 같은 습관이 드러난다(개선안 ⑦).
                     성격은 서버가 컨텍스트 구간만 보고 붙이므로 정답이 새지 않는다. */}
-                {isLoggedIn && (
+                {isLoggedIn && !firm?.carry && (
                     <div className="mt-3 sm:mt-5">
                         <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 mb-1.5">어떤 자리에서 시작할까요</p>
                         <div className="flex gap-1.5 flex-wrap">
@@ -824,7 +849,7 @@ function FirmDashboard({ onStart, busy, isLoggedIn, firm, bestReturn, history, h
                 <button onClick={() => onStart(want)} disabled={busy}
                     className="mt-2.5 sm:mt-4 w-full inline-flex items-center justify-center gap-2 min-h-[52px] rounded-xl bg-gradient-to-b from-[#f7dc8c] to-[#d9a52a] hover:from-[#ffe7a4] hover:to-[#e6b13a] text-[#2a1c00] font-black text-[15px] disabled:opacity-50 transition-all">
                     <Play size={16} strokeWidth={2.6} />
-                    {busy ? "종목을 고르는 중…" : `${(firm?.quarters ?? 0) + 1}분기 운용 시작`}
+                    {busy ? "종목을 고르는 중…" : firm?.carry ? `${(firm?.quarters ?? 0) + 1}분기 이어서 운용` : `${(firm?.quarters ?? 0) + 1}분기 운용 시작`}
                 </button>
             </SectionPanel>
 
@@ -964,6 +989,12 @@ function QuarterReport({ round, isLoggedIn }: { round: ReplayRound; isLoggedIn: 
                         <p className={cn("text-lg sm:text-xl font-black font-mono", pnlValueColor(bh >= 0))}>{pct(bh)}</p>
                     </div>
                 </div>
+
+                {round.carried && (
+                    <p className="text-[11.5px] sm:text-[13px] font-bold break-keep text-[#a1730a] dark:text-[#e3b34a]">
+                        {round.qty}주를 다음 분기로 넘겼습니다. 아직 들고 있으므로 어떤 회사였는지는 열지 않습니다.
+                    </p>
+                )}
 
                 <p className="text-[12px] sm:text-[14px] font-bold break-keep text-neutral-700 dark:text-neutral-200">
                     {beat

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -62,6 +62,22 @@ const RESERVE_KINDS: { id: Reservation["kind"]; label: string; hint: string }[] 
 ];
 const reserveLabel = (k: string) => RESERVE_KINDS.find(r => r.id === k)?.label ?? k;
 
+// 살 때는 현금의 몇 %, 팔 때는 보유의 몇 %. 주식 수를 손으로 적는 것보다 이쪽이
+// 실제로 하는 생각("반은 실어 보자")에 가깝고, 폰에서 한 손으로 굴러간다.
+const BUY_PARTS = [
+    { pct: 10, label: "10%" },
+    { pct: 25, label: "25%" },
+    { pct: 50, label: "50%" },
+    { pct: 100, label: "최대" },
+];
+const SELL_PARTS = [
+    { pct: 25, label: "25%" },
+    { pct: 50, label: "50%" },
+    { pct: 100, label: "전부" },
+];
+// 예약 가격도 값을 적는 대신 지금 값에서 얼마나 떨어진 자리인지로 고른다.
+const RESERVE_STEPS = { down: [3, 5, 10], up: [5, 10, 20] };
+
 // 여러 날 건너뛰기를 멈추는 문턱. 이만큼 움직인 날은 지나치면 손쓸 수 없다.
 const JUMP_STOP_PCT = 7;
 const SKIP_STEPS = [3, 5];
@@ -86,12 +102,12 @@ export default function ReplayGamePage() {
     const [activeTools, setActiveTools] = useState<string[]>([]);
     const [loading, setLoading] = useState(true);
     const [busy, setBusy] = useState(false);
-    const [qty, setQty] = useState(10);
     // 예약 패널 — 접었다 편다. 모바일은 한 화면이 빡빡해 기본은 접어 둔다.
     const [reserveOpen, setReserveOpen] = useState(false);
     const [resKind, setResKind] = useState<Reservation["kind"]>("buy_limit");
-    const [resPrice, setResPrice] = useState(0);
-    const [resQty, setResQty] = useState(10);
+    // 값 대신 "지금 값에서 몇 % 떨어진 자리"와 "얼마만큼"으로 고른다.
+    const [resStep, setResStep] = useState(5);
+    const [resPart, setResPart] = useState(50);
 
     // 비로그인 판을 만들 때 쓸 종목 풀. 로그인은 서버가 알아서 뽑는다.
     useEffect(() => { if (!isLoggedIn) dispatch(reqGetNcavDailyList("latest")); }, [isLoggedIn, dispatch]);
@@ -141,7 +157,6 @@ export default function ReplayGamePage() {
                 if (!built) { addToast("error", "판을 만들지 못했습니다. 다시 시도해주세요."); return; }
                 setRound(built);
             }
-            setQty(10);
         } finally {
             setBusy(false);
         }
@@ -260,29 +275,44 @@ export default function ReplayGamePage() {
         ? `그냥 들고 ${pct(bhRate)} · 나 ${pct(totalRate)} (${edge >= 0 ? "+" : ""}${edge.toFixed(1)}%p)`
         : null;
 
-    // cash / price 만으로는 수수료가 빠진다 — 현금이 가격으로 딱 나누어떨어지면
-    // 최대매수를 누르고 사기를 눌렀을 때 "현금이 부족합니다"로 거절당한다.
-    // 실제 견적(quoteBuy)으로 확인해 들어가는 수량까지 줄인다. 한두 번이면 끝난다.
-    const maxBuy = useMemo(() => {
-        const cash = round?.cash ?? 0;
-        if (price <= 0) return 0;
-        let n = Math.floor(cash / price);
-        while (n > 0 && !quoteBuy({ price, qty: n, cash }).ok) n--;
+    // 현금의 pct% 로 살 수 있는 주식 수. 수수료까지 넣어 실제로 통과하는 수량까지 줄인다.
+    const buyQtyFor = useCallback((pct: number, atPrice = price) => {
+        const cash = Math.floor((round?.cash ?? 0) * pct / 100);
+        if (atPrice <= 0 || cash <= 0) return 0;
+        let n = Math.floor(cash / atPrice);
+        while (n > 0 && !quoteBuy({ price: atPrice, qty: n, cash }).ok) n--;
         return n;
-    }, [price, round?.cash]);
+    }, [round?.cash, price]);
+
+    /** 보유의 pct%. 100% 는 남김없이 — 1주라도 남으면 "전부"가 거짓말이 된다. */
+    const sellQtyFor = useCallback((pct: number) => {
+        const held = round?.qty ?? 0;
+        if (held <= 0) return 0;
+        return pct >= 100 ? held : Math.max(1, Math.min(held, Math.floor(held * pct / 100)));
+    }, [round?.qty]);
+
+    // 예약 가격 — 익절은 위로, 나머지는 아래로.
+    const resPriceAt = useCallback((step: number) =>
+        Math.max(1, Math.round(price * (resKind === "take_profit" ? 1 + step / 100 : 1 - step / 100))),
+        [price, resKind]);
+    // 예약 수량 — 사는 예약은 그 가격 기준 현금 비율, 파는 예약은 보유 비율.
+    const resQtyFor = useCallback((part: number) =>
+        resKind === "buy_limit" ? buyQtyFor(part, resPriceAt(resStep)) : sellQtyFor(part),
+        [resKind, resStep, buyQtyFor, sellQtyFor, resPriceAt]);
 
     const reserve = useCallback(async () => {
         if (!round) return;
         setBusy(true);
         try {
-            const res = await reserveOrder(round.id, { kind: resKind, price: resPrice, qty: resQty });
+            const p = resPriceAt(resStep), n = resQtyFor(resPart);
+            const res = await reserveOrder(round.id, { kind: resKind, price: p, qty: n });
             if (!res.success) { addToast("error", res.error); return; }
             setRound(res.round);
-            addToast("success", `${reserveLabel(resKind)} ${resPrice.toLocaleString()}원 ${resQty}주를 걸어 뒀습니다.`);
+            addToast("success", `${reserveLabel(resKind)} ${p.toLocaleString()}원 ${n}주를 걸어 뒀습니다.`);
         } finally {
             setBusy(false);
         }
-    }, [round, resKind, resPrice, resQty, addToast]);
+    }, [round, resKind, resStep, resPart, resPriceAt, resQtyFor, addToast]);
 
     const unreserve = useCallback(async (index: number) => {
         if (!round) return;
@@ -555,58 +585,68 @@ export default function ReplayGamePage() {
                         {round.status === "playing" && (
                             <SectionPanel className="shrink-0 p-3 sm:p-5">
                                 <div className="flex flex-col gap-2 sm:gap-4">
-                                    <div className="flex items-center gap-1.5 sm:gap-2">
-                                        <span className="text-[10px] sm:text-xs font-black text-neutral-400 uppercase tracking-wider shrink-0">수량</span>
-                                        <input
-                                            type="number" min={1} value={qty} aria-label="주문 수량"
-                                            onChange={e => setQty(Math.max(1, Math.floor(Number(e.target.value) || 1)))}
-                                            className="w-16 sm:w-24 min-h-[40px] sm:min-h-[44px] px-2 sm:px-3 rounded-xl text-sm text-right font-mono bg-neutral-50 dark:bg-[#1a1917] border border-neutral-200 dark:border-[#35332e] text-neutral-900 dark:text-white"
-                                        />
-                                        <div className="flex gap-1 sm:gap-1.5 flex-1 justify-end">
-                                            {[10, 50, 100].map(n => (
-                                                <button key={n} onClick={() => setQty(n)}
-                                                    className="min-h-[36px] px-2 sm:px-2.5 rounded-lg text-[11px] font-bold text-neutral-500 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26]">
-                                                    {n}
-                                                </button>
-                                            ))}
-                                            {/* 수량 칸 하나를 사기·팔기가 같이 쓰므로 "최대"도 한쪽만
-                                                가리킬 수 없다. 현금 기준과 보유 기준을 따로 둔다. */}
-                                            <button onClick={() => setQty(Math.max(1, maxBuy))} disabled={maxBuy < 1}
-                                                className="min-h-[36px] px-1.5 sm:px-2.5 rounded-lg text-[10px] sm:text-[11px] font-bold whitespace-nowrap text-red-500/90 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40">
-                                                최대매수
-                                            </button>
-                                            <button onClick={() => setQty(round.qty)} disabled={round.qty < 1}
-                                                className="min-h-[36px] px-1.5 sm:px-2.5 rounded-lg text-[10px] sm:text-[11px] font-bold whitespace-nowrap text-[#16a34a] border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40">
-                                                전량매도
-                                            </button>
+                                    {/* 살 때는 현금의 몇 %, 팔 때는 보유의 몇 %. 누르면 그 자리에서 체결되고
+                                        하루가 지나간다 — 수량을 적고 다시 사기를 누르던 두 걸음을 한 걸음으로. */}
+                                    <div className="grid grid-cols-[34px_1fr] gap-x-2 gap-y-1.5 items-center">
+                                        <span className="text-[10.5px] font-black text-red-500">사기</span>
+                                        <div className="grid grid-cols-4 gap-1.5">
+                                            {BUY_PARTS.map(part => {
+                                                const n = buyQtyFor(part.pct);
+                                                return (
+                                                    <button key={part.pct} aria-label={`사기 ${part.label}`}
+                                                        onClick={() => advance({ side: "buy", qty: n })} disabled={busy || n < 1}
+                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-white bg-red-500 hover:bg-red-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex flex-col items-center justify-center leading-none gap-0.5">
+                                                        {part.label}
+                                                        <span className="text-[9px] font-bold opacity-80">{n > 0 ? `${n}주` : "—"}</span>
+                                                    </button>
+                                                );
+                                            })}
                                         </div>
-                                    </div>
 
-                                    {/* 라벨을 짧게 — "사고 하루 넘기기"는 390px 3열에서 두 줄로 쪼개진다.
-                                        어느 쪽을 눌러도 하루가 지나간다는 건 아래 한 줄로 말한다. */}
-                                    <div className="grid grid-cols-3 gap-2">
-                                        <button onClick={() => advance({ side: "buy", qty })} disabled={busy || maxBuy < 1}
-                                            className="min-h-[52px] rounded-xl text-[15px] font-black text-white bg-red-500 hover:bg-red-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
-                                            사기
-                                        </button>
-                                        {/* 마지막 날에는 관망 자리가 '들고 가기'가 된다 — 41일 안에 반드시
-                                            정리해야 하는 규칙이 길게 보는 전략을 무조건 불리하게 만들었다(개선안 ⑧).
-                                            넘긴 보유는 넘길 때 종가로 다시 산 셈이 되고, 다음 분기도 시드는 그대로다. */}
+                                        <span className="text-[10.5px] font-black text-[#16a34a]">팔기</span>
+                                        <div className="grid grid-cols-3 gap-1.5">
+                                            {SELL_PARTS.map(part => {
+                                                const n = sellQtyFor(part.pct);
+                                                return (
+                                                    <button key={part.pct} aria-label={`팔기 ${part.label}`}
+                                                        onClick={() => advance({ side: "sell", qty: n })} disabled={busy || n < 1}
+                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-[#16a34a] border border-[#16a34a]/40 hover:bg-[#f0fdf4] dark:hover:bg-[#052e16]/40 disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex flex-col items-center justify-center leading-none gap-0.5">
+                                                        {part.label}
+                                                        <span className="text-[9px] font-bold opacity-70">{n > 0 ? `${n}주` : "—"}</span>
+                                                    </button>
+                                                );
+                                            })}
+                                        </div>
+
+                                        {/* 사기·팔기와 같은 줄 문법 — 관망도 "얼마나"를 고른다.
+                                            마지막 날에는 남은 보유를 다음 분기로 넘길 수 있다(개선안 ⑧). */}
+                                        <span className="text-[10.5px] font-black text-neutral-400">관망</span>
                                         {canCarry ? (
-                                            <button onClick={() => advance(null, true)} disabled={busy}
-                                                className="min-h-[52px] rounded-xl text-[13.5px] font-black text-[#a1730a] dark:text-[#e3b34a] border border-[#e3b34a]/50 hover:bg-[#faf1dc] dark:hover:bg-[#2a2211] disabled:opacity-40 transition-colors">
-                                                들고 가기
-                                            </button>
+                                            <div className="grid grid-cols-2 gap-1.5">
+                                                <button onClick={() => advance(null, true)} disabled={busy}
+                                                    className="min-h-[46px] rounded-xl text-[13px] font-black text-[#a1730a] dark:text-[#e3b34a] border border-[#e3b34a]/50 hover:bg-[#faf1dc] dark:hover:bg-[#2a2211] disabled:opacity-40 transition-colors">
+                                                    들고 가기
+                                                </button>
+                                                <button onClick={() => advance(null)} disabled={busy}
+                                                    className="min-h-[46px] rounded-xl text-[13px] font-black text-neutral-600 dark:text-neutral-300 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40 transition-colors">
+                                                    정리하고 끝
+                                                </button>
+                                            </div>
                                         ) : (
-                                            <button onClick={() => advance(null)} disabled={busy}
-                                                className="min-h-[52px] rounded-xl text-[15px] font-black text-neutral-700 dark:text-neutral-200 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40 transition-colors">
-                                                관망
-                                            </button>
+                                            <div className="grid grid-cols-3 gap-1.5">
+                                                <button onClick={() => advance(null)} disabled={busy}
+                                                    className="min-h-[46px] rounded-xl text-[13px] font-black text-neutral-600 dark:text-neutral-300 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40 transition-colors">
+                                                    하루
+                                                </button>
+                                                {SKIP_STEPS.map(n => (
+                                                    <button key={n} onClick={() => skipDays(n)} disabled={busy} aria-label={`${n}일`}
+                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-neutral-600 dark:text-neutral-300 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40 transition-colors flex flex-col items-center justify-center leading-none gap-0.5">
+                                                        {n}일
+                                                        <span className="text-[9px] font-bold opacity-60">±{JUMP_STOP_PCT}%면 멈춤</span>
+                                                    </button>
+                                                ))}
+                                            </div>
                                         )}
-                                        <button onClick={() => advance({ side: "sell", qty })} disabled={busy || round.qty < 1}
-                                            className="min-h-[52px] rounded-xl text-[15px] font-black text-[#16a34a] border border-[#16a34a]/40 hover:bg-[#f0fdf4] dark:hover:bg-[#052e16]/40 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
-                                            팔기
-                                        </button>
                                     </div>
 
                                     {/* 예약 — 41일 내내 화면 앞에 앉아 있지 않아도 되게(개선안 ②).
@@ -617,7 +657,7 @@ export default function ReplayGamePage() {
                                             <div className="flex items-center gap-1.5 flex-wrap">
                                                 {/* pending 이 없는 응답(0020 배포 전 워커)에도 화면이 살아 있어야 한다 —
                                                     orders 가 같은 이유로 ?? [] 를 쓴다. */}
-                                                <button onClick={() => { setReserveOpen(v => !v); if (!resPrice) setResPrice(price); }}
+                                                <button onClick={() => setReserveOpen(v => !v)}
                                                     className="min-h-[36px] px-3 rounded-lg text-[11px] font-bold text-neutral-600 dark:text-neutral-300 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26]">
                                                     예약 {(round.pending ?? []).length > 0 && <b className="text-[#e3b34a]">{(round.pending ?? []).length}</b>} {reserveOpen ? "▾" : "▸"}
                                                 </button>
@@ -641,16 +681,47 @@ export default function ReplayGamePage() {
                                                             {k.label}
                                                         </button>
                                                     ))}
-                                                    <input type="number" min={1} value={resPrice} aria-label="예약 가격"
-                                                        onChange={e => setResPrice(Math.max(0, Math.floor(Number(e.target.value) || 0)))}
-                                                        className="w-[86px] min-h-[32px] px-2 rounded-lg text-[12px] text-right font-mono bg-neutral-50 dark:bg-[#1a1917] border border-neutral-200 dark:border-[#35332e] text-neutral-900 dark:text-white" />
-                                                    <input type="number" min={1} value={resQty} aria-label="예약 수량"
-                                                        onChange={e => setResQty(Math.max(1, Math.floor(Number(e.target.value) || 1)))}
-                                                        className="w-[58px] min-h-[32px] px-2 rounded-lg text-[12px] text-right font-mono bg-neutral-50 dark:bg-[#1a1917] border border-neutral-200 dark:border-[#35332e] text-neutral-900 dark:text-white" />
-                                                    <button onClick={reserve} disabled={busy || resPrice < 1}
-                                                        className="min-h-[32px] px-3 rounded-lg text-[11px] font-black text-white bg-[#0d2a1a] dark:bg-[#e3b34a] dark:text-[#2a1c00] disabled:opacity-40">
-                                                        걸기
-                                                    </button>
+                                                    {/* 값을 적는 대신 지금 값에서 얼마나 떨어진 자리인지로 고른다. */}
+                                                    <div className="flex items-center gap-1 w-full">
+                                                        <span className="text-[10px] font-black text-neutral-400 shrink-0 w-8">자리</span>
+                                                        {(resKind === "take_profit" ? RESERVE_STEPS.up : RESERVE_STEPS.down).map(step => {
+                                                            const target = resPriceAt(step);
+                                                            return (
+                                                                <button key={step} onClick={() => setResStep(step)}
+                                                                    aria-label={`${resKind === "take_profit" ? "+" : "-"}${step}%`}
+                                                                    className={cn("flex-1 min-h-[34px] rounded-lg text-[11px] font-bold border transition-colors flex flex-col items-center justify-center leading-none gap-0.5",
+                                                                        resStep === step
+                                                                            ? "bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 border-neutral-900 dark:border-white"
+                                                                            : "text-neutral-500 dark:text-neutral-400 border-neutral-200 dark:border-[#35332e]")}>
+                                                                    {resKind === "take_profit" ? "+" : "−"}{step}%
+                                                                    <span className="text-[9px] font-mono opacity-70">{target.toLocaleString()}</span>
+                                                                </button>
+                                                            );
+                                                        })}
+                                                    </div>
+
+                                                    <div className="flex items-center gap-1 w-full">
+                                                        <span className="text-[10px] font-black text-neutral-400 shrink-0 w-8">수량</span>
+                                                        {(resKind === "buy_limit" ? BUY_PARTS : SELL_PARTS).map(part => {
+                                                            const n = resQtyFor(part.pct);
+                                                            return (
+                                                                <button key={part.pct} onClick={() => setResPart(part.pct)}
+                                                                    aria-label={`예약 수량 ${part.label}`} disabled={n < 1}
+                                                                    className={cn("flex-1 min-h-[34px] rounded-lg text-[11px] font-bold border transition-colors flex flex-col items-center justify-center leading-none gap-0.5 disabled:opacity-30",
+                                                                        resPart === part.pct
+                                                                            ? "bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 border-neutral-900 dark:border-white"
+                                                                            : "text-neutral-500 dark:text-neutral-400 border-neutral-200 dark:border-[#35332e]")}>
+                                                                    {part.label}
+                                                                    <span className="text-[9px] font-mono opacity-70">{n > 0 ? `${n}주` : "—"}</span>
+                                                                </button>
+                                                            );
+                                                        })}
+                                                        <button onClick={reserve} disabled={busy || resQtyFor(resPart) < 1}
+                                                            className="shrink-0 min-h-[34px] px-3 rounded-lg text-[11px] font-black text-white bg-[#0d2a1a] dark:bg-[#e3b34a] dark:text-[#2a1c00] disabled:opacity-40">
+                                                            걸기
+                                                        </button>
+                                                    </div>
+
                                                     <span className="text-[10px] text-neutral-400 dark:text-neutral-500 w-full">
                                                         걸어 둔 값에 그날 가격이 닿으면 체결됩니다. 갭으로 건너뛴 날은 시가로 체결됩니다.
                                                     </span>
@@ -658,21 +729,6 @@ export default function ReplayGamePage() {
                                             )}
                                         </div>
                                     )}
-
-                                    {/* 여러 날 건너뛰기 — 아무 일도 없는 날의 클릭이 이 게임에서 가장 많다.
-                                        한 번에 최대 며칠까지는 위 SKIP_STEPS 로 정한다. */}
-                                    <div className="flex items-center gap-1.5">
-                                        <span className="text-[10px] sm:text-xs font-black text-neutral-400 uppercase tracking-wider shrink-0">건너뛰기</span>
-                                        {SKIP_STEPS.map(n => (
-                                            <button key={n} onClick={() => skipDays(n)} disabled={busy}
-                                                className="min-h-[36px] px-3 rounded-lg text-[11px] font-bold text-neutral-600 dark:text-neutral-300 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40">
-                                                {n}일
-                                            </button>
-                                        ))}
-                                        <span className="text-[10px] text-neutral-400 dark:text-neutral-500 truncate">
-                                            ±{JUMP_STOP_PCT}% 움직인 날에는 멈춥니다
-                                        </span>
-                                    </div>
 
                                     {/* 모바일은 한 줄만. 수수료·자동청산 규칙은 시작 화면에 적어 뒀다. */}
                                     <p className="sm:hidden text-[10px] text-neutral-400 dark:text-neutral-500 text-center">

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -24,9 +24,9 @@ import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { reqGetNcavDailyList, selectNcavDailyList } from "@/lib/features/algorithmTrade/algorithmTradeSlice";
 
 import { avgPrice, quoteBuy, quoteSell, applyBuy, applySell } from "@/lib/paper/engine";
-import { CONTEXT_DAYS, TOTAL_DAYS, type ReplayRound, type ReplayHistoryItem, type RoundHabits, type HabitSummary } from "@/lib/paper/round";
+import { CONTEXT_DAYS, TOTAL_DAYS, type ReplayRound, type ReplayHistoryItem, type RoundHabits, type HabitSummary, type Reservation } from "@/lib/paper/round";
 import { buildLocalRound, loadLocal, saveLocal, advanceLocal, giveUpLocal } from "@/lib/paper/localRound";
-import { getReplayState, startReplayRound, advanceReplayRound, giveUpReplayRound, buyTool } from "@/lib/features/paper/replayAPI";
+import { getReplayState, startReplayRound, advanceReplayRound, giveUpReplayRound, buyTool, reserveOrder, cancelReserve } from "@/lib/features/paper/replayAPI";
 import { TOOLS, INITIAL_AUM, rankOf, fmtMoney, type Firm } from "@/lib/paper/firm";
 import { movingAverage, bollinger } from "@/lib/paper/indicators";
 import SectorSprite, { sectorAccent } from "@/app/(screener)/screener/components/SectorSprite";
@@ -54,6 +54,14 @@ const SCENARIOS: { id: string; label: string; hint: string }[] = [
 const scenarioLabel = (id?: string | null) =>
     id === "mixed" ? "보통" : (SCENARIOS.find(s => s.id === id)?.label ?? null);
 
+// 예약 종류. id 와 이름은 워커 src/lib/reservations.js 의 RESERVE_KINDS·RESERVE_LABEL 과 같아야 한다.
+const RESERVE_KINDS: { id: Reservation["kind"]; label: string; hint: string }[] = [
+    { id: "buy_limit", label: "지정가 매수", hint: "이 값까지 내려오면 산다" },
+    { id: "stop_loss", label: "손절", hint: "이 값까지 내려오면 판다" },
+    { id: "take_profit", label: "익절", hint: "이 값을 넘으면 판다" },
+];
+const reserveLabel = (k: string) => RESERVE_KINDS.find(r => r.id === k)?.label ?? k;
+
 // 여러 날 건너뛰기를 멈추는 문턱. 이만큼 움직인 날은 지나치면 손쓸 수 없다.
 const JUMP_STOP_PCT = 7;
 const SKIP_STEPS = [3, 5];
@@ -79,6 +87,11 @@ export default function ReplayGamePage() {
     const [loading, setLoading] = useState(true);
     const [busy, setBusy] = useState(false);
     const [qty, setQty] = useState(10);
+    // 예약 패널 — 접었다 편다. 모바일은 한 화면이 빡빡해 기본은 접어 둔다.
+    const [reserveOpen, setReserveOpen] = useState(false);
+    const [resKind, setResKind] = useState<Reservation["kind"]>("buy_limit");
+    const [resPrice, setResPrice] = useState(0);
+    const [resQty, setResQty] = useState(10);
 
     // 비로그인 판을 만들 때 쓸 종목 풀. 로그인은 서버가 알아서 뽑는다.
     useEffect(() => { if (!isLoggedIn) dispatch(reqGetNcavDailyList("latest")); }, [isLoggedIn, dispatch]);
@@ -254,6 +267,31 @@ export default function ReplayGamePage() {
         while (n > 0 && !quoteBuy({ price, qty: n, cash }).ok) n--;
         return n;
     }, [price, round?.cash]);
+
+    const reserve = useCallback(async () => {
+        if (!round) return;
+        setBusy(true);
+        try {
+            const res = await reserveOrder(round.id, { kind: resKind, price: resPrice, qty: resQty });
+            if (!res.success) { addToast("error", res.error); return; }
+            setRound(res.round);
+            addToast("success", `${reserveLabel(resKind)} ${resPrice.toLocaleString()}원 ${resQty}주를 걸어 뒀습니다.`);
+        } finally {
+            setBusy(false);
+        }
+    }, [round, resKind, resPrice, resQty, addToast]);
+
+    const unreserve = useCallback(async (index: number) => {
+        if (!round) return;
+        setBusy(true);
+        try {
+            const res = await cancelReserve(round.id, index);
+            if (!res.success) { addToast("error", res.error); return; }
+            setRound(res.round);
+        } finally {
+            setBusy(false);
+        }
+    }, [round, addToast]);
 
     const purchase = useCallback(async (toolId: string) => {
         setBusy(true);
@@ -557,6 +595,56 @@ export default function ReplayGamePage() {
                                             팔기
                                         </button>
                                     </div>
+
+                                    {/* 예약 — 41일 내내 화면 앞에 앉아 있지 않아도 되게(개선안 ②).
+                                        체결 판정과 체결가 규칙은 전부 워커에 있다. 여기는 걸고 지우기만 한다.
+                                        기본은 접어 둔다 — 폰에서 한 화면이 이미 빡빡하다. */}
+                                    {isLoggedIn && (
+                                        <div className="flex flex-col gap-2">
+                                            <div className="flex items-center gap-1.5 flex-wrap">
+                                                {/* pending 이 없는 응답(0020 배포 전 워커)에도 화면이 살아 있어야 한다 —
+                                                    orders 가 같은 이유로 ?? [] 를 쓴다. */}
+                                                <button onClick={() => { setReserveOpen(v => !v); if (!resPrice) setResPrice(price); }}
+                                                    className="min-h-[36px] px-3 rounded-lg text-[11px] font-bold text-neutral-600 dark:text-neutral-300 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26]">
+                                                    예약 {(round.pending ?? []).length > 0 && <b className="text-[#e3b34a]">{(round.pending ?? []).length}</b>} {reserveOpen ? "▾" : "▸"}
+                                                </button>
+                                                {(round.pending ?? []).map((r, i) => (
+                                                    <span key={`${r.kind}-${i}`} className="inline-flex items-center gap-1 min-h-[36px] px-2 rounded-lg text-[10.5px] font-bold bg-[#faf1dc] dark:bg-[#2a2211] text-[#a1730a] dark:text-[#e3b34a]">
+                                                        {reserveLabel(r.kind)} {r.price.toLocaleString()}원 {r.qty}주
+                                                        <button onClick={() => unreserve(i)} disabled={busy}
+                                                            className="ml-0.5 px-1 rounded hover:bg-black/10 dark:hover:bg-white/10 disabled:opacity-40" aria-label="예약 취소">×</button>
+                                                    </span>
+                                                ))}
+                                            </div>
+
+                                            {reserveOpen && (
+                                                <div className="flex items-center gap-1.5 flex-wrap rounded-xl border border-neutral-200 dark:border-[#35332e] p-2">
+                                                    {RESERVE_KINDS.map(k => (
+                                                        <button key={k.id} onClick={() => setResKind(k.id)} title={k.hint}
+                                                            className={cn("min-h-[32px] px-2.5 rounded-lg text-[10.5px] font-bold border transition-colors",
+                                                                resKind === k.id
+                                                                    ? "bg-neutral-900 dark:bg-white text-white dark:text-neutral-900 border-neutral-900 dark:border-white"
+                                                                    : "text-neutral-500 dark:text-neutral-400 border-neutral-200 dark:border-[#35332e]")}>
+                                                            {k.label}
+                                                        </button>
+                                                    ))}
+                                                    <input type="number" min={1} value={resPrice} aria-label="예약 가격"
+                                                        onChange={e => setResPrice(Math.max(0, Math.floor(Number(e.target.value) || 0)))}
+                                                        className="w-[86px] min-h-[32px] px-2 rounded-lg text-[12px] text-right font-mono bg-neutral-50 dark:bg-[#1a1917] border border-neutral-200 dark:border-[#35332e] text-neutral-900 dark:text-white" />
+                                                    <input type="number" min={1} value={resQty} aria-label="예약 수량"
+                                                        onChange={e => setResQty(Math.max(1, Math.floor(Number(e.target.value) || 1)))}
+                                                        className="w-[58px] min-h-[32px] px-2 rounded-lg text-[12px] text-right font-mono bg-neutral-50 dark:bg-[#1a1917] border border-neutral-200 dark:border-[#35332e] text-neutral-900 dark:text-white" />
+                                                    <button onClick={reserve} disabled={busy || resPrice < 1}
+                                                        className="min-h-[32px] px-3 rounded-lg text-[11px] font-black text-white bg-[#0d2a1a] dark:bg-[#e3b34a] dark:text-[#2a1c00] disabled:opacity-40">
+                                                        걸기
+                                                    </button>
+                                                    <span className="text-[10px] text-neutral-400 dark:text-neutral-500 w-full">
+                                                        걸어 둔 값에 그날 가격이 닿으면 체결됩니다. 갭으로 건너뛴 날은 시가로 체결됩니다.
+                                                    </span>
+                                                </div>
+                                            )}
+                                        </div>
+                                    )}
 
                                     {/* 여러 날 건너뛰기 — 아무 일도 없는 날의 클릭이 이 게임에서 가장 많다.
                                         한 번에 최대 며칠까지는 위 SKIP_STEPS 로 정한다. */}

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -43,6 +43,10 @@ const LineChart = dynamic(() => import("@/components/LineChart"), {
     loading: () => <div className="h-full min-h-[120px] rounded-2xl bg-neutral-100 dark:bg-[#242320] animate-pulse" />,
 });
 
+// 여러 날 건너뛰기를 멈추는 문턱. 이만큼 움직인 날은 지나치면 손쓸 수 없다.
+const JUMP_STOP_PCT = 7;
+const SKIP_STEPS = [3, 5];
+
 const pct = (v: number) => `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
 const fmtDate = (d?: string | null) => (d && d.length === 8 ? `${d.slice(0, 4)}.${d.slice(4, 6)}.${d.slice(6, 8)}` : "");
 
@@ -119,13 +123,17 @@ export default function ReplayGamePage() {
         }
     }, [isLoggedIn, localPool, addToast]);
 
-    const advance = useCallback(async (trade?: { side: "buy" | "sell"; qty: number } | null) => {
-        if (!round || round.status !== "playing") return;
+    // 어느 판에서 출발하는지 인자로 받는다 — 여러 날 건너뛰기가 앞선 응답을 이어받아야 해서,
+    // 클로저에 잡힌 옛 round 로는 비로그인 경로(advanceLocal)가 같은 날을 반복한다.
+    const advanceFrom = useCallback(async (
+        from: ReplayRound, trade?: { side: "buy" | "sell"; qty: number } | null,
+    ): Promise<ReplayRound | null> => {
+        if (from.status !== "playing") return null;
         setBusy(true);
         try {
             if (isLoggedIn) {
-                const res = await advanceReplayRound(round.id, trade);
-                if (!res.success) { addToast("error", res.error); return; }
+                const res = await advanceReplayRound(from.id, trade);
+                if (!res.success) { addToast("error", res.error); return null; }
                 setRound(res.round);
                 if (res.done) {
                     const st = await getReplayState();
@@ -136,15 +144,41 @@ export default function ReplayGamePage() {
                         setBestReturn(st.wallet?.best_return ?? null);
                     }
                 }
-            } else {
-                const res = advanceLocal(round, trade);
-                if (!res.ok) { addToast("error", res.error); return; }
-                setRound(res.round);
+                return res.round;
             }
+            const res = advanceLocal(from, trade);
+            if (!res.ok) { addToast("error", res.error); return null; }
+            setRound(res.round);
+            return res.round;
         } finally {
             setBusy(false);
         }
-    }, [round, isLoggedIn, addToast]);
+    }, [isLoggedIn, addToast]);
+
+    const advance = useCallback(async (trade?: { side: "buy" | "sell"; qty: number } | null) => {
+        if (!round) return;
+        await advanceFrom(round, trade);
+    }, [round, advanceFrom]);
+
+    // 여러 날 한 번에 넘기기. 아무 일도 없는 날의 클릭을 없애되, 큰 폭으로 움직인 날에는
+    // 반드시 세운다 — 지나치고 나면 손쓸 수 없는 게 그런 날이다.
+    const skipDays = useCallback(async (n: number) => {
+        if (!round || round.status !== "playing") return;
+        let cur: ReplayRound | null = round;
+        for (let i = 0; i < n && cur; i++) {
+            const before = cur.candles[cur.cursor - 1]?.c ?? 0;
+            const next: ReplayRound | null = await advanceFrom(cur, null);
+            if (!next) break;
+            cur = next;
+            if (next.status !== "playing") break;
+            const after = next.candles[next.cursor - 1]?.c ?? 0;
+            const move = before > 0 ? ((after - before) / before) * 100 : 0;
+            if (Math.abs(move) >= JUMP_STOP_PCT) {
+                addToast("info", `하루에 ${move >= 0 ? "+" : ""}${move.toFixed(1)}% 움직여 여기서 멈췄습니다.`);
+                break;
+            }
+        }
+    }, [round, advanceFrom, addToast]);
 
     const giveUp = useCallback(async () => {
         if (!round || round.status !== "playing") return;
@@ -244,6 +278,11 @@ export default function ReplayGamePage() {
             out.push({ name: "밴드상단", data: b.upper, color: "#94a3b8", dash: "3 3" });
             out.push({ name: "밴드하단", data: b.lower, color: "#94a3b8", dash: "3 3" });
         }
+
+        // 하루가 얼마나 흔들렸는지. 같은 종가라도 하루 안에서 15% 오갔던 날과 조용한 날은
+        // 완전히 다른 날인데, 종가 선 하나로는 둘이 똑같아 보인다. 고가·저가는 이미 캔들에 있다.
+        out.push({ name: "고가", data: visible.map(c => c.h || null), color: "#c5bfb2" });
+        out.push({ name: "저가", data: visible.map(c => c.l || null), color: "#c5bfb2" });
 
         // 내 자산 곡선. 가격선이 곧 "그냥 사서 들고 있었을 때"라 비교 상대는 이미 화면에 있고,
         // 없던 건 내 쪽이었다. 같은 축에 얹으려고 시드를 거래 시작가로 환산한다 —
@@ -490,6 +529,21 @@ export default function ReplayGamePage() {
                                         </button>
                                     </div>
 
+                                    {/* 여러 날 건너뛰기 — 아무 일도 없는 날의 클릭이 이 게임에서 가장 많다.
+                                        한 번에 최대 며칠까지는 위 SKIP_STEPS 로 정한다. */}
+                                    <div className="flex items-center gap-1.5">
+                                        <span className="text-[10px] sm:text-xs font-black text-neutral-400 uppercase tracking-wider shrink-0">건너뛰기</span>
+                                        {SKIP_STEPS.map(n => (
+                                            <button key={n} onClick={() => skipDays(n)} disabled={busy}
+                                                className="min-h-[36px] px-3 rounded-lg text-[11px] font-bold text-neutral-600 dark:text-neutral-300 border border-neutral-200 dark:border-[#35332e] hover:bg-neutral-100 dark:hover:bg-[#2c2a26] disabled:opacity-40">
+                                                {n}일
+                                            </button>
+                                        ))}
+                                        <span className="text-[10px] text-neutral-400 dark:text-neutral-500 truncate">
+                                            ±{JUMP_STOP_PCT}% 움직인 날에는 멈춥니다
+                                        </span>
+                                    </div>
+
                                     {/* 모바일은 한 줄만. 수수료·자동청산 규칙은 시작 화면에 적어 뒀다. */}
                                     <p className="sm:hidden text-[10px] text-neutral-400 dark:text-neutral-500 text-center">
                                         어느 쪽을 눌러도 하루가 지나갑니다 · 그날 종가로 체결
@@ -719,6 +773,23 @@ function FirmDashboard({ onStart, busy, isLoggedIn, firm, bestReturn, history, h
 }
 
 // ─────────────────────────────────────────────────────────
+/**
+ * 정산 결과를 고객의 말로 옮긴다. 새로 계산하는 것은 없다 — 이미 나온 자금 유출입과
+ * 등급 변화를 문장으로 바꿀 뿐이다. 과하게 쓰면 유치해지므로 사실만 담는다.
+ */
+function clientNote(flow: number, flowPct: number, rankBefore: string, rankAfter: string): string {
+    const money = fmtMoney(Math.abs(flow));
+    const head =
+        flowPct >= 30 ? `성과를 보고 큰돈이 들어왔습니다. 신규 자금 ${money}.`
+            : flowPct >= 10 ? `고객이 자금을 더 맡겼습니다. +${money}.`
+                : flowPct > 0 ? `고객들이 조금씩 더 맡겼습니다. +${money}.`
+                    : flowPct === 0 ? "고객 자금은 그대로입니다."
+                        : flowPct > -10 ? `일부 고객이 자금을 뺐습니다. −${money}.`
+                            : `환매 요청이 몰렸습니다. −${money}.`;
+    if (rankBefore === rankAfter) return head;
+    return `${head} 회사가 ${rankBefore} 에서 ${rankAfter} 로 ${flow >= 0 ? "올라섰습니다" : "내려앉았습니다"}.`;
+}
+
 /** 분기 보고서 — 성적과 그것이 회사에 미친 결과를 나란히. */
 function QuarterReport({ round, isLoggedIn }: { round: ReplayRound; isLoggedIn: boolean }) {
     const mine = round.final_return ?? 0;
@@ -757,8 +828,14 @@ function QuarterReport({ round, isLoggedIn }: { round: ReplayRound; isLoggedIn: 
                     </p>
                 )}
 
+                {settled && (
+                    <p className="text-[11.5px] sm:text-[13px] font-bold break-keep text-[#a1730a] dark:text-[#e3b34a] border-t border-neutral-100 dark:border-[#35332e] pt-1.5 sm:pt-3">
+                        {clientNote(flow, flowPct, rankOf(round.aum_before!), rankOf(round.aum_after!))}
+                    </p>
+                )}
+
                 {settled ? (
-                    <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 text-[12px] sm:text-[13px] border-t border-neutral-100 dark:border-[#35332e] pt-1.5 sm:pt-3">
+                    <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 text-[12px] sm:text-[13px]">
                         <span className="text-neutral-500 dark:text-neutral-400">
                             고객 자금{" "}
                             <b className={pnlValueColor(flow >= 0)}>{flowPct >= 0 ? "+" : ""}{flowPct.toFixed(1)}%</b>

--- a/cf-idiotquant/components/LineChart.tsx
+++ b/cf-idiotquant/components/LineChart.tsx
@@ -211,7 +211,9 @@ export default function LineChart(props: any) {
                         dot={false}
                         activeDot={false}
                         isAnimationActive={false}
-                        legendType="none"
+                        // 보조지표는 범례를 차지하지 않는다(작은 화면에서 이름만 늘어난다).
+                        // 다만 legend 를 켠 겹선은 무슨 선인지 알아야 해서 범례에 넣는다.
+                        legendType={o.legend ? "line" : "none"}
                         connectNulls={false}
                     />
                 ))}

--- a/cf-idiotquant/lib/features/paper/replayAPI.ts
+++ b/cf-idiotquant/lib/features/paper/replayAPI.ts
@@ -47,7 +47,8 @@ export type ReplayResponse =
 
 export const getReplayState = (): Promise<ReplayResponse> => replayRequest("GET");
 
-export const startReplayRound = (): Promise<ReplayResponse> => replayRequest("POST", { action: "start" });
+export const startReplayRound = (scenario?: string | null): Promise<ReplayResponse> =>
+    replayRequest("POST", { action: "start", ...(scenario ? { scenario } : {}) });
 
 /**
  * 하루 진행. 체결가는 서버가 그날 종가로 잡으므로 price 를 보내지 않는다.

--- a/cf-idiotquant/lib/features/paper/replayAPI.ts
+++ b/cf-idiotquant/lib/features/paper/replayAPI.ts
@@ -57,8 +57,12 @@ export const startReplayRound = (scenario?: string | null): Promise<ReplayRespon
  * non-GET body 에 PDNO·ORD_QTY·buyOrSell 을 끼워 넣고 buyOrSell 은 값이 없으면 "sell" 로
  * 채운다. 그 이름을 피해야 매수가 매도로 새지 않는다.
  */
-export const advanceReplayRound = (roundId: string, trade?: { side: "buy" | "sell"; qty: number } | null): Promise<ReplayResponse> =>
-    replayRequest("POST", { action: "advance", round_id: roundId, trade: trade ?? undefined });
+export const advanceReplayRound = (
+    roundId: string,
+    trade?: { side: "buy" | "sell"; qty: number } | null,
+    carry?: boolean,
+): Promise<ReplayResponse> =>
+    replayRequest("POST", { action: "advance", round_id: roundId, trade: trade ?? undefined, ...(carry ? { carry: true } : {}) });
 
 export const giveUpReplayRound = (roundId: string): Promise<ReplayResponse> =>
     replayRequest("POST", { action: "giveup", round_id: roundId });

--- a/cf-idiotquant/lib/features/paper/replayAPI.ts
+++ b/cf-idiotquant/lib/features/paper/replayAPI.ts
@@ -1,7 +1,7 @@
 // 리플레이 라운드 API — 로그인 사용자 (백엔드 /user/replay).
 // 비로그인은 lib/paper/localRound.ts 가 같은 모양을 브라우저 안에서 다룬다.
 
-import type { ReplayRound, ReplayHistoryItem, HabitSummary } from "@/lib/paper/round";
+import type { ReplayRound, ReplayHistoryItem, HabitSummary, Reservation } from "@/lib/paper/round";
 import type { Firm } from "@/lib/paper/firm";
 
 async function replayRequest(method: "GET" | "POST", body?: object) {
@@ -69,3 +69,11 @@ export const buyTool = (toolId: string): Promise<ReplayResponse> =>
 
 export const renameFirm = (name: string): Promise<ReplayResponse> =>
     replayRequest("POST", { action: "rename-firm", name });
+
+/** 예약 걸기 — 얼마가 되면 사고, 얼마가 되면 판다. 체결 규칙은 서버에만 있다. */
+export const reserveOrder = (roundId: string, reservation: Reservation): Promise<ReplayResponse> =>
+    replayRequest("POST", { action: "reserve", round_id: roundId, reservation });
+
+/** 자리(index)로 지운다 — 같은 조건을 두 번 걸 수도 있어 값으로는 못 고른다. */
+export const cancelReserve = (roundId: string, index: number): Promise<ReplayResponse> =>
+    replayRequest("POST", { action: "cancel-reserve", round_id: roundId, index });

--- a/cf-idiotquant/lib/paper/firm.ts
+++ b/cf-idiotquant/lib/paper/firm.ts
@@ -20,6 +20,13 @@ const PERF_FEE_PCT = 10;    // 초과수익분의 10%
 
 const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v));
 
+/** 다음 분기로 넘긴 보유. 종목은 알려 주지 않는다 — 이어지는 판도 블라인드여야 한다. */
+export interface Carry {
+    qty: number;
+    price: number;
+    sector: string | null;
+}
+
 export interface Firm {
     name: string | null;
     aum: number;
@@ -27,6 +34,7 @@ export interface Firm {
     quarters: number;
     tools: string[];
     rank: string;
+    carry?: Carry | null;
 }
 
 export interface Tool {

--- a/cf-idiotquant/lib/paper/localRound.ts
+++ b/cf-idiotquant/lib/paper/localRound.ts
@@ -69,6 +69,7 @@ export async function buildLocalRound(pool: { ticker: string; name: string }[]):
                 sector: null,     // 업종·판 성격도 서버가 붙인다
                 scenario: null,
                 pending: [],      // 예약 체결 규칙은 워커에만 있다 — 체험 운용은 지원하지 않는다
+                carried: false,   // 이월도 회사가 있어야 한다
             };
             saveLocal(round);
             return round;

--- a/cf-idiotquant/lib/paper/localRound.ts
+++ b/cf-idiotquant/lib/paper/localRound.ts
@@ -68,6 +68,7 @@ export async function buildLocalRound(pool: { ticker: string; name: string }[]):
                 habits: null,     // 체험 운용은 서버가 없어 습관도 안 붙는다
                 sector: null,     // 업종·판 성격도 서버가 붙인다
                 scenario: null,
+                pending: [],      // 예약 체결 규칙은 워커에만 있다 — 체험 운용은 지원하지 않는다
             };
             saveLocal(round);
             return round;

--- a/cf-idiotquant/lib/paper/localRound.ts
+++ b/cf-idiotquant/lib/paper/localRound.ts
@@ -65,7 +65,9 @@ export async function buildLocalRound(pool: { ticker: string; name: string }[]):
                 final_return: null, bh_return: null,
                 // 체험 운용에는 회사가 없다 — 정산은 로그인해야 붙는다
                 aum_before: null, aum_after: null, fee_base: null, fee_perf: null,
-                habits: null,   // 체험 운용은 서버가 없어 습관도 안 붙는다
+                habits: null,     // 체험 운용은 서버가 없어 습관도 안 붙는다
+                sector: null,     // 업종·판 성격도 서버가 붙인다
+                scenario: null,
             };
             saveLocal(round);
             return round;

--- a/cf-idiotquant/lib/paper/round.ts
+++ b/cf-idiotquant/lib/paper/round.ts
@@ -70,6 +70,8 @@ export interface ReplayRound {
     scenario: string | null;
     /** 걸어 둔 예약. 체결 판정과 체결가 규칙은 워커(src/lib/reservations.js)에만 있다. */
     pending: Reservation[];
+    /** 이 분기를 다음으로 이월했는가. 이월했으면 정답(종목명)은 아직 열리지 않는다. */
+    carried?: boolean;
     id: string;
     cursor: number;
     total_days: number;

--- a/cf-idiotquant/lib/paper/round.ts
+++ b/cf-idiotquant/lib/paper/round.ts
@@ -54,6 +54,13 @@ export interface HabitSummary extends Omit<RoundHabits, "buys" | "sells" | "maxE
     maxExposure: number | null;
 }
 
+/** 예약 한 건. kind 는 워커의 RESERVE_KINDS 와 같아야 한다. */
+export interface Reservation {
+    kind: "buy_limit" | "stop_loss" | "take_profit";
+    price: number;
+    qty: number;
+}
+
 /** 서버 `_publicRound` 와 같은 모양. 진행 중에는 정답과 미래 캔들이 비어 있다. */
 export interface ReplayRound {
     orders: ReplayOrder[];
@@ -61,6 +68,8 @@ export interface ReplayRound {
     sector: string | null;
     /** 판의 성격(plunge·range·peak·mixed). 컨텍스트 구간만 보고 붙인 값이라 정답이 새지 않는다. */
     scenario: string | null;
+    /** 걸어 둔 예약. 체결 판정과 체결가 규칙은 워커(src/lib/reservations.js)에만 있다. */
+    pending: Reservation[];
     id: string;
     cursor: number;
     total_days: number;

--- a/cf-idiotquant/lib/paper/round.ts
+++ b/cf-idiotquant/lib/paper/round.ts
@@ -57,6 +57,10 @@ export interface HabitSummary extends Omit<RoundHabits, "buys" | "sells" | "maxE
 /** 서버 `_publicRound` 와 같은 모양. 진행 중에는 정답과 미래 캔들이 비어 있다. */
 export interface ReplayRound {
     orders: ReplayOrder[];
+    /** 블라인드 중에도 열어 주는 업종. 예전 판·체험 운용은 null. */
+    sector: string | null;
+    /** 판의 성격(plunge·range·peak·mixed). 컨텍스트 구간만 보고 붙인 값이라 정답이 새지 않는다. */
+    scenario: string | null;
     id: string;
     cursor: number;
     total_days: number;


### PR DESCRIPTION
개선안 여덟 개의 화면 쪽. 규칙이 필요한 것(⑤⑦②⑧)은 전부 워커에 있고 여기는 받아 그린다 — 프론트에 규칙 사본을 늘리지 않는다. 워커 PR과 짝이다.

## ③ 벤치마크 (커밋 1)

차트 부제에 `그냥 들고 +9.24% · 나 +1.00% (-8.2%p)`. 이기면 초록, 지면 빨강. 첫 며칠은 값이 요동쳐 닷새 뒤부터 나온다.

가격선이 곧 "그냥 사서 들고 있었을 때"라 없던 건 내 쪽이었다 — **내 성과 곡선**을 시드=거래 시작가로 환산해 같은 축에 얹었다. 두 선이 같은 점에서 출발하므로 벌어진 만큼이 초과 성과다. 재는 시작점은 워커 `_finish` 와 같은 **거래 시작일**이다.

## ①④⑥ (커밋 2)

- **건너뛰기 3·5일** — 41번의 결정 중 대부분이 "다음 날을 보고 싶어서" 누르는 관망이었다. ±7% 움직인 날에는 멈추고 왜 멈췄는지 알려 준다. 진행 함수가 출발 판을 인자로 받게 고쳤다(클로저의 옛 round 로는 비로그인 경로가 같은 날을 반복한다).
- **하루 폭** — 고가·저가는 이미 캔들에 있었는데 안 그리고 있었다.
- **분기 마무리 한 줄** — 자금 유출입·등급 변화를 고객의 말로. 새로 계산하는 값은 없다.

## ⑤⑦ (커밋 3)

차트 머리에 **업종**(스크리너 스프라이트 그대로), 대시보드에서 시작 전 **자리 고르기**. 고른 자리가 안 나올 수 있어 실제로 만들어진 성격을 차트 옆에 적는다.

## ② 예약 주문 (커밋 4)

접었다 펴는 예약 칸. 걸어 둔 예약은 접힌 상태에서도 칩으로 보인다. 폰에서 한 화면이 빡빡해 기본은 접어 둔다.

## ⑧ 이월 (커밋 5)

마지막 날에는 관망 자리가 **들고 가기**가 된다. 보고서는 넘긴 수량을 적고 이월했으면 정답을 열지 않는다고 말한다. 대시보드는 들고 온 수량·단가를 보여 주고 버튼이 "이어서 운용"이 된다. 이월 중에는 판 고르기를 감춘다(종목이 이미 정해져 있다).

## 검증

워커 규칙 모듈(`firmRules`·`scenario`·`reservations`)을 그대로 쓰는 스텁으로 실제 플레이:

- **벤치마크** — 화면 숫자 = 규칙 계산, 곡선이 거래 전 비어 있음, 지고 있을 때 가격선 아래, 정산의 `bh_return` 과 같은 잣대
- **건너뛰기** — 3일 버튼이 3일 이동, 급등일에서 멈춤(5일 눌러 2일만), 멈춘 자리가 그날
- **하루 폭** — 종가선이 고가·저가 사이
- **마무리 문구** — 정산 방향·등급 변화와 일치
- **업종/자리** — 고른 성격이 서버로 전달, 업종은 열리고 종목명은 가려짐, 아이콘이 실제로 그려짐
- **예약** — 종가로는 안 닿고 저가로만 닿는 값에 걸어 체결 확인, 조건 가격 그대로, `auto=0`(습관에 포함), 체결·취소 후 사라짐
- **이월** — 마지막 날에만 버튼, 성적이 평가금액으로 잡힘, 정답 봉인, 다음 판이 `현금 + 평가금액 = 시드`

한 화면 측정(320/375/390/412 × 시작·진행·결과) · `tsc --noEmit` · `npm run build` 통과.

**검증 중 잡은 버그 2건** — `orders` 없는 응답, `pending` 없는 응답에서 페이지가 통째로 죽었다(0020 배포 전 워커에서 실제로 난다). 둘 다 `?? []` 로 막았고, 옛 스텁을 쓰는 회귀 스크립트가 먼저 잡았다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThonA5VU9EJwaxdqJSDA8P