### PR TITLE
가계부 사용성 개선 — 날짜별 묶기·연속 기입·인라인 삭제 확인

### DIFF
--- a/cf-idiotquant/app/(ledger)/ledger/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { ChevronLeft, ChevronRight, Plus, Trash2 } from "lucide-react";
+import type { LedgerEntry } from "@/lib/features/ledger/ledgerAPI";
 
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { cn } from "@/lib/utils";
@@ -39,7 +40,16 @@ function shiftMonth(month: string, delta: number) {
     return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
 }
 
+const WEEKDAY = ["일", "월", "화", "수", "목", "금", "토"];
+
+/** 'YYYY-MM-DD' → '25일 (화)'. 요일이 있어야 "주말에 얼마 썼나"가 눈에 들어온다. */
+function dayLabel(date: string) {
+    const [y, m, d] = date.split("-").map(Number);
+    return `${d}일 (${WEEKDAY[new Date(Date.UTC(y, m - 1, d)).getUTCDay()]})`;
+}
+
 const won = (n: number) => `${n.toLocaleString("ko-KR")}원`;
+const signed = (n: number) => `${n > 0 ? "+" : n < 0 ? "−" : ""}${Math.abs(n).toLocaleString("ko-KR")}`;
 
 export default function LedgerPage() {
     const { status } = useSession();
@@ -62,6 +72,12 @@ export default function LedgerPage() {
     const [fAmount, setFAmount] = useState("");
     const [fMemo, setFMemo] = useState("");
     const [formError, setFormError] = useState<string | null>(null);
+    const amountRef = useRef<HTMLInputElement>(null);
+
+    // 삭제 확인은 그 줄 안에서 한다 — 네이티브 confirm 은 화면 밖으로 흐름을 끊는다.
+    const [confirmId, setConfirmId] = useState<number | null>(null);
+    // 방금 저장한 줄. 연속으로 넣다 보면 어느 게 방금 것인지 놓치기 쉽다.
+    const [justAddedId, setJustAddedId] = useState<number | null>(null);
 
     const thisMonth = currentMonthKst();
 
@@ -69,6 +85,30 @@ export default function LedgerPage() {
         if (status !== "authenticated") return;
         dispatch(reqGetLedger(month));
     }, [dispatch, status, month]);
+
+    // 폼을 열면 금액으로 바로 간다. 날짜·구분·항목은 기본값이 맞는 경우가 대부분이고,
+    // 매번 바꾸는 건 금액이다.
+    useEffect(() => {
+        if (formOpen) amountRef.current?.focus();
+    }, [formOpen]);
+
+    // 하이라이트는 잠깐만 — 다음에 넣을 줄과 헷갈리지 않게.
+    useEffect(() => {
+        if (justAddedId === null) return;
+        const t = setTimeout(() => setJustAddedId(null), 1600);
+        return () => clearTimeout(t);
+    }, [justAddedId]);
+
+    // Esc — 삭제 확인이 떠 있으면 그것부터, 아니면 폼을 닫는다.
+    useEffect(() => {
+        function onKey(ev: KeyboardEvent) {
+            if (ev.key !== "Escape") return;
+            if (confirmId !== null) { setConfirmId(null); return; }
+            if (formOpen) setFormOpen(false);
+        }
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [confirmId, formOpen]);
 
     /* 요약·항목별 집계 — 그 달 내역이 이미 전부 있으므로 여기서 한 번 접는다.
        슬라이스에 따로 두면 리스트와 합계가 어긋날 자리가 생긴다. */
@@ -92,6 +132,22 @@ export default function LedgerPage() {
             .map(b => ({ ...b, pct: Math.round((b.sum / total) * 100) }))
             .sort((a, b) => b.sum - a.sum);
     }, [entries, barKind, income, expense]);
+
+    /* 날짜로 묶는다. 평평하게 나열하면 같은 날짜가 줄마다 반복되고, 정작 "그날 얼마나
+       썼는지"는 어디에도 없다. entries 가 이미 날짜 내림차순이라 Map 삽입 순서가 곧 표시 순서다. */
+    const days = useMemo(() => {
+        const map = new Map<string, LedgerEntry[]>();
+        for (const e of entries) {
+            const bucket = map.get(e.entry_date);
+            if (bucket) bucket.push(e);
+            else map.set(e.entry_date, [e]);
+        }
+        return [...map].map(([date, items]) => ({
+            date,
+            items,
+            net: items.reduce((s, e) => s + (e.kind === "income" ? e.amount : -e.amount), 0),
+        }));
+    }, [entries]);
 
     /* ─── 핸들러 ───────────────────────────────────────────────── */
     function changeKind(kind: LedgerKind) {
@@ -128,18 +184,16 @@ export default function LedgerPage() {
         }));
         if (result.meta.requestStatus !== "fulfilled") return;
 
-        setFormOpen(false);
+        // 가계부는 한 번에 여러 건을 넣는다. 폼을 닫아버리면 두 번째 줄마다 다시 열어야 한다.
+        // 금액·메모만 비우고 열어둔 채 금액으로 돌아간다 — 날짜·구분·항목은 대개 그대로 간다.
+        setFAmount("");
+        setFMemo("");
+        setJustAddedId((result.payload as { data?: { id?: number } })?.data?.id ?? null);
+        amountRef.current?.focus();
+
         // 보고 있지 않은 달에 넣었으면 그 달로 따라간다 — 방금 적은 줄이 어디 갔는지 찾게 두지 않는다.
         const entered = fDate.slice(0, 7);
         if (entered !== month) dispatch(setLedgerMonth(entered));
-    }
-
-    // 수정 기능이 없어 삭제가 유일한 되돌리기 수단인데, 그 삭제에는 되돌리기가 없다.
-    // 무엇을 지우는지 보여주고 한 번 묻는다.
-    function handleDelete(entry: { id: number; entry_date: string; kind: LedgerKind; category: string; amount: number }) {
-        const what = `${entry.entry_date} ${categoryLabel(entry.kind, entry.category)} ${entry.amount.toLocaleString("ko-KR")}원`;
-        if (!window.confirm(`${what}\n\n이 내역을 삭제할까요? 되돌릴 수 없습니다.`)) return;
-        dispatch(reqDeleteLedgerEntry(entry.id));
     }
 
     // 미들웨어가 로그아웃 상태를 막아주지만, 보고 있는 사이 세션이 만료되면 여기로 떨어진다.
@@ -196,9 +250,19 @@ export default function LedgerPage() {
                     >
                         <ChevronLeft size={17} strokeWidth={2.4} />
                     </button>
-                    <div className="min-w-[132px] text-center text-[15px] font-black tracking-[-0.02em] text-neutral-900 dark:text-white">
+                    {/* 반 년 전으로 가려고 ◀ 를 여섯 번 누르게 두지 않는다. 라벨을 누르면
+                        브라우저 월 선택기가 열린다(미지원 브라우저는 ◀▶ 로 그대로 동작). */}
+                    <label className="relative min-w-[132px] px-2 py-1 rounded-lg text-center text-[15px] font-black tracking-[-0.02em] text-neutral-900 dark:text-white cursor-pointer hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] transition-colors focus-within:ring-1 focus-within:ring-[#16a34a]">
                         {Number(month.slice(0, 4))}년 {Number(month.slice(5, 7))}월
-                    </div>
+                        <input
+                            type="month"
+                            value={month}
+                            max={thisMonth}
+                            onChange={e => { if (e.target.value) dispatch(setLedgerMonth(e.target.value)); }}
+                            className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                            aria-label="월 선택"
+                        />
+                    </label>
                     <button
                         type="button"
                         onClick={() => dispatch(setLedgerMonth(shiftMonth(month, 1)))}
@@ -236,6 +300,7 @@ export default function LedgerPage() {
                                     key={k}
                                     type="button"
                                     onClick={() => setBarKind(k)}
+                                    aria-pressed={barKind === k}
                                     className={cn(
                                         "px-3 py-1.5 text-[11px] font-black transition-colors",
                                         barKind === k
@@ -298,6 +363,7 @@ export default function LedgerPage() {
                                             key={k}
                                             type="button"
                                             onClick={() => changeKind(k)}
+                                            aria-pressed={fKind === k}
                                             className={cn(
                                                 "flex-1 py-2 text-xs font-black transition-colors",
                                                 fKind === k
@@ -324,6 +390,7 @@ export default function LedgerPage() {
                             <div className="flex flex-col gap-1.5 flex-1 min-w-[130px]">
                                 <label htmlFor="f-amt" className={FIELD_LABEL_CLS}>금액 (원)</label>
                                 <input
+                                    ref={amountRef}
                                     id="f-amt" type="text" inputMode="numeric" required placeholder="0"
                                     value={fAmount}
                                     onChange={e => {
@@ -347,15 +414,20 @@ export default function LedgerPage() {
                             </p>
                         )}
 
-                        <div className="flex justify-end gap-2 pt-0.5">
+                        <div className="flex items-center justify-between gap-2 pt-0.5">
+                            <span className="text-[11px] text-neutral-400 dark:text-neutral-500">
+                                저장해도 폼은 열려 있습니다 — 이어서 기입하세요.
+                            </span>
+                            <div className="flex gap-2 shrink-0">
                             <button type="button" onClick={() => setFormOpen(false)}
                                 className="px-4 py-2 rounded-xl border border-neutral-200 dark:border-[#3a3834] bg-[#faf9f7] dark:bg-[#1a1915] text-xs font-black text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200/70 dark:hover:bg-[#2c2b27] transition-colors">
-                                취소
+                                닫기
                             </button>
                             <button type="submit" disabled={mutating || !fAmount}
                                 className="px-5 py-2 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-xs font-black disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
                                 {mutating ? "저장 중…" : "저장"}
                             </button>
+                            </div>
                         </div>
                     </form>
                 )}
@@ -382,45 +454,99 @@ export default function LedgerPage() {
                             <br />위 “기입하기”로 첫 줄을 남겨보세요.
                         </div>
                     ) : (
-                        <div className="divide-y divide-neutral-50 dark:divide-[#35332e]/40">
-                            {entries.map(e => {
-                                const isIncome = e.kind === "income";
-                                return (
-                                    <div key={e.id} className="group grid grid-cols-[auto_auto_1fr_auto_28px] items-center gap-2.5 px-4 py-2.5 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] transition-colors">
-                                        {/* 날짜는 어느 화면에서도 지우지 않는다 — 같은 항목·같은 금액이
-                                            두 줄이면 날짜 말고는 구분할 단서가 없다. */}
-                                        <span className="text-[11px] font-bold tabular-nums text-neutral-400">
-                                            {e.entry_date.slice(5).replace("-", ".")}
+                        <div>
+                            {days.map(day => (
+                                <div key={day.date}>
+                                    {/* 날짜 머리 — 날짜를 줄마다 반복하는 대신 한 번 쓰고,
+                                        그 자리에 그날 수지를 얹는다. */}
+                                    <div className="flex items-baseline justify-between gap-3 px-4 py-1.5 bg-[#faf9f7] dark:bg-[#1f1e1b] border-y border-neutral-100 dark:border-[#35332e]">
+                                        <span className="text-[11px] font-black text-neutral-500 dark:text-neutral-400 tabular-nums">
+                                            {dayLabel(day.date)}
                                         </span>
                                         <span className={cn(
-                                            "text-[11px] font-black px-2 py-0.5 rounded-md whitespace-nowrap",
-                                            isIncome
-                                                ? "bg-[#dcfce7] text-[#16a34a] dark:bg-[#052e16]/60 dark:text-[#16a34a]"
-                                                : "bg-red-100 text-red-600 dark:bg-red-950/40 dark:text-red-400"
+                                            "text-[11px] font-black tabular-nums",
+                                            day.net < 0 ? "text-red-600 dark:text-red-400" : "text-[#16a34a]"
                                         )}>
-                                            {categoryLabel(e.kind, e.category)}
+                                            {signed(day.net)}
                                         </span>
-                                        <span className="text-xs text-neutral-500 dark:text-neutral-400 truncate">{e.memo ?? ""}</span>
-                                        <span className={cn(
-                                            "text-[13px] font-black tabular-nums whitespace-nowrap",
-                                            isIncome ? "text-[#16a34a]" : "text-neutral-900 dark:text-neutral-100"
-                                        )}>
-                                            {isIncome ? "+" : "−"}{e.amount.toLocaleString("ko-KR")}
-                                        </span>
-                                        <button
-                                            type="button"
-                                            onClick={() => handleDelete(e)}
-                                            disabled={mutating}
-                                            // 터치 기기에는 hover 가 없다. sm 아래에서는 항상 보이게 두고,
-                                            // 마우스가 있는 화면에서만 hover 로 드러낸다.
-                                            className="w-7 h-7 rounded-lg flex items-center justify-center text-neutral-400 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/30 dark:hover:text-red-400 disabled:cursor-not-allowed transition-all"
-                                            aria-label={`${e.entry_date} ${categoryLabel(e.kind, e.category)} 내역 삭제`}
-                                        >
-                                            <Trash2 size={14} />
-                                        </button>
                                     </div>
-                                );
-                            })}
+
+                                    <div className="divide-y divide-neutral-50 dark:divide-[#35332e]/40">
+                                        {day.items.map(e => {
+                                            const isIncome = e.kind === "income";
+                                            const confirming = confirmId === e.id;
+                                            return (
+                                                <div
+                                                    key={e.id}
+                                                    className={cn(
+                                                        "group grid grid-cols-[auto_1fr_auto_28px] items-center gap-2.5 px-4 py-2.5 transition-colors",
+                                                        confirming
+                                                            ? "bg-red-50 dark:bg-red-950/20"
+                                                            : justAddedId === e.id
+                                                                ? "bg-[#dcfce7]/70 dark:bg-[#052e16]/40"
+                                                                : "hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]"
+                                                    )}
+                                                >
+                                                    <span className={cn(
+                                                        "text-[11px] font-black px-2 py-0.5 rounded-md whitespace-nowrap",
+                                                        isIncome
+                                                            ? "bg-[#dcfce7] text-[#16a34a] dark:bg-[#052e16]/60 dark:text-[#16a34a]"
+                                                            : "bg-red-100 text-red-600 dark:bg-red-950/40 dark:text-red-400"
+                                                    )}>
+                                                        {categoryLabel(e.kind, e.category)}
+                                                    </span>
+
+                                                    {confirming ? (
+                                                        <>
+                                                            <span className="text-xs font-bold text-red-700 dark:text-red-300">
+                                                                삭제할까요? 되돌릴 수 없습니다.
+                                                            </span>
+                                                            <span className="col-span-2 flex items-center justify-end gap-1.5">
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => { dispatch(reqDeleteLedgerEntry(e.id)); setConfirmId(null); }}
+                                                                    disabled={mutating}
+                                                                    className="px-2.5 py-1 rounded-lg bg-red-600 hover:bg-red-700 text-white text-[11px] font-black disabled:opacity-50 transition-colors"
+                                                                >
+                                                                    삭제
+                                                                </button>
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => setConfirmId(null)}
+                                                                    className="px-2.5 py-1 rounded-lg border border-neutral-200 dark:border-[#3a3834] bg-white dark:bg-[#242320] text-[11px] font-black text-neutral-600 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-[#2c2b27] transition-colors"
+                                                                >
+                                                                    취소
+                                                                </button>
+                                                            </span>
+                                                        </>
+                                                    ) : (
+                                                        <>
+                                                            <span className="text-xs text-neutral-500 dark:text-neutral-400 truncate">{e.memo ?? ""}</span>
+                                                            <span className={cn(
+                                                                "text-[13px] font-black tabular-nums whitespace-nowrap",
+                                                                isIncome ? "text-[#16a34a]" : "text-neutral-900 dark:text-neutral-100"
+                                                            )}>
+                                                                {isIncome ? "+" : "−"}{e.amount.toLocaleString("ko-KR")}
+                                                            </span>
+                                                            <button
+                                                                type="button"
+                                                                onClick={() => setConfirmId(e.id)}
+                                                                disabled={mutating}
+                                                                // 터치 기기에는 hover 가 없다. sm 아래에서는 항상 보이게 두고,
+                                                                // 마우스가 있는 화면에서만 hover 로 드러낸다.
+                                                                className="w-7 h-7 rounded-lg flex items-center justify-center text-neutral-400 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/30 dark:hover:text-red-400 disabled:cursor-not-allowed transition-all"
+                                                                aria-label={`${e.entry_date} ${categoryLabel(e.kind, e.category)} ${e.amount.toLocaleString("ko-KR")}원 삭제`}
+                                                            >
+                                                                <Trash2 size={14} />
+                                                            </button>
+                                                        </>
+                                                    )}
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            ))}
                         </div>
                     )}
                 </section>


### PR DESCRIPTION
#707 · #708 에 이어지는 세 번째 조각입니다. 기능을 더하지 않고, 실제로 여러 건을 넣어보면 걸리는 자리만 손봤습니다.

`app/(ledger)/ledger/page.tsx` 한 파일, +174/−48.

## 1. 내역을 날짜로 묶고 그날 수지를 머리에 올렸다

가장 큰 변화입니다. 평평하게 나열하면 같은 날짜가 줄마다 반복되는데, 정작 **"그날 얼마 썼나"는 어디에도 없었습니다.**

```
8월 25일 (화)                    +3,200,000
  급여    8월 급여              +3,200,000  🗑
8월 16일 (토)                      −214,000
  생활비  장보기                  −214,000  🗑
```

날짜가 머리로 올라가면서 각 줄에서는 빠졌습니다 — #708 에서 "모바일에서 날짜를 지우지 말자"고 고쳤던 것을 되돌린 게 아니라, **한 번만 쓰는 자리로 옮긴 것**입니다. 모든 폭에서 날짜는 여전히 보이고 오히려 더 크게 보입니다. 요일도 함께 나와 주말 지출이 눈에 들어옵니다.

`entries` 가 이미 날짜 내림차순이라 Map 삽입 순서가 곧 표시 순서입니다 — 정렬을 다시 하지 않습니다.

## 2. 저장해도 폼을 닫지 않는다

가계부는 한 번에 여러 건을 넣는 물건인데, 저장할 때마다 폼이 닫혀 두 번째 줄부터는 매번 다시 열어야 했습니다.

이제 금액·메모만 비우고 **금액 칸으로 포커스를 돌려줍니다.** 날짜·구분·항목은 대개 그대로 가므로 연속 입력이 금액 타이핑만으로 이어집니다. 방금 넣은 줄은 1.6초간 초록으로 표시해 어느 게 방금 것인지 알려줍니다. 하단 버튼은 "취소" → **"닫기"** 로 바꿨습니다(더 이상 취소가 아니므로).

## 3. 월 라벨을 누르면 월 선택기가 열린다

반 년 전으로 가려고 ◀ 를 여섯 번 누르게 두지 않습니다. 네이티브 `<input type="month">` 를 라벨 위에 투명하게 얹었고 `max` 는 이번 달입니다. 미지원 브라우저(Firefox)에서는 ◀▶ 가 그대로 동작합니다.

## 4. 삭제 확인을 그 줄 안으로 옮겼다

#708 에서 넣은 `window.confirm` 을 대체합니다. 네이티브 모달은 흐름을 화면 밖으로 끊고 모바일에서 특히 거칩니다. 이제 그 줄이 빨갛게 바뀌며 `삭제할까요? 되돌릴 수 없습니다.` + [삭제][취소] 가 그 자리에 뜹니다.

무엇을 지우는지는 **그 줄이 이미 보여주고 있어서** confirm 문구로 날짜·항목·금액을 반복하던 것도 없앴습니다.

## 5. Esc 로 닫는다

삭제 확인이 떠 있으면 그것부터, 아니면 폼을 닫습니다.

## 6. 세그먼트 버튼에 `aria-pressed`

수입/지출 토글 두 곳(항목별 막대·기입 폼) 모두. 스크린리더가 어느 쪽이 선택됐는지 읽습니다.

## 검증

- `npx tsc --noEmit` → 에러 0
- `npm run build` → 성공, `/ledger` 라우트 확인

최신 `main`(c590f55) 위에서 다시 세운 뒤 검증했습니다. 백엔드는 건드리지 않았습니다.

수동 확인:
1. 같은 날 두 건을 넣으면 날짜 머리 하나 아래 두 줄로 묶이고, 머리의 수지가 두 건의 합이다
2. 저장해도 폼이 열려 있고 커서가 금액에 있다 — 금액만 치고 다시 저장하면 연속으로 들어간다
3. 월 라벨을 누르면 월 선택기가 열린다
4. 🗑 을 누르면 그 줄에서 확인이 뜨고, Esc 로 취소된다

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkWhRiKfTxb61ByrP4YWtB)_