### PR TITLE
feat(game): 색 규칙 · 추세선 · 내 돈 기준 매수 · 순간 연출 (개편 1·2·4단계)

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -126,6 +126,29 @@ const TOOL_COLOR: Record<string, string> = {
     ma: "#f59e0b", dc: "#0d9488", bb: "#94a3b8", atr: "#d946ef",
 };
 
+/**
+ * 카드 안 미니 추세선. 값이 아니라 **모양**을 본다 — 네 종목 중 어느 게 오르는 중인지
+ * 알려고 하나씩 눌러 들어가지 않아도 되게 하는 것이 전부다.
+ *
+ * recharts 를 네 번 띄우면 무거워서 폴리라인 하나로 직접 그린다.
+ */
+function Spark({ data, color }: { data: number[]; color: string }) {
+    const W = 44, H = 14, PAD = 1.5;
+    if (data.length < 2) return <svg width={W} height={H} aria-hidden="true" />;
+    const lo = Math.min(...data), hi = Math.max(...data);
+    const span = hi - lo || 1;
+    const pts = data.map((v, i) =>
+        `${PAD + (i / (data.length - 1)) * (W - PAD * 2)},${H - PAD - ((v - lo) / span) * (H - PAD * 2)}`);
+    const [lx, ly] = pts[pts.length - 1].split(",");
+    return (
+        <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} aria-hidden="true" className="shrink-0">
+            <polyline points={pts.join(" ")} fill="none" stroke={color} strokeWidth="1.4"
+                strokeLinejoin="round" strokeLinecap="round" />
+            <circle cx={lx} cy={ly} r="1.7" fill={color} />
+        </svg>
+    );
+}
+
 const pct = (v: number) => `${v >= 0 ? "+" : ""}${v.toFixed(2)}%`;
 const fmtDate = (d?: string | null) => (d && d.length === 8 ? `${d.slice(0, 4)}.${d.slice(4, 6)}.${d.slice(6, 8)}` : "");
 
@@ -369,6 +392,13 @@ export default function ReplayGamePage() {
     const heldQty = sel ? sel.qty : (round?.qty ?? 0);
     const heldCost = sel ? sel.cost_basis : (round?.cost_basis ?? 0);
     const avg = avgPrice({ qty: heldQty, cost_basis: heldCost });
+
+    /** 그 자리의 최근 25일 종가. 카드 미니 추세선이 쓴다. */
+    const closesOf = useCallback((h: { candles: { c: number }[] }) => {
+        if (!round) return [];
+        const upto = round.status === "done" ? h.candles.length : round.cursor;
+        return h.candles.slice(Math.max(0, upto - 25), upto).map(c => c.c);
+    }, [round]);
 
     /** 그 자리의 마지막 공개 종가. 자리마다 값이 달라 계좌 합계를 낼 때 쓴다. */
     const lastCloseOf = useCallback((h: { candles: { c: number }[] }) => {
@@ -812,6 +842,9 @@ export default function ReplayGamePage() {
                                         const on = h.slot === (sel?.slot ?? 0);
                                         const rate = h.qty > 0 && h.cost_basis > 0
                                             ? ((last * h.qty - h.cost_basis) / h.cost_basis) * 100 : null;
+                                        // 추세선은 그 종목의 최근 25일. 구간 등락 부호로 색을 정한다(시장색).
+                                        const closes = overview ? closesOf(h) : [];
+                                        const trendUp = closes.length > 1 && closes[closes.length - 1] >= closes[0];
                                         return (
                                             <button key={h.slot}
                                                 onClick={() => { setSlot(h.slot); setDetail(true); }}
@@ -828,15 +861,14 @@ export default function ReplayGamePage() {
                                                     {/* 진행 중에는 이름이 없다 — 업종이 그 종목을 부르는 이름이 된다 */}
                                                     <span className="truncate">{h.name ?? h.sector ?? `${h.slot + 1}번`}</span>
                                                 </span>
+                                                {/* 개요에서는 추세선을 함께. 값(현재가)만으로는 종목마다 자릿수가 달라
+                                                    견줄 수가 없었고, 오르는 중인지 알려면 하나씩 눌러 봐야 했다. */}
+                                                {overview && <Spark data={closes} color={trendUp ? UP_COLOR : DOWN_COLOR} />}
                                                 {h.qty > 0
                                                     ? <span className={cn("font-mono", rate !== null ? pnlText(rate >= 0) : "")}>
                                                         {rate !== null ? pct(rate) : `${h.qty}주`}
                                                     </span>
                                                     : <span className="opacity-60">안 삼</span>}
-                                                {/* 개요에서는 값도 같이 — 눌러 들어가기 전에 견줄 수 있어야 한다 */}
-                                                {overview && (
-                                                    <span className="font-mono text-[9px] text-neutral-400">{fmtKrw(last)}</span>
-                                                )}
                                             </button>
                                         );
                                     })}

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -41,7 +41,7 @@ import { YEAR_CHOICES, halfOf, totalHalves } from "@/lib/paper/campaign";
 import SectorSprite, { sectorAccent } from "@/app/(screener)/screener/components/SectorSprite";
 
 import {
-    fmtKrw, KpiCard, PnlIcon, pnlIconBg, pnlValueColor, pnlAccentColor,
+    fmtKrw, KpiCard, PnlIcon,
     SectionPanel, SectionHeader, useToast, ToastContainer,
 } from "@/components/balance/shared";
 import { cn } from "@/lib/utils";
@@ -96,10 +96,30 @@ const RESERVE_STEPS = { down: [3, 5, 10], up: [5, 10, 20] };
 const JUMP_STOP_PCT = 7;
 const SKIP_STEPS = [3, 5];
 
-// 개요의 두 선. 벤치마크는 뒤로 물러난 흐린 점선, 내 성과는 진한 실선 — 색이 비슷하면
-// 어느 쪽이 나인지 매번 범례를 봐야 한다.
+// ── 이 화면의 색 규칙 ────────────────────────────────────────────────
+//
+//   빨강 = 오름 · 사기    파랑 = 내림 · 팔기
+//   금색 = 내 것(평단·성과·비중·켜 둔 도구)    회색 = 벤치마크(상대)
+//
+// 초록은 쓰지 않는다. 예전에는 손실 수익률이 초록이라 "내렸다"가 캔들(파랑)과
+// 글자(초록) 두 색이었고, 그 파랑은 개요의 "내 성과" 선과도 겹쳤다. 국내 증권앱
+// 관습으로 맞추면 색이 네 계열에서 세 계열로 준다.
+//
+// 공용 pnlText(잔고·스크리너와 공유)는 손실이 초록이다. 그 화면들까지 바꾸는 건
+// 이 작업 범위 밖이라, 게임 안에서만 쓰는 함수를 따로 둔다.
+const UP_COLOR = "#e14b4b";
+const DOWN_COLOR = "#3b82f6";
+const MINE_COLOR = "#e3b34a";
 const BENCH_COLOR = "#94a3b8";
-const MINE_COLOR = "#3b82f6";
+
+/** 오르면 빨강, 내리면 파랑. */
+const pnlText = (positive: boolean) => (positive ? "text-[#e14b4b]" : "text-[#3b82f6]");
+const pnlBg = (positive: boolean) => (positive
+    ? "bg-red-50 dark:bg-red-950/40 text-[#e14b4b]"
+    : "bg-blue-50 dark:bg-blue-950/40 text-[#3b82f6]");
+const pnlAccent = (positive: boolean) => (positive
+    ? "bg-red-400 dark:bg-red-600"
+    : "bg-[#3b82f6] dark:bg-[#2563eb]");
 
 // 도구가 그리는 선 색. 차트와 on/off 칩이 같은 색을 써야 어느 칩이 어느 선인지 안다.
 const TOOL_COLOR: Record<string, string> = {
@@ -616,7 +636,7 @@ export default function ReplayGamePage() {
             .map(o => ({
                 x: visible[o.day_index].d.slice(4),
                 y: o.price,
-                color: o.side === "buy" ? "#ef4444" : "#16a34a",
+                color: o.side === "buy" ? UP_COLOR : DOWN_COLOR,
                 label: withLabel ? `${o.side === "buy" ? "+" : "−"}${o.qty}` : undefined,
                 labelPosition: (o.side === "buy" ? "bottom" : "top") as "bottom" | "top",
             }));
@@ -639,8 +659,8 @@ export default function ReplayGamePage() {
         },
         {
             label: "수익률", value: pct(totalRate), sub: `실현 ${fmtKrw(round.realized)}`,
-            icon: <PnlIcon positive={totalPnl >= 0} />, iconBg: pnlIconBg(totalPnl >= 0),
-            valueColor: pnlValueColor(totalPnl >= 0), accentColor: pnlAccentColor(totalPnl >= 0),
+            icon: <PnlIcon positive={totalPnl >= 0} />, iconBg: pnlBg(totalPnl >= 0),
+            valueColor: pnlText(totalPnl >= 0), accentColor: pnlAccent(totalPnl >= 0),
         },
     ] : [];
 
@@ -745,7 +765,7 @@ export default function ReplayGamePage() {
                                     {round.status === "done"
                                         ? <span className="text-neutral-400">{`${round.ticker} · ${fmtDate(round.start_date)}~${fmtDate(round.end_date)}`}</span>
                                         : benchNote
-                                            ? <span className={edge >= 0 ? "text-[#16a34a]" : "text-red-500"}>{benchNote}</span>
+                                            ? <span className={pnlText(edge >= 0)}>{benchNote}</span>
                                             : <span className="text-neutral-400">종목·시기는 끝나야 열립니다</span>}
                                 </p>
                                 {holdings.length > 1 && !overview ? (
@@ -809,7 +829,7 @@ export default function ReplayGamePage() {
                                                     <span className="truncate">{h.name ?? h.sector ?? `${h.slot + 1}번`}</span>
                                                 </span>
                                                 {h.qty > 0
-                                                    ? <span className={cn("font-mono", rate !== null ? pnlValueColor(rate >= 0) : "")}>
+                                                    ? <span className={cn("font-mono", rate !== null ? pnlText(rate >= 0) : "")}>
                                                         {rate !== null ? pct(rate) : `${h.qty}주`}
                                                     </span>
                                                     : <span className="opacity-60">안 삼</span>}
@@ -905,8 +925,10 @@ export default function ReplayGamePage() {
                                             candles={visible}
                                             markers={markers}
                                             overlays={[
+                                                // 평단은 흐름이 아니라 "수준"이다 — 점선으로 둔다. 종목이 하나뿐인
+                                                // 판에서는 같은 차트에 금색 성과 곡선도 올라와서, 색만으로는 둘이 안 갈린다.
                                                 ...(heldQty > 0
-                                                    ? [{ name: "내 평단", data: visible.map(() => Math.round(avg)), color: "#e3b34a" }]
+                                                    ? [{ name: "내 평단", data: visible.map(() => Math.round(avg)), color: MINE_COLOR, dash: "5 3" }]
                                                     : []),
                                                 ...overlays.map(o => ({ name: o.name, data: o.data, color: o.color, dash: o.dash })),
                                             ]}
@@ -920,10 +942,12 @@ export default function ReplayGamePage() {
                             폰에서는 카드 대신 두 줄. 카드 넉 장이 128px 을 먹어 차트가 100px 까지
                             눌리고 그래도 자리가 모자랐다. 같은 값 넉 개가 두 줄이면 52px 이다. */}
                         <div className="lg:hidden shrink-0 rounded-xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] px-2.5 py-1 flex flex-col gap-0.5">
+                            {/* 굴리는 돈이 이 줄의 주인공이다 — 한 단계 키우고, 등락률은 칩으로
+                                떼어 색을 한 곳에 모은다. 나머지는 라벨로 눕힌다. */}
                             <div className="flex items-baseline justify-between gap-2 text-[12px]">
                                 <span className="truncate">
                                     <span className="text-neutral-400 mr-1">내 돈</span>
-                                    <b className="font-mono font-black text-neutral-900 dark:text-white">{fmtKrw(totalAssets)}</b>
+                                    <b className="font-mono font-black text-[14px] tracking-tight text-neutral-900 dark:text-white">{fmtKrw(totalAssets)}</b>
                                     {overview
                                         ? <>
                                             <span className="text-neutral-400 ml-1.5 mr-1">보유</span>
@@ -936,7 +960,9 @@ export default function ReplayGamePage() {
                                             <b className="font-mono font-black text-neutral-900 dark:text-white">{fmtKrw(price)}</b>
                                         </>}
                                 </span>
-                                <b className={cn("font-mono font-black shrink-0", pnlValueColor(totalPnl >= 0))}>{pct(totalRate)}</b>
+                                <b className={cn("font-mono font-black shrink-0 px-1.5 py-0.5 rounded-md text-[11.5px]", pnlBg(totalPnl >= 0))}>
+                                    {totalPnl >= 0 ? "▲" : "▼"} {Math.abs(totalRate).toFixed(2)}%
+                                </b>
                             </div>
                             <div className="flex items-baseline justify-between gap-2 text-[11px] text-neutral-500 dark:text-neutral-400">
                                 <span className="shrink-0">
@@ -976,7 +1002,7 @@ export default function ReplayGamePage() {
                                                 return (
                                                     <button key={part.pct} aria-label={`사기 ${part.label}`}
                                                         onClick={() => trade("buy", n, sel?.slot ?? 0)} disabled={busy || n < 1}
-                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-white bg-red-500 hover:bg-red-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex flex-col items-center justify-center leading-none gap-0.5">
+                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-white bg-[#e14b4b] hover:bg-[#c93c3c] disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex flex-col items-center justify-center leading-none gap-0.5">
                                                         {part.label}
                                                         <span className="text-[9px] font-bold opacity-80">{n > 0 ? `${n}주` : "—"}</span>
                                                     </button>
@@ -984,14 +1010,14 @@ export default function ReplayGamePage() {
                                             })}
                                         </div>
 
-                                        <span className="text-[10.5px] font-black text-[#16a34a]">팔기</span>
+                                        <span className="text-[10.5px] font-black text-[#3b82f6]">팔기</span>
                                         <div className="grid grid-cols-3 gap-1.5">
                                             {SELL_PARTS.map(part => {
                                                 const n = sellQtyFor(part.pct);
                                                 return (
                                                     <button key={part.pct} aria-label={`팔기 ${part.label}`}
                                                         onClick={() => trade("sell", n, sel?.slot ?? 0)} disabled={busy || n < 1}
-                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-[#16a34a] border border-[#16a34a]/40 hover:bg-[#f0fdf4] dark:hover:bg-[#052e16]/40 disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex flex-col items-center justify-center leading-none gap-0.5">
+                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-[#3b82f6] border border-[#3b82f6]/40 hover:bg-blue-50 dark:hover:bg-[#0b1e3a]/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex flex-col items-center justify-center leading-none gap-0.5">
                                                         {part.label}
                                                         <span className="text-[9px] font-bold opacity-70">{n > 0 ? `${n}주` : "—"}</span>
                                                     </button>
@@ -1222,13 +1248,13 @@ function FinalReport({ campaign, firm, history, habits, bestReturn, onClear }: {
 
             <ul className="mt-3 pt-3 border-t border-neutral-100 dark:border-[#35332e] flex flex-col gap-1.5 text-[12px] sm:text-[13px]">
                 <Row k="맡은 돈" v={`${fmtMoney(INITIAL_AUM)} → ${fmtMoney(aum)}`}
-                    tone={pnlValueColor(grown)} />
+                    tone={pnlText(grown)} />
                 <Row k="등급" v={`${rankOf(INITIAL_AUM)} → ${firm?.rank ?? rankOf(aum)}`} />
                 <Row k="회사 금고" v={`${fmtMoney(firm?.cash ?? 0)}원`} />
                 <Row k="굴린 반기" v={`${firm?.quarters ?? campaign.total_halves}반기`} />
-                {seen > 0 && <Row k={`최근 ${seen}반기 평균`} v={pct(avg)} tone={pnlValueColor(avg >= 0)} />}
+                {seen > 0 && <Row k={`최근 ${seen}반기 평균`} v={pct(avg)} tone={pnlText(avg >= 0)} />}
                 {seen > 0 && <Row k="벤치마크 이긴 반기" v={`${beats}/${seen}반기`} />}
-                {bestReturn !== null && <Row k="가장 잘한 반기" v={pct(bestReturn)} tone={pnlValueColor(bestReturn >= 0)} />}
+                {bestReturn !== null && <Row k="가장 잘한 반기" v={pct(bestReturn)} tone={pnlText(bestReturn >= 0)} />}
                 {habits && habits.trades > 0 && (
                     <Row k="매매 습관" v={`체결 ${habits.trades}회${habits.holdDays !== null ? ` · 평균 ${habits.holdDays}일 보유` : ""}`} />
                 )}
@@ -1353,11 +1379,11 @@ function PastHalf({ h }: { h: ReplayHistoryItem }) {
                 </div>
             </div>
             <div className="text-right shrink-0">
-                <div className={cn("font-mono text-xs font-black", pnlValueColor(win))}>{pct(h.final_return ?? 0)}</div>
+                <div className={cn("font-mono text-xs font-black", pnlText(win))}>{pct(h.final_return ?? 0)}</div>
                 <div className="text-[11px] text-neutral-400">
                     벤치마크 {pct(h.bh_return ?? 0)}
                     {h.aum_after !== null && (
-                        <span className={cn("ml-1 font-bold", pnlValueColor(flow >= 0))}>
+                        <span className={cn("ml-1 font-bold", pnlText(flow >= 0))}>
                             · 자금 {flow >= 0 ? "+" : "−"}{fmtMoney(Math.abs(flow))}
                         </span>
                     )}
@@ -1408,7 +1434,7 @@ function PastStock({ s }: { s: HistoryStock }) {
             <span className="shrink-0 text-right">
                 {s.invested > 0 ? (
                     <>
-                        <span className={cn("font-mono text-[12px] font-black", pnlValueColor(s.realized >= 0))}>
+                        <span className={cn("font-mono text-[12px] font-black", pnlText(s.realized >= 0))}>
                             {s.realized >= 0 ? "+" : "−"}{fmtMoney(Math.abs(s.realized))}
                         </span>
                         <span className="ml-1.5 text-[10px] text-neutral-400 font-mono">
@@ -1565,7 +1591,7 @@ function FirmDashboard({
                         맡은 돈 <b className="text-neutral-900 dark:text-white font-mono">{fmtMoney(aum)}</b>
                         {" · "}회사 금고 <b className="text-neutral-900 dark:text-white font-mono">{fmtMoney(firm?.cash ?? 0)}</b>
                         {" · "}{firm?.quarters ?? 0}분기 운용
-                        {bestReturn !== null && <>{" · "}최고 <b className={pnlValueColor(bestReturn >= 0)}>{pct(bestReturn)}</b></>}
+                        {bestReturn !== null && <>{" · "}최고 <b className={pnlText(bestReturn >= 0)}>{pct(bestReturn)}</b></>}
                     </p>
                 )}
 
@@ -1618,7 +1644,7 @@ function FirmDashboard({
                                     {have ? (
                                         <button onClick={() => onToggle(t.id)}
                                             className={cn("shrink-0 inline-flex items-center gap-1 min-h-[36px] px-3 rounded-lg text-[11px] font-bold border transition-colors",
-                                                on ? "border-[#16a34a]/50 text-[#16a34a]" : "border-neutral-200 dark:border-[#35332e] text-neutral-400")}>
+                                                on ? "border-[#e3b34a]/60 text-[#a1730a] dark:text-[#e3b34a]" : "border-neutral-200 dark:border-[#35332e] text-neutral-400")}>
                                             <Check size={12} /> {on ? "켜짐" : "꺼짐"}
                                         </button>
                                     ) : (
@@ -1749,11 +1775,11 @@ function QuarterReport({ round, isLoggedIn }: { round: ReplayRound; isLoggedIn: 
                 <div className="flex items-baseline justify-between gap-3 flex-wrap">
                     <div>
                         <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 sm:mb-1">내 수익률</p>
-                        <p className={cn("text-2xl sm:text-4xl font-black font-mono", pnlValueColor(mine >= 0))}>{pct(mine)}</p>
+                        <p className={cn("text-2xl sm:text-4xl font-black font-mono", pnlText(mine >= 0))}>{pct(mine)}</p>
                     </div>
                     <div className="text-right">
                         <p className="text-[10px] font-black uppercase tracking-wider text-neutral-400 sm:mb-1">벤치마크</p>
-                        <p className={cn("text-lg sm:text-xl font-black font-mono", pnlValueColor(bh >= 0))}>{pct(bh)}</p>
+                        <p className={cn("text-lg sm:text-xl font-black font-mono", pnlText(bh >= 0))}>{pct(bh)}</p>
                     </div>
                 </div>
 
@@ -1785,7 +1811,7 @@ function QuarterReport({ round, isLoggedIn }: { round: ReplayRound; isLoggedIn: 
                     <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1 text-[12px] sm:text-[13px]">
                         <span className="text-neutral-500 dark:text-neutral-400">
                             고객 자금{" "}
-                            <b className={pnlValueColor(flow >= 0)}>{flowPct >= 0 ? "+" : ""}{flowPct.toFixed(1)}%</b>
+                            <b className={pnlText(flow >= 0)}>{flowPct >= 0 ? "+" : ""}{flowPct.toFixed(1)}%</b>
                             {" → "}
                             <b className="text-neutral-900 dark:text-white font-mono">{fmtMoney(round.aum_after!)}</b>
                         </span>


### PR DESCRIPTION
커밋 넷. [화면 개편안](https://claude.ai/code/artifact/009449d1-fd14-4def-952e-483afbc5ad7f)의 1·2·4단계 + 균등 매수 요청. **규칙·계산 엔진은 손대지 않는다.**

---

## 1단계 · 색 규칙 통일

같은 “내렸다”가 **두 색**이었다 — 캔들은 파랑, 수익률 글자는 초록. 그 파랑은 개요의 “내 성과” 선에도 쓰였다.

```
빨강 = 오름 · 사기        파랑 = 내림 · 팔기
금색 = 내 것(평단·성과·켜 둔 도구)     회색 = 벤치마크(상대)
```

손익·팔기 버튼의 초록 → 파랑, 사기 버튼을 캔들과 같은 빨강으로, 내 성과 곡선을 금색으로(겹치는 **평단선은 점선으로** 분리 — 평단은 흐름이 아니라 수준이다), 벤치마크 대비 문구는 **색이 반대**였던 것을 바로잡음, 계좌 줄에 위계(큰 숫자 + 등락 칩).

## 2단계 · 종목 칸 미니 추세선

네 칸이 글자뿐이라 **어느 종목이 오르는 중인지** 알려면 하나씩 눌러야 했다. 칸마다 최근 25일 추세선(오르면 빨강, 내리면 파랑). 자리는 현재가 줄을 빼서 만들었다 — 종목마다 자릿수가 달라 개요에서 값끼리 견줄 수가 없었다. **카드 높이 54px 그대로.**

## 사기 비율의 기준을 내 돈으로

현금 기준이라 25% 를 네 번 누르면 **25 → 18.7 → 14.1 → 10.5%** 로 줄어들어 균등 매수가 안 됐다. **내 돈(현금 + 평가금액) 기준**으로 바꾸니 네 자리가 정확히 **25.0%씩**(남는 현금 2,504원).

팔기는 보유 기준 유지 — 내 돈 기준으로 하면 비중이 작은 자리에서 25%·50%·전부가 모두 전량 매도로 붙는다. 대신 기준을 화면에 적었다(사기 줄 “내 돈”, 팔기 줄 “보유”).

## 4단계 · 순간 연출

게임과 대시보드를 가르는 건 대개 0.2초다.

| 순간 | 연출 |
|---|---|
| 하루 넘김 | 오늘 캔들이 아래에서 자라며 들어온다 (200ms) |
| 체결 | 값이 바뀐 계좌 줄이 한 번 물든다 (520ms) · 버튼은 눌린 순간 들어간다 |
| 정답 공개 | 종목명이 흐릿한 데서 잡힌다 (600ms) |
| 반기 마감 | 리포트가 올라오며 자리 잡고, **등급이 바뀐 분기에만** 그 줄이 물든다 |

- 새 날짜는 새 요소라 마운트될 때 **한 번만** 돈다 — 툴팁을 띄웠다 지운다고 다시 돌지 않는다.
- **숫자를 세는 연출은 넣지 않았다.** 화면을 읽는 쪽(테스트·스크린리더)이 중간값을 잡는다 — 리포트 숫자는 처음부터 최종값이다.
- `prefers-reduced-motion` 이면 넷 다 끈다.

---

## 검증

`tsc --noEmit` · `npm run build` 통과.

**새 e2e 4종**
- `color-e2e` 9건 — 게임 화면 전 요소의 색을 걷어 **초록 0건**, 손실은 파랑, 사기 버튼은 캔들과 같은 빨강.
- `spark-e2e` 12건 — 추세선의 **방향·색이 실제 값과 일치**, 사흘 지나면 점이 셋 늚.
- `even-e2e` 13건 — 25% 네 번 뒤 **비중 편차 0.00%p**, 현금 한도 준수, 팔기는 보유 기준.
- `motion-e2e` 10건 — `getAnimations()` 로 각 연출이 **실제로 도는지**, 오늘 캔들 **하나만** 자라는지, 그리고 `reducedMotion: 'reduce'` 컨텍스트에서 **하나도 안 도는데 결과는 그대로 보이는지**.

**이빨 확인**: 손실 초록 복귀 → 2건 · 추세선 색 고정 → 1건 · 현금 기준 복귀 → **5건** · reduced-motion 가드 삭제 → 1건 실패.

**회귀**: casual · tier-a~d · firm · habits · tools · campaign · replay · portfolio · bench · past · weight · bigmoney · desktop 전부 통과. 한 화면 측정(320/375/390/412 × 시작·진행·결과) **변화 없음**.

> `maxbtn.mjs` 는 이 PR 이전부터 실패한다 — 오래전에 없앤 “주문 수량” 입력창을 조작하는 낡은 스크립트다(변경 전 코드로도 같은 지점에서 멈추는 것을 확인).
