### PR TITLE
feat(game): 개편 3·4·5단계 · 내 돈 기준 매수 · perf: 랜딩 데이터 1.1MB → 34KB

### DIFF
--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -178,6 +178,10 @@ export default function ReplayGamePage() {
     const [activeTools, setActiveTools] = useState<string[]>([]);
     const [loading, setLoading] = useState(true);
     const [busy, setBusy] = useState(false);
+    // 체결 직후 계좌 줄을 한 번 물들인다. 값이 어디서 달라졌는지 눈이 못 따라가서,
+    // 눌렀는데 아무 일도 안 일어난 것처럼 보였다. 카운터가 바뀔 때마다 다시 돈다.
+    const [filled, setFilled] = useState(0);
+    const markFilled = useCallback(() => setFilled(n => n + 1), []);
     // 예약 패널 — 접었다 편다. 모바일은 한 화면이 빡빡해 기본은 접어 둔다.
     const [reserveOpen, setReserveOpen] = useState(false);
     const [resKind, setResKind] = useState<Reservation["kind"]>("buy_limit");
@@ -304,17 +308,18 @@ export default function ReplayGamePage() {
      */
     const trade = useCallback(async (side: "buy" | "sell", qty: number, atSlot: number) => {
         if (!round || round.status !== "playing" || qty < 1) return;
-        if (!isLoggedIn) { await advanceFrom(round, { side, qty }); return; }
+        if (!isLoggedIn) { await advanceFrom(round, { side, qty }); markFilled(); return; }
 
         setBusy(true);
         try {
             const res = await tradeReplayRound(round.id, { side, qty, slot: atSlot });
             if (!res.success) { addToast("error", res.error); return; }
             setRound(res.round);
+            markFilled();
         } finally {
             setBusy(false);
         }
-    }, [round, isLoggedIn, advanceFrom, addToast]);
+    }, [round, isLoggedIn, advanceFrom, addToast, markFilled]);
 
     // 여러 날 한 번에 넘기기. 아무 일도 없는 날의 클릭을 없애되, 큰 폭으로 움직인 날에는
     // 반드시 세운다 — 지나치고 나면 손쓸 수 없는 게 그런 날이다.
@@ -787,7 +792,8 @@ export default function ReplayGamePage() {
                             <div className="sm:hidden flex items-center justify-between gap-1.5 mb-1.5 shrink-0">
                                 <span className="text-[11px] font-black text-neutral-900 dark:text-neutral-100 shrink-0 flex items-center gap-1.5">
                                     {round.status === "done"
-                                        ? (round.name ?? "차트")
+                                        // 45일을 가린 끝에 열리는 이름이다 — 그냥 바뀌면 아무 일도 아닌 게 된다
+                                        ? <span className="reveal-answer">{round.name ?? "차트"}</span>
                                         : `${halfTitle} ${round.cursor - ctxDays + 1}/${totalDays - ctxDays + 1}일`}
                                     {/* 업종만 열어 준다 — 가격 말고 붙잡을 것 하나(개선안 ⑤) */}
                                     {!overview && (sel?.sector ?? round.sector) && (
@@ -803,7 +809,7 @@ export default function ReplayGamePage() {
                                     한 번 읽으면 되는 문장이고, 이쪽은 매일 달라진다. */}
                                 <p className={cn("text-[10px] truncate", benchNote ? "font-bold" : "text-neutral-400")}>
                                     {round.status === "done"
-                                        ? <span className="text-neutral-400">{`${round.ticker} · ${fmtDate(round.start_date)}~${fmtDate(round.end_date)}`}</span>
+                                        ? <span className="text-neutral-400 reveal-answer">{`${round.ticker} · ${fmtDate(round.start_date)}~${fmtDate(round.end_date)}`}</span>
                                         : benchNote
                                             ? <span className={pnlText(edge >= 0)}>{benchNote}</span>
                                             : <span className="text-neutral-400">종목·시기는 끝나야 열립니다</span>}
@@ -869,7 +875,9 @@ export default function ReplayGamePage() {
                                                         <SectorSprite sector={h.sector ?? undefined} color={sectorAccent(h.sector ?? undefined)} />
                                                     </span>
                                                     {/* 진행 중에는 이름이 없다 — 업종이 그 종목을 부르는 이름이 된다 */}
-                                                    <span className="truncate">{h.name ?? h.sector ?? `${h.slot + 1}번`}</span>
+                                                    <span className={cn("truncate", h.name && round.status === "done" && "reveal-answer")}>
+                                                        {h.name ?? h.sector ?? `${h.slot + 1}번`}
+                                                    </span>
                                                 </span>
                                                 {/* 개요에서는 추세선을 함께. 값(현재가)만으로는 종목마다 자릿수가 달라
                                                     견줄 수가 없었고, 오르는 중인지 알려면 하나씩 눌러 봐야 했다. */}
@@ -965,6 +973,7 @@ export default function ReplayGamePage() {
                                         <CandleChart
                                             height="100%"
                                             candles={visible}
+                                            growLast={round.status === "playing"}
                                             markers={markers}
                                             overlays={[
                                                 // 평단은 흐름이 아니라 "수준"이다 — 점선으로 둔다. 종목이 하나뿐인
@@ -983,7 +992,9 @@ export default function ReplayGamePage() {
                         {/* ── 계좌 ──────────────────────────
                             폰에서는 카드 대신 두 줄. 카드 넉 장이 128px 을 먹어 차트가 100px 까지
                             눌리고 그래도 자리가 모자랐다. 같은 값 넉 개가 두 줄이면 52px 이다. */}
-                        <div className="lg:hidden shrink-0 rounded-xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] px-2.5 py-1 flex flex-col gap-0.5">
+                        <div key={`acct-${filled}`}
+                            className={cn("lg:hidden shrink-0 rounded-xl border border-neutral-200 dark:border-[#35332e] bg-white dark:bg-[#242320] px-2.5 py-1 flex flex-col gap-0.5",
+                                filled > 0 && "flash-mine")}>
                             {/* 굴리는 돈이 이 줄의 주인공이다 — 한 단계 키우고, 등락률은 칩으로
                                 떼어 색을 한 곳에 모은다. 나머지는 라벨로 눕힌다. */}
                             <div className="flex items-baseline justify-between gap-2 text-[12px]">
@@ -1049,7 +1060,7 @@ export default function ReplayGamePage() {
                                                 return (
                                                     <button key={part.pct} aria-label={`사기 ${part.label}`}
                                                         onClick={() => trade("buy", n, sel?.slot ?? 0)} disabled={busy || n < 1}
-                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-white bg-[#e14b4b] hover:bg-[#c93c3c] disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex flex-col items-center justify-center leading-none gap-0.5">
+                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-white bg-[#e14b4b] hover:bg-[#c93c3c] disabled:opacity-30 disabled:cursor-not-allowed transition-[background-color,transform] active:scale-[0.96] motion-reduce:active:scale-100 flex flex-col items-center justify-center leading-none gap-0.5">
                                                         {part.label}
                                                         <span className="text-[9px] font-bold opacity-80">{n > 0 ? `${n}주` : "—"}</span>
                                                     </button>
@@ -1067,7 +1078,7 @@ export default function ReplayGamePage() {
                                                 return (
                                                     <button key={part.pct} aria-label={`팔기 ${part.label}`}
                                                         onClick={() => trade("sell", n, sel?.slot ?? 0)} disabled={busy || n < 1}
-                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-[#3b82f6] border border-[#3b82f6]/40 hover:bg-blue-50 dark:hover:bg-[#0b1e3a]/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors flex flex-col items-center justify-center leading-none gap-0.5">
+                                                        className="min-h-[46px] rounded-xl text-[13px] font-black text-[#3b82f6] border border-[#3b82f6]/40 hover:bg-blue-50 dark:hover:bg-[#0b1e3a]/50 disabled:opacity-30 disabled:cursor-not-allowed transition-[background-color,transform] active:scale-[0.96] motion-reduce:active:scale-100 flex flex-col items-center justify-center leading-none gap-0.5">
                                                         {part.label}
                                                         <span className="text-[9px] font-bold opacity-70">{n > 0 ? `${n}주` : "—"}</span>
                                                     </button>
@@ -1821,7 +1832,7 @@ function QuarterReport({ round, isLoggedIn }: { round: ReplayRound; isLoggedIn: 
     const feeTotal = (round.fee_base ?? 0) + (round.fee_perf ?? 0);
 
     return (
-        <SectionPanel className={cn("shrink-0 border-2 p-3 sm:p-5", beat ? "border-[#e3b34a]/60" : "border-neutral-200 dark:border-[#35332e]")}>
+        <SectionPanel className={cn("shrink-0 border-2 p-3 sm:p-5 pop-in", beat ? "border-[#e3b34a]/60" : "border-neutral-200 dark:border-[#35332e]")}>
             <div className="flex flex-col gap-1.5 sm:gap-3">
                 <div className="flex items-baseline justify-between gap-3 flex-wrap">
                     <div>
@@ -1853,7 +1864,9 @@ function QuarterReport({ round, isLoggedIn }: { round: ReplayRound; isLoggedIn: 
                 )}
 
                 {settled && (
-                    <p className="text-[11.5px] sm:text-[13px] font-bold break-keep text-[#a1730a] dark:text-[#e3b34a] border-t border-neutral-100 dark:border-[#35332e] pt-1.5 sm:pt-3">
+                    // 등급이 바뀌는 건 자주 없는 일이다 — 그 줄만 한 번 물들여 눈에 띄게 한다
+                    <p className={cn("text-[11.5px] sm:text-[13px] font-bold break-keep text-[#a1730a] dark:text-[#e3b34a] border-t border-neutral-100 dark:border-[#35332e] pt-1.5 sm:pt-3",
+                        rankOf(round.aum_before!) !== rankOf(round.aum_after!) && "flash-mine rounded-md px-1")}>
                         {clientNote(flow, flowPct, rankOf(round.aum_before!), rankOf(round.aum_after!))}
                     </p>
                 )}

--- a/cf-idiotquant/app/(game)/game/page.tsx
+++ b/cf-idiotquant/app/(game)/game/page.tsx
@@ -457,14 +457,24 @@ export default function ReplayGamePage() {
         ? `그냥 들고 ${pct(bhRate)} · 나 ${pct(totalRate)} (${edge >= 0 ? "+" : ""}${edge.toFixed(1)}%p)`
         : null;
 
-    // 현금의 pct% 로 살 수 있는 주식 수. 수수료까지 넣어 실제로 통과하는 수량까지 줄인다.
+    /**
+     * **내 돈**(현금 + 자리별 평가금액)의 pct% 어치로 살 수 있는 주식 수.
+     *
+     * 현금 기준이 아니라 총자산 기준이다 — 현금 기준으로 25% 를 네 번 누르면
+     * 25 → 19 → 14 → 10% 로 줄어들어 네 종목을 고르게 담을 수가 없었다.
+     * 내 돈 기준이면 25% 를 네 번 눌러 균등 매수가 그대로 된다.
+     *
+     * 살 돈은 어차피 현금을 넘을 수 없으므로 현금으로 한 번 자른다(그래서 현금이
+     * 모자라면 버튼에 적힌 주수가 그만큼 줄어든다). "최대"만 현금 전액이다.
+     */
     const buyQtyFor = useCallback((pct: number, atPrice = price) => {
-        const cash = Math.floor((round?.cash ?? 0) * pct / 100);
-        if (atPrice <= 0 || cash <= 0) return 0;
-        let n = Math.floor(cash / atPrice);
-        while (n > 0 && !quoteBuy({ price: atPrice, qty: n, cash }).ok) n--;
+        const cash = round?.cash ?? 0;
+        const budget = pct >= 100 ? cash : Math.min(cash, Math.floor(totalAssets * pct / 100));
+        if (atPrice <= 0 || budget <= 0) return 0;
+        let n = Math.floor(budget / atPrice);
+        while (n > 0 && !quoteBuy({ price: atPrice, qty: n, cash: budget }).ok) n--;
         return n;
-    }, [round?.cash, price]);
+    }, [round?.cash, totalAssets, price]);
 
     /** 보유의 pct%. 100% 는 남김없이 — 1주라도 남으면 "전부"가 거짓말이 된다. */
     const sellQtyFor = useCallback((pct: number) => {
@@ -1027,7 +1037,12 @@ export default function ReplayGamePage() {
                                         시간은 아래 관망 줄에서만 흐른다(phase 3). */}
                                     <div className={cn("grid grid-cols-[34px_1fr] gap-x-2 gap-y-1.5 items-center",
                                         overview && "hidden")}>
-                                        <span className="text-[10.5px] font-black text-red-500">사기</span>
+                                        {/* 기준을 적어 둔다 — 사기는 내 돈, 팔기는 보유.
+                                            안 적으면 같은 25% 가 두 가지 뜻이 된다. */}
+                                        <span className="leading-[1.15]">
+                                            <span className="block text-[10.5px] font-black text-[#e14b4b]">사기</span>
+                                            <span className="block text-[8px] font-bold text-neutral-400">내 돈</span>
+                                        </span>
                                         <div className="grid grid-cols-4 gap-1.5">
                                             {BUY_PARTS.map(part => {
                                                 const n = buyQtyFor(part.pct);
@@ -1042,7 +1057,10 @@ export default function ReplayGamePage() {
                                             })}
                                         </div>
 
-                                        <span className="text-[10.5px] font-black text-[#3b82f6]">팔기</span>
+                                        <span className="leading-[1.15]">
+                                            <span className="block text-[10.5px] font-black text-[#3b82f6]">팔기</span>
+                                            <span className="block text-[8px] font-bold text-neutral-400">보유</span>
+                                        </span>
                                         <div className="grid grid-cols-3 gap-1.5">
                                             {SELL_PARTS.map(part => {
                                                 const n = sellQtyFor(part.pct);
@@ -1638,7 +1656,8 @@ function FirmDashboard({
                         `지금 맡고 있는 돈으로 한 반기를 운용합니다. 1년은 8반기(1-1 … 4-2)입니다.`,
                         `한 반기는 달력 45일입니다. 앞 한 달을 먼저 보고, 그다음부터 하루씩 넘깁니다.`,
                         // 판이 도는 중에는 화면이 좁아 이 규칙을 적을 자리가 없다 — 여기서 한 번 말한다.
-                        `사기·팔기·관망 — 어느 쪽을 눌러도 하루가 지나갑니다.`,
+                        `사기는 내 돈 기준 비율입니다 — 네 종목에 고르게 담으려면 25%씩 누르면 됩니다.`,
+                        `사고파는 것으로는 날이 안 갑니다. 하루는 관망에서만 지나갑니다.`,
                         `체결은 그날 종가. 수수료 0.015%, 매도 거래세 0.18%. 마지막 날 자동 청산.`,
                         `벤치마크(그냥 사서 들고 있기)와 견주어 고객 자금이 들고 납니다.`,
                     ].map((line, i) => (

--- a/cf-idiotquant/app/global.css
+++ b/cf-idiotquant/app/global.css
@@ -43,9 +43,45 @@ html { scroll-behavior: smooth; }
 }
 .reveal.is-in { opacity: 1; transform: none; }
 
+/* ── 게임(/game)의 순간 연출 ──
+   대시보드와 게임을 가르는 건 대개 0.2초다. 하루를 넘기고, 체결하고, 정답이 열릴 때
+   화면이 그냥 다시 그려지면 누른 보람이 없다. 전부 짧게(180~600ms) 한 번만 돈다. */
+
+/* 새 캔들 — 아래에서 자라 오른쪽에서 들어온다. 오늘이 어느 칸인지 눈이 따라간다. */
+@keyframes candle-in {
+  from { opacity: 0; transform: translateX(6px) scaleY(0.25); }
+  to   { opacity: 1; transform: none; }
+}
+.candle-in { animation: candle-in 200ms cubic-bezier(0.2, 0.8, 0.3, 1) both; transform-box: fill-box; transform-origin: bottom; }
+
+/* 체결 — 값이 바뀐 자리가 한 번 물든다. 어느 줄이 달라졌는지 눈이 찾아간다. */
+@keyframes flash-mine {
+  0%   { background-color: rgba(227, 179, 74, 0); }
+  25%  { background-color: rgba(227, 179, 74, 0.28); }
+  100% { background-color: rgba(227, 179, 74, 0); }
+}
+.flash-mine { animation: flash-mine 520ms ease-out both; }
+
+/* 정답 공개 — 45일을 가린 끝에 종목명이 흐릿한 데서 잡힌다. */
+@keyframes reveal-answer {
+  from { opacity: 0; filter: blur(7px); letter-spacing: 0.12em; }
+  to   { opacity: 1; filter: none; letter-spacing: normal; }
+}
+.reveal-answer { animation: reveal-answer 600ms cubic-bezier(0.16, 1, 0.3, 1) both; }
+
+/* 반기 마감 — 리포트가 올라오며 자리 잡는다. 숫자는 처음부터 최종값이다
+   (세는 연출을 넣으면 화면을 읽는 쪽이 중간값을 잡는다). */
+@keyframes pop-in {
+  from { opacity: 0; transform: translateY(7px); }
+  to   { opacity: 1; transform: none; }
+}
+.pop-in { animation: pop-in 280ms cubic-bezier(0.16, 1, 0.3, 1) both; }
+
 @media (prefers-reduced-motion: reduce) {
   html { scroll-behavior: auto; }
   .reveal { opacity: 1; transform: none; transition: none; }
   .animate-float { animation: none; }
+  /* 연출은 뜻이 아니라 덤이다 — 끄면 결과 화면만 남는다 */
+  .candle-in, .flash-mine, .reveal-answer, .pop-in { animation: none; }
 }
 

--- a/cf-idiotquant/components/CandleChart.tsx
+++ b/cf-idiotquant/components/CandleChart.tsx
@@ -39,9 +39,13 @@ const UP = "#e14b4b";
 const DOWN = "#3b82f6";
 
 function CandleShape(props: any) {
-    const { x, y, width, height, payload } = props;
+    const { x, y, width, height, payload, index, growLast, lastIndex } = props;
     const { o, h, l, c } = payload;
     if (!(h > 0) || !(l > 0)) return null;
+
+    // 오늘 새로 열린 캔들만 자라며 들어온다. 하루를 넘겼는데 화면이 그냥 다시 그려지면
+    // 무엇이 달라졌는지 눈이 못 따라간다. 새 날짜는 새 요소라 마운트될 때 한 번만 돈다.
+    const fresh = growLast && index === lastIndex;
 
     const span = h - l;
     // 저가~고가가 height 픽셀이다. 그 사이 값은 비례로 찍는다.
@@ -58,7 +62,7 @@ function CandleShape(props: any) {
     const cx = x + width / 2;
 
     return (
-        <g>
+        <g className={fresh ? "candle-in" : undefined}>
             {/* 꼬리 — 그날 오간 폭 */}
             <line x1={cx} x2={cx} y1={y} y2={y + height} stroke={color} strokeWidth={1} />
             <rect x={bx} y={bodyTop} width={bw} height={bodyH} fill={color} stroke={color} />
@@ -106,12 +110,14 @@ function CandleTooltip({ active, payload, label }: any) {
 }
 
 export default function CandleChart({
-    candles, overlays = [], markers = [], height = "100%",
+    candles, overlays = [], markers = [], height = "100%", growLast = false,
 }: {
     candles: Candle[];
     overlays?: CandleOverlay[];
     markers?: CandleMarker[];
     height?: number | string;
+    /** 마지막(오늘) 캔들이 자라며 들어오게 한다 — 진행 중인 판에서만 뜻이 있다. */
+    growLast?: boolean;
 }) {
     const { theme } = useTheme();
     const textColor = theme === "dark" ? "#9ca3af" : "#4b5563";
@@ -160,7 +166,8 @@ export default function CandleChart({
                     wrapperStyle={{ zIndex: 30, pointerEvents: "none" }}
                 />
 
-                <Bar dataKey="range" shape={<CandleShape />} isAnimationActive={false} />
+                <Bar dataKey="range" isAnimationActive={false}
+                    shape={<CandleShape growLast={growLast} lastIndex={data.length - 1} />} />
 
                 {overlays.map(ov => (
                     <Line


### PR DESCRIPTION
커밋 다섯. [화면 개편안](https://claude.ai/code/artifact/009449d1-fd14-4def-952e-483afbc5ad7f)의 **3·4·5단계**(1·2단계는 #703 으로 머지됨) + 균등 매수 + **전송량 다이어트**.

> 워커 PR [#103](https://github.com/MinSikSon/idiotquant-worker/pull/103) 과 짝이다. 없어도 화면은 안 깨진다(트랙은 빈 칸, 개수는 `total` 로 폴백).

---

## perf · 화면이 그리는 만큼만 받는다

프로덕션 빌드를 실제 브라우저로 재 보니, 페이지마다 정적 자원 **730KB** 위에 발굴 목록 **2,016행(압축 전 1.1MB, gzip 200KB)** 이 더 얹혀 있었다. 랜딩이 그 목록으로 그리는 건 **일곱 줄**(미리보기 3 + 오늘의 발굴 4)이다.

| 화면 | 전 | 후 |
|---|---|---|
| 랜딩 `/` | 2,016행 · **1,136KB** | 60행 · **34KB** (gzip 7KB) |
| 게임 `/game` (로그인) | 2,016행 · 1,136KB | **호출 없음** |
| 게임 `/game` (비로그인) | 2,016행 · 1,136KB | 200행 · **113KB** |
| 스크리너 `/screener` | 2,016행 | **그대로**(필터·정렬이 전부 클라이언트에 있다) |

- `getScanDailyList(date, strategy, limit)` — limit 인자를 열었다. 기본 2,500 은 스크리너 몫.
- 개수는 목록 길이가 아니라 **`meta.matched`** 로 읽는다. 안 그러면 “오늘 60곳 발굴”처럼 숫자가 같이 줄어든다.
- 게임은 **세션이 확정되기 전에는 안 부른다** — `status === "loading"` 동안 `isLoggedIn` 이 false 라, 로그인한 사람도 들어오자마자 쓰지도 않는 목록을 받아 갔다.

## 사기 비율의 기준을 내 돈으로

현금 기준이라 25% 를 네 번 누르면 **25 → 18.7 → 14.1 → 10.5%**. **내 돈 기준**으로 바꾸니 네 자리가 정확히 **25.0%씩**(남는 현금 2,504원). 팔기는 보유 기준 유지(내 돈 기준이면 세 버튼이 모두 전량 매도로 붙는다). 기준은 화면에 적었다.

## 4단계 · 순간 연출

하루 넘김(캔들이 자라며 들어옴 200ms) · 체결(계좌 줄이 물듦 520ms) · 정답 공개(블러 해제 600ms) · 반기 마감(리포트 등장, 등급이 바뀐 분기만 강조). 새 날짜는 새 요소라 **한 번만** 돈다. 숫자 세는 연출은 넣지 않았다(읽는 쪽이 중간값을 잡는다). `prefers-reduced-motion` 이면 전부 끈다.

## 3단계 · 반기 트랙과 자금 곡선

시작 버튼 안에 이번 해 여덟 칸(이김 빨강 / 짐 파랑 / 지금 어둡게) — **버튼 높이 52px 그대로**. 지난 분기 맨 위에 자금 곡선(내 자금 금색 / 그냥 나눠 담기 회색 점선) — 접혀 있으면 **0px**. 곡선 값은 서버가 남긴 `aum_before/after` 를 그대로 잇는다.

## 5단계 · 캠페인 종료 리포트

```
1년 운용 종료 · 8반기
1억 → 1억 4,400만                        연 +44.00%
        [ 자금 곡선 ]
벤치마크 이김 5/8반기 · 최대 낙폭 −23.33% · 회사 금고 240만
체결 26회 · 평균 6.4일 보유 · 이익을 빨리 실현하는 편
```

**최대 낙폭**을 새로 넣었다(고점 추적 기준). 시작 자금은 그 캠페인 첫 반기의 `aum_before` — 두 번째 캠페인은 1억에서 시작하지 않는다.

---

## 검증

`tsc --noEmit` · `npm run build` 통과.

**새 e2e 5종** — `even-e2e`(비중 편차 0.00%p) · `motion-e2e`(연출이 실제로 돌고, reduced-motion 에서 전부 꺼짐) · `track-e2e`(칸 색이 실제 성적과 일치, 곡선 최고·최저점 위치) · `report-e2e`(캠페인을 실제로 끝내고 연 환산·낙폭 대조) · 전송량 측정 스크립트.

**이빨 확인**: 현금 기준 복귀 5건 · reduced-motion 가드 삭제 1건 · 트랙 색 고정 1건 · 곡선 재계산 2건 · 낙폭 고점 추적 제거 1건 실패.

**회귀**: replay · past · color · spark · weight · portfolio · casual · campaign · bench · tier-a~d · firm · habits · tools · bigmoney · desktop · screener-sort · screener-grade 통과. 한 화면 측정 변화 없음.

> 이 PR 범위 밖이라 두었다: 랜딩 히어로의 `오늘 아침 N곳을 뒤져 M곳이 남았습니다` 는 **N 과 M 이 같은 값**이다(변경 전에도 그랬다 — 둘 다 응답 개수였다). 제대로 고치려면 “뒤진 곳”과 “조건 충족”을 각각 세야 한다.
