### PR TITLE
로그인 유저 전용 가계부 페이지 추가

### DIFF
--- a/cf-idiotquant/app/(ledger)/layout.tsx
+++ b/cf-idiotquant/app/(ledger)/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+
+// 로그인해야만 닿는 화면이라 색인하지 않는다 — 검색 결과에서 들어와도 로그인으로 튕긴다.
+export const metadata: Metadata = {
+  title: '가계부 - 수입·지출 기록',
+  description: '수입과 지출을 직접 기입하고 월별로 확인하는 가계부. 급여·주식 배당·이자부터 고정비·생활비·투자까지 항목별로 나눠 봅니다.',
+  robots: { index: false, follow: false },
+};
+
+export default function LedgerLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/cf-idiotquant/app/(ledger)/ledger/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/page.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSession } from "next-auth/react";
+import { ChevronLeft, ChevronRight, Plus, Trash2 } from "lucide-react";
+
+import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { cn } from "@/lib/utils";
+import { PageHeader } from "@/components/pageHeader";
+import {
+    setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqDeleteLedgerEntry,
+    selectLedgerMonth, selectLedgerEntries, selectLedgerState,
+    selectLedgerMutating, selectLedgerError,
+    currentMonthKst,
+} from "@/lib/features/ledger/ledgerSlice";
+import {
+    categoriesOf, categoryLabel, type LedgerKind,
+} from "@/lib/features/ledger/categories";
+
+/* ─── 공통 클래스 (ticker-map 화면과 같은 입력 모양) ────────────────── */
+const CTL_CLS =
+    "w-full px-3 py-2 bg-[#faf9f7] dark:bg-[#1a1915] border border-neutral-200 dark:border-[#35332e] " +
+    "rounded-xl text-sm font-bold text-neutral-900 dark:text-white " +
+    "focus:outline-none focus:ring-1 focus:ring-[#16a34a] focus:border-[#16a34a]";
+
+const FIELD_LABEL_CLS =
+    "text-[10px] font-black text-neutral-400 dark:text-neutral-500 uppercase tracking-widest";
+
+const CARD_CLS =
+    "bg-white dark:bg-[#242320] border border-neutral-200 dark:border-[#35332e] rounded-2xl";
+
+/* ─── 날짜 유틸 — 사용자가 보는 달·오늘은 KST 기준이다 ─────────────── */
+const todayKst = () => new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+function shiftMonth(month: string, delta: number) {
+    const [y, m] = month.split("-").map(Number);
+    const d = new Date(Date.UTC(y, m - 1 + delta, 1));
+    return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+const won = (n: number) => `${n.toLocaleString("ko-KR")}원`;
+
+export default function LedgerPage() {
+    const { status } = useSession();
+    const dispatch = useAppDispatch();
+
+    const month = useAppSelector(selectLedgerMonth);
+    const entries = useAppSelector(selectLedgerEntries);
+    const loadState = useAppSelector(selectLedgerState);
+    const mutating = useAppSelector(selectLedgerMutating);
+    const error = useAppSelector(selectLedgerError);
+
+    // 항목별 막대를 수입 기준으로 볼지 지출 기준으로 볼지
+    const [barKind, setBarKind] = useState<LedgerKind>("income");
+
+    // 기입 폼
+    const [formOpen, setFormOpen] = useState(false);
+    const [fDate, setFDate] = useState(todayKst());
+    const [fKind, setFKind] = useState<LedgerKind>("income");
+    const [fCategory, setFCategory] = useState("salary");
+    const [fAmount, setFAmount] = useState("");
+    const [fMemo, setFMemo] = useState("");
+
+    const thisMonth = currentMonthKst();
+
+    useEffect(() => {
+        if (status !== "authenticated") return;
+        dispatch(reqGetLedger(month));
+    }, [dispatch, status, month]);
+
+    /* 요약·항목별 집계 — 그 달 내역이 이미 전부 있으므로 여기서 한 번 접는다.
+       슬라이스에 따로 두면 리스트와 합계가 어긋날 자리가 생긴다. */
+    const { income, expense, net } = useMemo(() => {
+        const income = entries.filter(e => e.kind === "income").reduce((s, e) => s + e.amount, 0);
+        const expense = entries.filter(e => e.kind === "expense").reduce((s, e) => s + e.amount, 0);
+        return { income, expense, net: income - expense };
+    }, [entries]);
+
+    const buckets = useMemo(() => {
+        const total = barKind === "income" ? income : expense;
+        if (!total) return [];
+        return categoriesOf(barKind)
+            .map(c => ({
+                label: c.label,
+                sum: entries
+                    .filter(e => e.kind === barKind && e.category === c.key)
+                    .reduce((s, e) => s + e.amount, 0),
+            }))
+            .filter(b => b.sum > 0)
+            .map(b => ({ ...b, pct: Math.round((b.sum / total) * 100) }))
+            .sort((a, b) => b.sum - a.sum);
+    }, [entries, barKind, income, expense]);
+
+    /* ─── 핸들러 ───────────────────────────────────────────────── */
+    function changeKind(kind: LedgerKind) {
+        setFKind(kind);
+        setFCategory(categoriesOf(kind)[0].key);
+    }
+
+    function openForm() {
+        setFDate(month === thisMonth ? todayKst() : `${month}-01`);
+        changeKind("income");
+        setFAmount("");
+        setFMemo("");
+        setFormOpen(true);
+    }
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        const amount = Number(fAmount.replace(/[^\d]/g, ""));
+        if (!amount) return;
+
+        const result = await dispatch(reqAddLedgerEntry({
+            entry_date: fDate,
+            kind: fKind,
+            category: fCategory,
+            amount,
+            memo: fMemo.trim() || undefined,
+        }));
+        if (result.meta.requestStatus !== "fulfilled") return;
+
+        setFormOpen(false);
+        // 보고 있지 않은 달에 넣었으면 그 달로 따라간다 — 방금 적은 줄이 어디 갔는지 찾게 두지 않는다.
+        const entered = fDate.slice(0, 7);
+        if (entered !== month) dispatch(setLedgerMonth(entered));
+    }
+
+    const loading = status === "loading" || (loadState === "pending" && entries.length === 0);
+
+    return (
+        <div className="min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
+            <PageHeader
+                emoji="📒"
+                title="가계부"
+                meta={<><span>로그인 사용자 전용</span><span aria-hidden>·</span><span>내 계정에만 저장됩니다</span></>}
+                containerClassName="max-w-3xl mx-auto px-4 sm:px-7"
+            />
+
+            <div className="max-w-3xl mx-auto px-4 sm:px-7 py-5 space-y-3.5">
+
+                {/* ① 월 선택 */}
+                <div className={cn(CARD_CLS, "flex items-center justify-center gap-1.5 p-2.5")}>
+                    <button
+                        type="button"
+                        onClick={() => dispatch(setLedgerMonth(shiftMonth(month, -1)))}
+                        className="w-9 h-9 rounded-xl flex items-center justify-center text-neutral-600 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] transition-colors"
+                        aria-label="이전 달"
+                    >
+                        <ChevronLeft size={17} strokeWidth={2.4} />
+                    </button>
+                    <div className="min-w-[132px] text-center text-[15px] font-black tracking-[-0.02em] text-neutral-900 dark:text-white">
+                        {Number(month.slice(0, 4))}년 {Number(month.slice(5, 7))}월
+                    </div>
+                    <button
+                        type="button"
+                        onClick={() => dispatch(setLedgerMonth(shiftMonth(month, 1)))}
+                        disabled={month >= thisMonth}
+                        className="w-9 h-9 rounded-xl flex items-center justify-center text-neutral-600 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors"
+                        aria-label="다음 달"
+                    >
+                        <ChevronRight size={17} strokeWidth={2.4} />
+                    </button>
+                </div>
+
+                {/* ② 요약 */}
+                <div className={cn(CARD_CLS, "grid grid-cols-3")}>
+                    {[
+                        { k: "수입", v: won(income), cls: "text-[#16a34a]" },
+                        { k: "지출", v: won(expense), cls: "text-red-600 dark:text-red-400" },
+                        { k: "잔액", v: `${net > 0 ? "+" : ""}${won(net)}`, cls: net < 0 ? "text-red-600 dark:text-red-400" : "text-[#16a34a]" },
+                    ].map((cell, i) => (
+                        <div key={cell.k} className={cn("py-3.5 px-2 text-center", i < 2 && "border-r border-neutral-100 dark:border-[#35332e]")}>
+                            <div className={FIELD_LABEL_CLS}>{cell.k}</div>
+                            <div className={cn("mt-1 text-[17px] font-black tracking-[-0.02em] tabular-nums", cell.cls)}>
+                                {loading ? "—" : cell.v}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+
+                {/* ③ 항목별 막대 */}
+                <section className={CARD_CLS}>
+                    <div className="flex items-center justify-between px-4 pt-3 pb-2.5 border-b border-neutral-100 dark:border-[#35332e]">
+                        <h2 className={FIELD_LABEL_CLS}>항목별</h2>
+                        <div className="flex rounded-[10px] border border-neutral-200 dark:border-[#35332e] overflow-hidden">
+                            {(["income", "expense"] as LedgerKind[]).map(k => (
+                                <button
+                                    key={k}
+                                    type="button"
+                                    onClick={() => setBarKind(k)}
+                                    className={cn(
+                                        "px-3 py-1.5 text-[11px] font-black transition-colors",
+                                        barKind === k
+                                            ? k === "income" ? "bg-[#16a34a] text-white" : "bg-red-600 text-white"
+                                            : "bg-white dark:bg-[#242320] text-neutral-500 hover:bg-neutral-50 dark:hover:bg-[#35332e]"
+                                    )}
+                                >
+                                    {k === "income" ? "수입" : "지출"}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    <div className="px-4 py-3.5 flex flex-col gap-2.5">
+                        {buckets.length === 0 ? (
+                            <div className="py-3 text-center text-xs text-neutral-400 dark:text-neutral-500">
+                                이 달에 기록된 {barKind === "income" ? "수입" : "지출"}이 없습니다.
+                            </div>
+                        ) : buckets.map(b => (
+                            <div key={b.label} className="grid grid-cols-[64px_1fr_auto] items-center gap-2.5">
+                                <div className="text-xs font-bold text-neutral-600 dark:text-neutral-400 truncate">{b.label}</div>
+                                <div className="h-2 rounded-full bg-neutral-100 dark:bg-[#2c2b27] overflow-hidden">
+                                    <div
+                                        className={cn("h-full rounded-full transition-all duration-300", barKind === "income" ? "bg-[#16a34a]" : "bg-red-500")}
+                                        style={{ width: `${Math.max(b.pct, 2)}%` }}
+                                    />
+                                </div>
+                                <div className="text-xs font-black tabular-nums text-neutral-800 dark:text-neutral-200 whitespace-nowrap">
+                                    {b.sum.toLocaleString("ko-KR")}
+                                    <span className="ml-1.5 text-[11px] font-medium text-neutral-400">{b.pct}%</span>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                {/* ④ 기입 */}
+                {!formOpen ? (
+                    <button
+                        type="button"
+                        onClick={openForm}
+                        className="w-full flex items-center justify-center gap-1.5 py-3.5 rounded-2xl bg-[#16a34a] hover:bg-[#15803d] text-white text-[13px] font-black transition-colors"
+                    >
+                        <Plus size={15} strokeWidth={2.6} />
+                        기입하기
+                    </button>
+                ) : (
+                    <form onSubmit={handleSubmit} className={cn(CARD_CLS, "p-4 flex flex-col gap-3")}>
+                        <div className="flex gap-2.5 flex-wrap">
+                            <div className="flex flex-col gap-1.5 basis-[150px] grow-0">
+                                <label htmlFor="f-date" className={FIELD_LABEL_CLS}>날짜</label>
+                                <input id="f-date" type="date" required value={fDate}
+                                    onChange={e => setFDate(e.target.value)} className={CTL_CLS} />
+                            </div>
+                            <div className="flex flex-col gap-1.5 flex-1 min-w-[140px]">
+                                <span className={FIELD_LABEL_CLS}>구분</span>
+                                <div className="flex rounded-xl border border-neutral-200 dark:border-[#35332e] overflow-hidden">
+                                    {(["income", "expense"] as LedgerKind[]).map(k => (
+                                        <button
+                                            key={k}
+                                            type="button"
+                                            onClick={() => changeKind(k)}
+                                            className={cn(
+                                                "flex-1 py-2 text-xs font-black transition-colors",
+                                                fKind === k
+                                                    ? k === "income" ? "bg-[#16a34a] text-white" : "bg-red-600 text-white"
+                                                    : "bg-[#faf9f7] dark:bg-[#1a1915] text-neutral-500"
+                                            )}
+                                        >
+                                            {k === "income" ? "수입" : "지출"}
+                                        </button>
+                                    ))}
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="flex gap-2.5 flex-wrap">
+                            <div className="flex flex-col gap-1.5 flex-1 min-w-[130px]">
+                                <label htmlFor="f-cat" className={FIELD_LABEL_CLS}>항목</label>
+                                <select id="f-cat" value={fCategory} onChange={e => setFCategory(e.target.value)} className={CTL_CLS}>
+                                    {categoriesOf(fKind).map(c => (
+                                        <option key={c.key} value={c.key}>{c.label}</option>
+                                    ))}
+                                </select>
+                            </div>
+                            <div className="flex flex-col gap-1.5 flex-1 min-w-[130px]">
+                                <label htmlFor="f-amt" className={FIELD_LABEL_CLS}>금액 (원)</label>
+                                <input
+                                    id="f-amt" type="text" inputMode="numeric" required placeholder="0"
+                                    value={fAmount}
+                                    onChange={e => {
+                                        const digits = e.target.value.replace(/[^\d]/g, "").slice(0, 12);
+                                        setFAmount(digits ? Number(digits).toLocaleString("ko-KR") : "");
+                                    }}
+                                    className={cn(CTL_CLS, "text-right tabular-nums")}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="flex flex-col gap-1.5">
+                            <label htmlFor="f-memo" className={FIELD_LABEL_CLS}>메모 (선택)</label>
+                            <input id="f-memo" type="text" maxLength={40} placeholder="예: 삼성전자 반기 배당"
+                                value={fMemo} onChange={e => setFMemo(e.target.value)} className={CTL_CLS} />
+                        </div>
+
+                        {error && (
+                            <p className="text-xs font-bold text-red-600 dark:text-red-400">{error}</p>
+                        )}
+
+                        <div className="flex justify-end gap-2 pt-0.5">
+                            <button type="button" onClick={() => setFormOpen(false)}
+                                className="px-4 py-2 rounded-xl border border-neutral-200 dark:border-[#3a3834] bg-[#faf9f7] dark:bg-[#1a1915] text-xs font-black text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200/70 dark:hover:bg-[#2c2b27] transition-colors">
+                                취소
+                            </button>
+                            <button type="submit" disabled={mutating || !fAmount}
+                                className="px-5 py-2 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-xs font-black disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                                {mutating ? "저장 중…" : "저장"}
+                            </button>
+                        </div>
+                    </form>
+                )}
+
+                {/* ⑤ 내역 */}
+                <section className={cn(CARD_CLS, "overflow-hidden")}>
+                    <div className="flex items-center justify-between px-4 pt-3 pb-2.5 border-b border-neutral-100 dark:border-[#35332e]">
+                        <h2 className={FIELD_LABEL_CLS}>내역</h2>
+                        {entries.length > 0 && (
+                            <span className="text-[11px] font-bold text-neutral-400">{entries.length}건</span>
+                        )}
+                    </div>
+
+                    {loading ? (
+                        <div className="divide-y divide-neutral-50 dark:divide-[#35332e]/40">
+                            {[0, 1, 2].map(i => (
+                                <div key={i} className="h-[46px] bg-[#faf9f7] dark:bg-[#1f1e1b] animate-pulse" />
+                            ))}
+                        </div>
+                    ) : entries.length === 0 ? (
+                        <div className="py-10 px-4 text-center text-[13px] text-neutral-400 dark:text-neutral-500">
+                            <span className="block text-2xl mb-2 opacity-60" aria-hidden>📭</span>
+                            이 달에는 아직 기록이 없습니다.
+                            <br />위 “기입하기”로 첫 줄을 남겨보세요.
+                        </div>
+                    ) : (
+                        <div className="divide-y divide-neutral-50 dark:divide-[#35332e]/40">
+                            {entries.map(e => {
+                                const isIncome = e.kind === "income";
+                                return (
+                                    <div key={e.id} className="group grid grid-cols-[auto_auto_1fr_auto_28px] items-center gap-2.5 px-4 py-2.5 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] transition-colors">
+                                        <span className="hidden sm:block text-[11px] font-bold tabular-nums text-neutral-400">
+                                            {e.entry_date.slice(5).replace("-", ".")}
+                                        </span>
+                                        <span className={cn(
+                                            "text-[11px] font-black px-2 py-0.5 rounded-md whitespace-nowrap",
+                                            isIncome
+                                                ? "bg-[#dcfce7] text-[#16a34a] dark:bg-[#052e16]/60 dark:text-[#16a34a]"
+                                                : "bg-red-100 text-red-600 dark:bg-red-950/40 dark:text-red-400"
+                                        )}>
+                                            {categoryLabel(e.kind, e.category)}
+                                        </span>
+                                        <span className="text-xs text-neutral-500 dark:text-neutral-400 truncate">{e.memo ?? ""}</span>
+                                        <span className={cn(
+                                            "text-[13px] font-black tabular-nums whitespace-nowrap",
+                                            isIncome ? "text-[#16a34a]" : "text-neutral-900 dark:text-neutral-100"
+                                        )}>
+                                            {isIncome ? "+" : "−"}{e.amount.toLocaleString("ko-KR")}
+                                        </span>
+                                        <button
+                                            type="button"
+                                            onClick={() => dispatch(reqDeleteLedgerEntry(e.id))}
+                                            disabled={mutating}
+                                            className="w-7 h-7 rounded-lg flex items-center justify-center text-neutral-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/30 dark:hover:text-red-400 disabled:cursor-not-allowed transition-all"
+                                            aria-label={`${e.entry_date} 내역 삭제`}
+                                        >
+                                            <Trash2 size={14} />
+                                        </button>
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+                </section>
+
+                {loadState === "rejected" && !formOpen && (
+                    <p className="text-center text-xs font-bold text-red-600 dark:text-red-400">
+                        내역을 불러오지 못했습니다. {error}
+                    </p>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/cf-idiotquant/components/navigation.tsx
+++ b/cf-idiotquant/components/navigation.tsx
@@ -19,6 +19,7 @@ import {
   Wallet,
   MoreHorizontal,
   ChevronDown,
+  NotebookText,
 } from "lucide-react";
 
 /* ─── NAV CONFIG ──────────────────────────────────────────────────── */
@@ -30,6 +31,7 @@ type NavItem = {
   exact?: boolean;
   badge?: string;
   adminOnly?: boolean;
+  authOnly?: boolean;   // 로그인해야 보이는 항목 (미들웨어가 어차피 막지만, 못 쓸 메뉴를 띄우지 않는다)
 };
 
 // 순서·아이콘을 홈 온보딩 설명 순서에 맞춤: 발굴(🥇) → 분석(💎). 모의투자는 admin 전용.
@@ -44,6 +46,7 @@ const MAIN_NAV: NavItem[] = [
 // '더 보기'로 숨기는 보조 메뉴
 const MORE_NAV: NavItem[] = [
   { label: "수익 계산", href: "/calculator",  icon: Calculator              },
+  { label: "가계부",    href: "/ledger",      icon: NotebookText, authOnly: true },
 ];
 
 // 한 화면(/balance)으로 가는 항목이라 하나만 둔다. 국가 선택은 그 화면 안의 🇰🇷/🇺🇸 토글이 맡는다.
@@ -207,8 +210,10 @@ export function NavbarWithSimpleLinks() {
   const isMasterUser = session?.user?.name === process.env.NEXT_PUBLIC_MASTER;
   const isAdmin = (session?.user as any)?.role === "admin";
 
-  // '더 보기' — 보조 메뉴(계산기) 접기/펼치기. 해당 경로에 있으면 자동 노출.
-  const moreActive = MORE_NAV.some(i => active(pathname, i.href));
+  // '더 보기' — 보조 메뉴(계산기·가계부) 접기/펼치기. 해당 경로에 있으면 자동 노출.
+  // 필터는 한 번만 만들어 데스크톱·모바일이 같은 목록을 본다 — 따로 걸면 둘이 어긋난다.
+  const moreNav = MORE_NAV.filter(i => !i.authOnly || status === "authenticated");
+  const moreActive = moreNav.some(i => active(pathname, i.href));
   const [moreOpen, setMoreOpen] = useState(false);
   const [moreSheet, setMoreSheet] = useState(false);
   const showMore = moreOpen || moreActive;
@@ -284,7 +289,7 @@ export function NavbarWithSimpleLinks() {
             <span className="flex-1 truncate text-left">더 보기</span>
             <ChevronDown size={14} className={cn("shrink-0 text-neutral-400 transition-transform", showMore && "rotate-180")} />
           </button>
-          {showMore && MORE_NAV.map(item => (
+          {showMore && moreNav.map(item => (
             <SideItem
               key={item.href}
               href={item.href}
@@ -389,7 +394,7 @@ export function NavbarWithSimpleLinks() {
         <>
           <div className="md:hidden fixed inset-0 z-40" onClick={() => setMoreSheet(false)} />
           <div className="md:hidden fixed bottom-[72px] right-3 z-50 min-w-[160px] rounded-2xl bg-white dark:bg-[#242320] border border-neutral-200 dark:border-[#35332e] shadow-xl p-1.5 animate-in fade-in slide-in-from-bottom-2 duration-150">
-            {MORE_NAV.map(item => {
+            {moreNav.map(item => {
               const Icon = item.icon;
               const isActive = active(pathname, item.href);
               return (

--- a/cf-idiotquant/lib/features/ledger/categories.ts
+++ b/cf-idiotquant/lib/features/ledger/categories.ts
@@ -1,0 +1,30 @@
+// 가계부 항목 프리셋. 폼 select · 리스트 배지 · 항목별 막대가 같은 출처를 쓰도록 한곳에 둔다.
+// 워커는 category 를 문자열로만 저장한다 — 라벨 해석은 전부 여기서 한다.
+
+export type LedgerKind = "income" | "expense";
+
+export interface LedgerCategory {
+    key: string;
+    label: string;
+}
+
+export const INCOME_CATEGORIES: LedgerCategory[] = [
+    { key: "salary", label: "급여" },
+    { key: "dividend", label: "주식 배당" },
+    { key: "interest", label: "이자" },
+    { key: "etc", label: "기타" },
+];
+
+export const EXPENSE_CATEGORIES: LedgerCategory[] = [
+    { key: "fixed", label: "고정비" },
+    { key: "living", label: "생활비" },
+    { key: "invest", label: "투자" },
+    { key: "etc", label: "기타" },
+];
+
+export const categoriesOf = (kind: LedgerKind) =>
+    kind === "income" ? INCOME_CATEGORIES : EXPENSE_CATEGORIES;
+
+/** 라벨을 못 찾으면 키를 그대로 보여준다 — 프리셋이 바뀌어도 옛 내역이 빈칸이 되지 않는다. */
+export const categoryLabel = (kind: LedgerKind, key: string) =>
+    categoriesOf(kind).find((c) => c.key === key)?.label ?? key;

--- a/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
+++ b/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
@@ -1,0 +1,37 @@
+import type { LedgerKind } from "./categories";
+
+export interface LedgerEntry {
+    id: number;
+    entry_date: string;   // 'YYYY-MM-DD'
+    kind: LedgerKind;
+    category: string;
+    amount: number;       // 원 단위 양수. 부호는 kind 가 정한다.
+    memo: string | null;
+    created_at: number;
+}
+
+export interface NewLedgerEntry {
+    entry_date: string;
+    kind: LedgerKind;
+    category: string;
+    amount: number;
+    memo?: string;
+}
+
+async function ledgerRequest(subUrl: string, method = "GET", body?: object) {
+    const url = `/api/proxy${subUrl}`;
+    const res = await fetch(url, {
+        method,
+        credentials: "include",
+        headers: { "content-type": "application/json" },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+    });
+    return res.json();
+}
+
+export const getLedger = (month: string) => ledgerRequest(`/user/ledger?month=${month}`);
+
+export const addLedgerEntry = (entry: NewLedgerEntry) => ledgerRequest("/user/ledger", "POST", entry);
+
+// 삭제 id 는 쿼리로 보낸다 — 프록시가 non-GET body 에 주문 필드를 병합하기 때문.
+export const deleteLedgerEntry = (id: number) => ledgerRequest(`/user/ledger?id=${id}`, "DELETE");

--- a/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
+++ b/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
@@ -1,0 +1,117 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
+import { createAppSlice } from "@/lib/createAppSlice";
+import { getLedger, addLedgerEntry, deleteLedgerEntry, type LedgerEntry, type NewLedgerEntry } from "./ledgerAPI";
+
+/** 사용자가 보는 달은 KST 기준이다 — UTC 로 세면 매달 1일 오전 9시 전에 지난달이 열린다. */
+export function currentMonthKst(): string {
+    return new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 7);
+}
+
+/** 최신 날짜가 위. 같은 날은 나중에 넣은 것이 위로 온다 (워커 ORDER BY 와 같은 기준). */
+const byRecent = (a: LedgerEntry, b: LedgerEntry) =>
+    b.entry_date.localeCompare(a.entry_date) || b.id - a.id;
+
+interface LedgerState {
+    state: "init" | "pending" | "fulfilled" | "rejected";
+    month: string;              // 'YYYY-MM'
+    entries: LedgerEntry[];
+    mutating: boolean;
+    error: string | null;
+}
+
+const initialState: LedgerState = {
+    state: "init",
+    month: currentMonthKst(),
+    entries: [],
+    mutating: false,
+    error: null,
+};
+
+export const ledgerSlice = createAppSlice({
+    name: "ledger",
+    initialState,
+    reducers: (create) => ({
+        setLedgerMonth: create.reducer((state, action: PayloadAction<string>) => {
+            state.month = action.payload;
+        }),
+
+        reqGetLedger: create.asyncThunk(
+            async (month: string) => {
+                const result = await getLedger(month);
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
+            {
+                pending: (state) => { state.state = "pending"; state.error = null; },
+                fulfilled: (state, action) => {
+                    state.entries = (action.payload?.data ?? []) as LedgerEntry[];
+                    state.state = "fulfilled";
+                },
+                rejected: (state, action) => {
+                    state.state = "rejected";
+                    state.error = action.error?.message ?? null;
+                },
+            }
+        ),
+
+        reqAddLedgerEntry: create.asyncThunk(
+            async (entry: NewLedgerEntry) => {
+                const result = await addLedgerEntry(entry);
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
+            {
+                pending: (state) => { state.mutating = true; state.error = null; },
+                fulfilled: (state, action) => {
+                    state.mutating = false;
+                    const entry = action.payload?.data as LedgerEntry | undefined;
+                    if (!entry) return;
+                    // 보고 있는 달의 내역일 때만 목록에 얹는다. 다른 달이면 화면이 그 달로
+                    // 옮겨가면서 다시 조회하므로 여기서 넣으면 잠깐 남의 달 내역이 섞인다.
+                    if (entry.entry_date.startsWith(state.month)) {
+                        state.entries = [entry, ...state.entries].sort(byRecent);
+                    }
+                },
+                rejected: (state, action) => {
+                    state.mutating = false;
+                    state.error = action.error?.message ?? null;
+                },
+            }
+        ),
+
+        reqDeleteLedgerEntry: create.asyncThunk(
+            async (id: number) => {
+                const result = await deleteLedgerEntry(id);
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return id;
+            },
+            {
+                pending: (state) => { state.mutating = true; state.error = null; },
+                fulfilled: (state, action) => {
+                    state.mutating = false;
+                    state.entries = state.entries.filter((e) => e.id !== action.payload);
+                },
+                rejected: (state, action) => {
+                    state.mutating = false;
+                    state.error = action.error?.message ?? null;
+                },
+            }
+        ),
+    }),
+    selectors: {
+        selectLedgerMonth: (state) => state.month,
+        selectLedgerEntries: (state) => state.entries,
+        selectLedgerState: (state) => state.state,
+        selectLedgerMutating: (state) => state.mutating,
+        selectLedgerError: (state) => state.error,
+    },
+});
+
+export const { setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqDeleteLedgerEntry } = ledgerSlice.actions;
+export const {
+    selectLedgerMonth,
+    selectLedgerEntries,
+    selectLedgerState,
+    selectLedgerMutating,
+    selectLedgerError,
+} = ledgerSlice.selectors;

--- a/cf-idiotquant/lib/store.tsx
+++ b/cf-idiotquant/lib/store.tsx
@@ -18,6 +18,7 @@ import { controlSlice } from "./features/control/controlSlice";
 import { capitalSlice } from "./features/capital/capitalSlice";
 import { searchLogSlice } from "./features/searchLog/searchLogSlice";
 import { stockLikesSlice } from "./features/stockLikes/stockLikesSlice";
+import { ledgerSlice } from "./features/ledger/ledgerSlice";
 
 const rootReducer: any = combineSlices(
     financialInfoSlice,
@@ -39,6 +40,7 @@ const rootReducer: any = combineSlices(
     capitalSlice,
     searchLogSlice,
     stockLikesSlice,
+    ledgerSlice,
 );
 
 export type RootState = ReturnType<typeof rootReducer>;


### PR DESCRIPTION
수입·지출을 직접 기입하고 월 단위로 항목별 흐름을 보는 화면입니다. 계산기와 같이 **'더 보기'** 안에 두어 주 메뉴는 그대로 둡니다.

> **백엔드 PR 이 함께 필요합니다** — MinSikSon/idiotquant-worker#105 (`/user/ledger` + `ledger_entries` 테이블). 워커가 배포되고 테이블이 만들어지기 전까지 이 화면은 내역을 불러오지 못합니다. D1 테이블은 Cloudflare 대시보드 D1 Console 에서 SQL 한 번으로 만들 수 있습니다 (백엔드 PR 본문 참고).

## 화면

한 화면에 위에서 아래로 한 줄기입니다. 탭도 모달도 없습니다.

```
📒 가계부                      로그인 사용자 전용 · 내 계정에만 저장됩니다
─────────────────────────────────────────────
◀   2026년 8월   ▶
수입 3,690,000원 │ 지출 2,782,000원 │ 잔액 +908,000원
항목별                              [수입|지출]
  급여   ████████████  3,200,000  87%
  배당   ██              452,000  12%
[+ 기입하기]  ← 누르면 아래로 펼쳐지는 인라인 폼
내역                                        8건
  08.25  급여   8월 급여        +3,200,000  🗑
```

## 설계에서 고른 것들

**`middleware.ts` 는 건드리지 않았습니다.**
public 화이트리스트에 없는 경로는 이미 `/login?callbackUrl=` 로 보내집니다. `/ledger` 를 아무 데도 추가하지 않는 것이 곧 로그인 강제입니다.

**`NavItem` 에 `authOnly` 를 추가하고, 필터한 목록을 한 번만 만듭니다.**
`moreNav` 하나를 `moreActive` 계산 · 데스크톱 사이드바 · 모바일 시트 세 곳이 공유합니다. 각자 거르면 한쪽에만 뜨는 상태가 생깁니다. (기존 `adminOnly` 가 사이드바와 모바일 탭에 따로 쓰여 있는 것과 같은 함정입니다.)

**합계·항목별 집계는 슬라이스가 아니라 페이지의 `useMemo` 에서 합니다.**
그 달 내역이 이미 전부 내려와 있어 한 번 접으면 끝이고, 리스트와 합계가 어긋날 자리가 없습니다.

**항목별 막대는 CSS `width %` 입니다.**
recharts 가 설치되어 있지만 이 그림에는 과합니다. 이 화면은 가볍고 단순해야 합니다.

**수정 기능은 넣지 않았습니다.**
삭제 후 재입력으로 충분하고, 인라인 편집을 붙이면 리스트 한 줄이 두 배로 복잡해집니다. (대신 삭제에 확인을 넣었습니다 — 아래 참고.)

**월 계산은 KST 기준입니다.**
`currentMonthKst()` — UTC 로 세면 매달 1일 오전 9시 전에 지난달이 열립니다.

## 두 번째 커밋 — 직접 훑어 찾은 결함 5건

초안을 다시 읽으며 "쓰다 보면 걸리는" 문제들을 고쳤습니다.

| # | 문제 | 수정 |
|---|---|---|
| 1 | 삭제 버튼이 **터치 기기에서 보이지 않음** — `opacity-0 group-hover:opacity-100` 은 hover 가 있는 화면 전제 | `sm` 아래에서는 항상 노출, hover 는 `sm` 이상에서만. 겸해서 삭제 전 확인 추가 — 수정 기능이 없어 삭제가 유일한 정정 수단인데 그 삭제에 되돌리기가 없다. 무엇을 지우는지 문구에 실음 |
| 2 | 월을 연달아 넘기면 **먼저 보낸 응답이 나중에 도착해 최신 화면을 덮음** | `fulfilled`/`rejected` 에서 `action.meta.arg` 와 `state.month` 를 비교해 지금 보는 달의 응답만 반영. 같은 뿌리로 `setLedgerMonth` 가 이전 달 내역을 비움 — 안 그러면 8월 제목 아래 7월 합계가 잠깐 떠 있음 |
| 3 | 금액에 **0 을 넣으면 저장이 조용히 실패** — `"0"` 은 입력값이 있는 상태라 버튼이 열려 있는데 `handleSubmit` 이 말없이 반환 | 이유를 폼에 표시 (`role="alert"`) |
| 4 | 모바일에서 **날짜를 숨김**(`hidden sm:block`) — 같은 항목·같은 금액이 두 줄이면 구분할 단서가 없음 | 모든 폭에서 노출 |
| 5 | 세션 만료 시 조회를 걸지 않아 **"아직 기록이 없습니다"** 가 뜸 — 내역이 지워진 것처럼 보임 | 로그인이 풀렸다고 말하고 `/login?callbackUrl=/ledger` 링크 제공 |

## 변경 파일

| 파일 | 내용 |
|---|---|
| `app/(ledger)/layout.tsx` | metadata + `robots: noindex` (로그인해야 닿는 화면) |
| `app/(ledger)/ledger/page.tsx` | 페이지 본체 |
| `lib/features/ledger/categories.ts` | 고정 프리셋 — 수입 급여·주식 배당·이자·기타 / 지출 고정비·생활비·투자·기타 |
| `lib/features/ledger/ledgerAPI.ts` | `/api/proxy/user/ledger` 호출 (`stockLikesAPI` 패턴) |
| `lib/features/ledger/ledgerSlice.tsx` | `createAppSlice` + `create.asyncThunk` |
| `lib/store.tsx` | slice 등록 |
| `components/navigation.tsx` | `authOnly` 플래그 + `MORE_NAV` 에 가계부 |

## 검증

- `npx tsc --noEmit` → 에러 0
- `npm run build` → 성공, `/ledger` 라우트 생성 확인

배포 후 수동 확인:
1. 로그아웃 상태에서 '더 보기' 를 열면 가계부가 보이지 않고, `/ledger` 직접 접근 시 로그인으로 리다이렉트
2. 로그인 후 데스크톱 '더 보기' 와 모바일 '더보기' 시트 양쪽에 노출
3. 기입 → 요약·항목별 막대가 함께 갱신, 새로고침 후에도 유지 (D1 저장 확인)
4. 모바일 폭에서 삭제 버튼이 보이고, 누르면 확인창이 뜬다
5. ◀ 를 빠르게 여러 번 눌러도 제목의 달과 목록이 어긋나지 않는다