### PR TITLE
가계부 결함 5건 수정

### DIFF
--- a/cf-idiotquant/app/(ledger)/ledger/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import { ChevronLeft, ChevronRight, Plus, Trash2 } from "lucide-react";
 
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
@@ -60,6 +61,7 @@ export default function LedgerPage() {
     const [fCategory, setFCategory] = useState("salary");
     const [fAmount, setFAmount] = useState("");
     const [fMemo, setFMemo] = useState("");
+    const [formError, setFormError] = useState<string | null>(null);
 
     const thisMonth = currentMonthKst();
 
@@ -102,13 +104,20 @@ export default function LedgerPage() {
         changeKind("income");
         setFAmount("");
         setFMemo("");
+        setFormError(null);
         setFormOpen(true);
     }
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
         const amount = Number(fAmount.replace(/[^\d]/g, ""));
-        if (!amount) return;
+        // "0" 은 입력값이 있는 상태라 저장 버튼이 열려 있다. 여기서 조용히 되돌아가면
+        // 눌러도 아무 일이 없는 것처럼 보이므로 이유를 적어준다.
+        if (!amount) {
+            setFormError("금액은 0보다 커야 합니다.");
+            return;
+        }
+        setFormError(null);
 
         const result = await dispatch(reqAddLedgerEntry({
             entry_date: fDate,
@@ -125,16 +134,55 @@ export default function LedgerPage() {
         if (entered !== month) dispatch(setLedgerMonth(entered));
     }
 
+    // 수정 기능이 없어 삭제가 유일한 되돌리기 수단인데, 그 삭제에는 되돌리기가 없다.
+    // 무엇을 지우는지 보여주고 한 번 묻는다.
+    function handleDelete(entry: { id: number; entry_date: string; kind: LedgerKind; category: string; amount: number }) {
+        const what = `${entry.entry_date} ${categoryLabel(entry.kind, entry.category)} ${entry.amount.toLocaleString("ko-KR")}원`;
+        if (!window.confirm(`${what}\n\n이 내역을 삭제할까요? 되돌릴 수 없습니다.`)) return;
+        dispatch(reqDeleteLedgerEntry(entry.id));
+    }
+
+    // 미들웨어가 로그아웃 상태를 막아주지만, 보고 있는 사이 세션이 만료되면 여기로 떨어진다.
+    // 그때 빈 목록을 그대로 두면 "기록이 없습니다"가 떠서 내역이 지워진 것처럼 보인다.
+    const signedOut = status === "unauthenticated";
     const loading = status === "loading" || (loadState === "pending" && entries.length === 0);
+
+    const header = (
+        <PageHeader
+            emoji="📒"
+            title="가계부"
+            meta={<><span>로그인 사용자 전용</span><span aria-hidden>·</span><span>내 계정에만 저장됩니다</span></>}
+            containerClassName="max-w-3xl mx-auto px-4 sm:px-7"
+        />
+    );
+
+    if (signedOut) {
+        return (
+            <div className="min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
+                {header}
+                <div className="max-w-3xl mx-auto px-4 sm:px-7 py-5">
+                    <div className={cn(CARD_CLS, "py-12 px-4 text-center")}>
+                        <p className="text-[13px] font-bold text-neutral-700 dark:text-neutral-300">
+                            로그인이 풀렸습니다.
+                        </p>
+                        <p className="mt-1.5 text-xs text-neutral-400 dark:text-neutral-500">
+                            기록은 그대로 있습니다. 다시 로그인하면 이어서 보입니다.
+                        </p>
+                        <Link
+                            href="/login?callbackUrl=/ledger"
+                            className="inline-block mt-4 px-5 py-2.5 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-xs font-black transition-colors"
+                        >
+                            다시 로그인
+                        </Link>
+                    </div>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className="min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
-            <PageHeader
-                emoji="📒"
-                title="가계부"
-                meta={<><span>로그인 사용자 전용</span><span aria-hidden>·</span><span>내 계정에만 저장됩니다</span></>}
-                containerClassName="max-w-3xl mx-auto px-4 sm:px-7"
-            />
+            {header}
 
             <div className="max-w-3xl mx-auto px-4 sm:px-7 py-5 space-y-3.5">
 
@@ -293,8 +341,10 @@ export default function LedgerPage() {
                                 value={fMemo} onChange={e => setFMemo(e.target.value)} className={CTL_CLS} />
                         </div>
 
-                        {error && (
-                            <p className="text-xs font-bold text-red-600 dark:text-red-400">{error}</p>
+                        {(formError ?? error) && (
+                            <p role="alert" className="text-xs font-bold text-red-600 dark:text-red-400">
+                                {formError ?? error}
+                            </p>
                         )}
 
                         <div className="flex justify-end gap-2 pt-0.5">
@@ -337,7 +387,9 @@ export default function LedgerPage() {
                                 const isIncome = e.kind === "income";
                                 return (
                                     <div key={e.id} className="group grid grid-cols-[auto_auto_1fr_auto_28px] items-center gap-2.5 px-4 py-2.5 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] transition-colors">
-                                        <span className="hidden sm:block text-[11px] font-bold tabular-nums text-neutral-400">
+                                        {/* 날짜는 어느 화면에서도 지우지 않는다 — 같은 항목·같은 금액이
+                                            두 줄이면 날짜 말고는 구분할 단서가 없다. */}
+                                        <span className="text-[11px] font-bold tabular-nums text-neutral-400">
                                             {e.entry_date.slice(5).replace("-", ".")}
                                         </span>
                                         <span className={cn(
@@ -357,10 +409,12 @@ export default function LedgerPage() {
                                         </span>
                                         <button
                                             type="button"
-                                            onClick={() => dispatch(reqDeleteLedgerEntry(e.id))}
+                                            onClick={() => handleDelete(e)}
                                             disabled={mutating}
-                                            className="w-7 h-7 rounded-lg flex items-center justify-center text-neutral-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/30 dark:hover:text-red-400 disabled:cursor-not-allowed transition-all"
-                                            aria-label={`${e.entry_date} 내역 삭제`}
+                                            // 터치 기기에는 hover 가 없다. sm 아래에서는 항상 보이게 두고,
+                                            // 마우스가 있는 화면에서만 hover 로 드러낸다.
+                                            className="w-7 h-7 rounded-lg flex items-center justify-center text-neutral-400 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/30 dark:hover:text-red-400 disabled:cursor-not-allowed transition-all"
+                                            aria-label={`${e.entry_date} ${categoryLabel(e.kind, e.category)} 내역 삭제`}
                                         >
                                             <Trash2 size={14} />
                                         </button>

--- a/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
+++ b/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
@@ -32,7 +32,13 @@ export const ledgerSlice = createAppSlice({
     initialState,
     reducers: (create) => ({
         setLedgerMonth: create.reducer((state, action: PayloadAction<string>) => {
+            if (state.month === action.payload) return;
             state.month = action.payload;
+            // 이전 달 내역을 비운다. 남겨두면 새 응답이 오기 전까지 8월 제목 아래에
+            // 7월 합계가 떠 있게 된다 — 잠깐이라도 틀린 숫자를 보여주지 않는다.
+            state.entries = [];
+            state.state = "pending";
+            state.error = null;
         }),
 
         reqGetLedger: create.asyncThunk(
@@ -43,11 +49,15 @@ export const ledgerSlice = createAppSlice({
             },
             {
                 pending: (state) => { state.state = "pending"; state.error = null; },
+                // ◀▶ 를 연달아 누르면 먼저 보낸 요청이 나중에 도착할 수 있다. 그대로 반영하면
+                // 화면은 8월인데 목록은 6월인 상태가 된다 — 지금 보고 있는 달의 응답만 받는다.
                 fulfilled: (state, action) => {
+                    if (action.meta.arg !== state.month) return;
                     state.entries = (action.payload?.data ?? []) as LedgerEntry[];
                     state.state = "fulfilled";
                 },
                 rejected: (state, action) => {
+                    if (action.meta.arg !== state.month) return;
                     state.state = "rejected";
                     state.error = action.error?.message ?? null;
                 },


### PR DESCRIPTION
#707 로 들어간 가계부 화면을 다시 훑으며 찾은 결함들입니다. #707 이 머지될 때 이 커밋은 아직 푸시 전이라 함께 들어가지 못했습니다 — 그래서 별도 PR 입니다.

전부 "쓰다 보면 걸리는" 종류이고, 새 기능은 없습니다.

## 1. 삭제 버튼이 터치 기기에서 보이지 않았다

`opacity-0 group-hover:opacity-100` 은 hover 가 있는 화면을 전제합니다. 모바일에서는 버튼이 투명한 채로 자리만 차지하고 있었습니다 — **안 보이는데 눌리는** 조합이라 오삭제로 이어집니다.

`sm` 아래에서는 항상 보이게 하고 hover 는 `sm` 이상에서만 겁니다. 겸해서 **삭제 확인**을 넣었습니다: 수정 기능을 뺐기 때문에 삭제가 유일한 정정 수단인데, 그 삭제에는 되돌리기가 없습니다. 무엇을 지우는지(날짜·항목·금액)를 확인 문구에 싣습니다.

## 2. 월을 연달아 넘기면 화면과 목록이 어긋났다

◀ 를 빠르게 누르면 먼저 보낸 요청이 나중에 도착해 최신 응답을 덮어씁니다. 제목은 8월인데 목록은 6월인 상태가 됩니다.

`fulfilled`/`rejected` 에서 `action.meta.arg` 와 `state.month` 를 비교해 지금 보고 있는 달의 응답만 반영합니다. 같은 뿌리로 `setLedgerMonth` 가 이전 달 내역을 비웁니다 — 안 그러면 새 응답이 오기 전까지 8월 제목 아래 7월 합계가 떠 있습니다.

다섯 중 **실제로 잘못된 숫자가 보이는** 유일한 항목이라 가장 무겁습니다.

## 3. 금액에 0 을 넣으면 저장이 조용히 실패했다

`"0"` 은 입력값이 있는 상태라 저장 버튼이 활성화되는데, `handleSubmit` 의 `if (!amount) return;` 이 아무 말 없이 반환했습니다. 눌러도 반응이 없는 것처럼 보입니다. 이유를 폼에 표시합니다 (`role="alert"`).

## 4. 모바일에서 날짜가 사라졌다

`hidden sm:block` 으로 숨겨두었는데, 같은 항목·같은 금액의 두 줄이 있으면 날짜 말고 구분할 단서가 없습니다. 모든 폭에서 보이게 되돌렸습니다.

## 5. 세션이 만료되면 "아직 기록이 없습니다" 로 잘못 안내했다

`status === "unauthenticated"` 면 조회를 걸지 않으므로 빈 목록의 안내 문구가 그대로 떴습니다 — **내역이 지워진 것처럼 보입니다.** "로그인이 풀렸습니다 / 기록은 그대로 있습니다" 와 `/login?callbackUrl=/ledger` 링크를 줍니다.

## 변경 파일

| 파일 | 내용 |
|---|---|
| `app/(ledger)/ledger/page.tsx` | 1·3·4·5 |
| `lib/features/ledger/ledgerSlice.tsx` | 2 |

## 검증

- `npx tsc --noEmit` → 에러 0
- `npm run build` → 성공, `/ledger` 라우트 확인

최신 `main`(0465b4f) 위에서 다시 세운 뒤 검증했습니다. 백엔드는 건드리지 않았습니다 (`MinSikSon/idiotquant-worker#105` 는 이미 머지됨).

수동 확인:
1. 모바일 폭에서 삭제 버튼이 보이고, 누르면 확인창에 지울 내역이 적혀 있다
2. ◀ 를 빠르게 여러 번 눌러도 제목의 달과 합계·목록이 어긋나지 않는다
3. 금액에 `0` 을 넣고 저장하면 "금액은 0보다 커야 합니다" 가 뜬다
4. 모바일 폭에서도 각 줄의 날짜가 보인다