### PR TITLE
가계부 추가·수정 UI 모바일 최적화 + 내역 수정 기능

### DIFF
--- a/cf-idiotquant/app/(ledger)/ledger/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/page.tsx
@@ -3,14 +3,14 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, Plus, Trash2 } from "lucide-react";
-import type { LedgerEntry } from "@/lib/features/ledger/ledgerAPI";
+import { ChevronLeft, ChevronRight, ChevronDown, Plus, Trash2 } from "lucide-react";
 
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { cn } from "@/lib/utils";
 import { PageHeader } from "@/components/pageHeader";
+import type { LedgerEntry, NewLedgerEntry } from "@/lib/features/ledger/ledgerAPI";
 import {
-    setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqDeleteLedgerEntry,
+    setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqUpdateLedgerEntry, reqDeleteLedgerEntry,
     selectLedgerMonth, selectLedgerEntries, selectLedgerState,
     selectLedgerMutating, selectLedgerError,
     currentMonthKst,
@@ -19,9 +19,9 @@ import {
     categoriesOf, categoryLabel, type LedgerKind,
 } from "@/lib/features/ledger/categories";
 
-/* ─── 공통 클래스 (ticker-map 화면과 같은 입력 모양) ────────────────── */
+/* ─── 공통 클래스 ──────────────────────────────────────────────── */
 const CTL_CLS =
-    "w-full px-3 py-2 bg-[#faf9f7] dark:bg-[#1a1915] border border-neutral-200 dark:border-[#35332e] " +
+    "w-full px-3 min-h-[44px] bg-[#faf9f7] dark:bg-[#1a1915] border border-neutral-200 dark:border-[#35332e] " +
     "rounded-xl text-sm font-bold text-neutral-900 dark:text-white " +
     "focus:outline-none focus:ring-1 focus:ring-[#16a34a] focus:border-[#16a34a]";
 
@@ -31,8 +31,17 @@ const FIELD_LABEL_CLS =
 const CARD_CLS =
     "bg-white dark:bg-[#242320] border border-neutral-200 dark:border-[#35332e] rounded-2xl";
 
-/* ─── 날짜 유틸 — 사용자가 보는 달·오늘은 KST 기준이다 ─────────────── */
+const CHIP_CLS =
+    "min-h-[40px] px-3.5 rounded-xl border text-[13px] font-bold transition-colors";
+
+/* ─── 날짜 유틸 — 사용자가 보는 달·오늘은 KST 기준이다 ─────────── */
 const todayKst = () => new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
+
+function shiftDay(date: string, delta: number) {
+    const [y, m, d] = date.split("-").map(Number);
+    const t = new Date(Date.UTC(y, m - 1, d + delta));
+    return t.toISOString().slice(0, 10);
+}
 
 function shiftMonth(month: string, delta: number) {
     const [y, m] = month.split("-").map(Number);
@@ -51,6 +60,9 @@ function dayLabel(date: string) {
 const won = (n: number) => `${n.toLocaleString("ko-KR")}원`;
 const signed = (n: number) => `${n > 0 ? "+" : n < 0 ? "−" : ""}${Math.abs(n).toLocaleString("ko-KR")}`;
 
+/** 모바일에서 0 을 여섯 번 치는 게 가장 성가시다. 지금 값에 더한다. */
+const QUICK_ADD = [10000, 50000, 100000];
+
 export default function LedgerPage() {
     const { status } = useSession();
     const dispatch = useAppDispatch();
@@ -61,11 +73,12 @@ export default function LedgerPage() {
     const mutating = useAppSelector(selectLedgerMutating);
     const error = useAppSelector(selectLedgerError);
 
-    // 항목별 막대를 수입 기준으로 볼지 지출 기준으로 볼지
     const [barKind, setBarKind] = useState<LedgerKind>("income");
 
-    // 기입 폼
-    const [formOpen, setFormOpen] = useState(false);
+    /* 시트 — editingId 가 null 이면 기입, 값이 있으면 그 줄을 수정한다 */
+    const [sheetOpen, setSheetOpen] = useState(false);
+    const [editingId, setEditingId] = useState<number | null>(null);
+    const [askDelete, setAskDelete] = useState(false);
     const [fDate, setFDate] = useState(todayKst());
     const [fKind, setFKind] = useState<LedgerKind>("income");
     const [fCategory, setFCategory] = useState("salary");
@@ -74,44 +87,42 @@ export default function LedgerPage() {
     const [formError, setFormError] = useState<string | null>(null);
     const amountRef = useRef<HTMLInputElement>(null);
 
-    // 삭제 확인은 그 줄 안에서 한다 — 네이티브 confirm 은 화면 밖으로 흐름을 끊는다.
-    const [confirmId, setConfirmId] = useState<number | null>(null);
-    // 방금 저장한 줄. 연속으로 넣다 보면 어느 게 방금 것인지 놓치기 쉽다.
+    // 시트가 목록을 가리므로 저장 결과는 시트 위에 뜨는 토스트로 알린다.
+    const [toast, setToast] = useState<string | null>(null);
     const [justAddedId, setJustAddedId] = useState<number | null>(null);
 
     const thisMonth = currentMonthKst();
+    const editing = editingId !== null;
 
     useEffect(() => {
         if (status !== "authenticated") return;
         dispatch(reqGetLedger(month));
     }, [dispatch, status, month]);
 
-    // 폼을 열면 금액으로 바로 간다. 날짜·구분·항목은 기본값이 맞는 경우가 대부분이고,
-    // 매번 바꾸는 건 금액이다.
     useEffect(() => {
-        if (formOpen) amountRef.current?.focus();
-    }, [formOpen]);
+        if (!toast) return;
+        const t = setTimeout(() => setToast(null), 1600);
+        return () => clearTimeout(t);
+    }, [toast]);
 
-    // 하이라이트는 잠깐만 — 다음에 넣을 줄과 헷갈리지 않게.
     useEffect(() => {
         if (justAddedId === null) return;
         const t = setTimeout(() => setJustAddedId(null), 1600);
         return () => clearTimeout(t);
     }, [justAddedId]);
 
-    // Esc — 삭제 확인이 떠 있으면 그것부터, 아니면 폼을 닫는다.
+    // Esc — 삭제 확인이 떠 있으면 그것부터, 아니면 시트를 닫는다.
     useEffect(() => {
         function onKey(ev: KeyboardEvent) {
             if (ev.key !== "Escape") return;
-            if (confirmId !== null) { setConfirmId(null); return; }
-            if (formOpen) setFormOpen(false);
+            if (askDelete) { setAskDelete(false); return; }
+            if (sheetOpen) setSheetOpen(false);
         }
         window.addEventListener("keydown", onKey);
         return () => window.removeEventListener("keydown", onKey);
-    }, [confirmId, formOpen]);
+    }, [askDelete, sheetOpen]);
 
-    /* 요약·항목별 집계 — 그 달 내역이 이미 전부 있으므로 여기서 한 번 접는다.
-       슬라이스에 따로 두면 리스트와 합계가 어긋날 자리가 생긴다. */
+    /* 요약·항목별 — 그 달 내역이 이미 전부 있으므로 여기서 한 번 접는다. */
     const { income, expense, net } = useMemo(() => {
         const income = entries.filter(e => e.kind === "income").reduce((s, e) => s + e.amount, 0);
         const expense = entries.filter(e => e.kind === "expense").reduce((s, e) => s + e.amount, 0);
@@ -133,8 +144,7 @@ export default function LedgerPage() {
             .sort((a, b) => b.sum - a.sum);
     }, [entries, barKind, income, expense]);
 
-    /* 날짜로 묶는다. 평평하게 나열하면 같은 날짜가 줄마다 반복되고, 정작 "그날 얼마나
-       썼는지"는 어디에도 없다. entries 가 이미 날짜 내림차순이라 Map 삽입 순서가 곧 표시 순서다. */
+    /* 날짜로 묶는다 — entries 가 이미 날짜 내림차순이라 Map 삽입 순서가 곧 표시 순서다. */
     const days = useMemo(() => {
         const map = new Map<string, LedgerEntry[]>();
         for (const e of entries) {
@@ -149,25 +159,43 @@ export default function LedgerPage() {
         }));
     }, [entries]);
 
-    /* ─── 핸들러 ───────────────────────────────────────────────── */
-    function changeKind(kind: LedgerKind) {
+    /* ─── 시트 열고 닫기 ───────────────────────────────────────── */
+    function changeKind(kind: LedgerKind, keep?: string) {
         setFKind(kind);
-        setFCategory(categoriesOf(kind)[0].key);
+        const list = categoriesOf(kind);
+        setFCategory(keep && list.some(c => c.key === keep) ? keep : list[0].key);
     }
 
-    function openForm() {
+    function openAdd() {
+        setEditingId(null);
+        setAskDelete(false);
         setFDate(month === thisMonth ? todayKst() : `${month}-01`);
         changeKind("income");
         setFAmount("");
         setFMemo("");
         setFormError(null);
-        setFormOpen(true);
+        setSheetOpen(true);
+        setTimeout(() => amountRef.current?.focus(), 60);
     }
+
+    function openEdit(entry: LedgerEntry) {
+        setEditingId(entry.id);
+        setAskDelete(false);
+        setFDate(entry.entry_date);
+        changeKind(entry.kind, entry.category);
+        setFAmount(entry.amount.toLocaleString("ko-KR"));
+        setFMemo(entry.memo ?? "");
+        setFormError(null);
+        setSheetOpen(true);
+    }
+
+    const amountValue = () => Number(fAmount.replace(/[^\d]/g, ""));
+    const setAmountNumber = (n: number) => setFAmount(n ? n.toLocaleString("ko-KR") : "");
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
-        const amount = Number(fAmount.replace(/[^\d]/g, ""));
-        // "0" 은 입력값이 있는 상태라 저장 버튼이 열려 있다. 여기서 조용히 되돌아가면
+        const amount = amountValue();
+        // "0" 은 입력값이 있는 상태라 저장 버튼이 열려 있다. 조용히 되돌아가면
         // 눌러도 아무 일이 없는 것처럼 보이므로 이유를 적어준다.
         if (!amount) {
             setFormError("금액은 0보다 커야 합니다.");
@@ -175,29 +203,47 @@ export default function LedgerPage() {
         }
         setFormError(null);
 
-        const result = await dispatch(reqAddLedgerEntry({
+        const payload: NewLedgerEntry = {
             entry_date: fDate,
             kind: fKind,
             category: fCategory,
             amount,
             memo: fMemo.trim() || undefined,
-        }));
+        };
+        const entered = fDate.slice(0, 7);
+
+        if (editingId !== null) {
+            // 수정은 한 건만 고치러 들어온 흐름이라 저장하면 닫는다.
+            const result = await dispatch(reqUpdateLedgerEntry({ id: editingId, entry: payload }));
+            if (result.meta.requestStatus !== "fulfilled") return;
+            setSheetOpen(false);
+            setToast("수정했습니다");
+            if (entered !== month) dispatch(setLedgerMonth(entered));
+            return;
+        }
+
+        const result = await dispatch(reqAddLedgerEntry(payload));
         if (result.meta.requestStatus !== "fulfilled") return;
 
-        // 가계부는 한 번에 여러 건을 넣는다. 폼을 닫아버리면 두 번째 줄마다 다시 열어야 한다.
-        // 금액·메모만 비우고 열어둔 채 금액으로 돌아간다 — 날짜·구분·항목은 대개 그대로 간다.
+        // 기입은 한 번에 여러 건을 넣는다. 금액·메모만 비우고 열어둔 채 금액으로 돌아간다.
         setFAmount("");
         setFMemo("");
         setJustAddedId((result.payload as { data?: { id?: number } })?.data?.id ?? null);
+        setToast("저장했습니다");
         amountRef.current?.focus();
 
-        // 보고 있지 않은 달에 넣었으면 그 달로 따라간다 — 방금 적은 줄이 어디 갔는지 찾게 두지 않는다.
-        const entered = fDate.slice(0, 7);
         if (entered !== month) dispatch(setLedgerMonth(entered));
     }
 
+    async function handleDelete() {
+        if (editingId === null) return;
+        const result = await dispatch(reqDeleteLedgerEntry(editingId));
+        if (result.meta.requestStatus !== "fulfilled") return;
+        setSheetOpen(false);
+        setToast("삭제했습니다");
+    }
+
     // 미들웨어가 로그아웃 상태를 막아주지만, 보고 있는 사이 세션이 만료되면 여기로 떨어진다.
-    // 그때 빈 목록을 그대로 두면 "기록이 없습니다"가 떠서 내역이 지워진 것처럼 보인다.
     const signedOut = status === "unauthenticated";
     const loading = status === "loading" || (loadState === "pending" && entries.length === 0);
 
@@ -238,22 +284,32 @@ export default function LedgerPage() {
         <div className="min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
             {header}
 
+            {toast && (
+                <div
+                    role="status"
+                    className="fixed top-[60px] md:top-5 left-1/2 -translate-x-1/2 z-[60] px-4 py-2 rounded-full bg-[#16a34a] text-white text-xs font-black shadow-lg shadow-[#16a34a]/30"
+                >
+                    {toast}
+                </div>
+            )}
+
             <div className="max-w-3xl mx-auto px-4 sm:px-7 py-5 space-y-3.5">
 
-                {/* ① 월 선택 */}
-                <div className={cn(CARD_CLS, "flex items-center justify-center gap-1.5 p-2.5")}>
+                {/* ① 월 선택 — 터치 타겟 44px */}
+                <div className={cn(CARD_CLS, "flex items-center justify-center gap-1 p-1.5")}>
                     <button
                         type="button"
                         onClick={() => dispatch(setLedgerMonth(shiftMonth(month, -1)))}
-                        className="w-9 h-9 rounded-xl flex items-center justify-center text-neutral-600 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] transition-colors"
+                        className="w-11 h-11 rounded-xl flex items-center justify-center text-neutral-600 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] transition-colors"
                         aria-label="이전 달"
                     >
-                        <ChevronLeft size={17} strokeWidth={2.4} />
+                        <ChevronLeft size={18} strokeWidth={2.4} />
                     </button>
-                    {/* 반 년 전으로 가려고 ◀ 를 여섯 번 누르게 두지 않는다. 라벨을 누르면
-                        브라우저 월 선택기가 열린다(미지원 브라우저는 ◀▶ 로 그대로 동작). */}
-                    <label className="relative min-w-[132px] px-2 py-1 rounded-lg text-center text-[15px] font-black tracking-[-0.02em] text-neutral-900 dark:text-white cursor-pointer hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] transition-colors focus-within:ring-1 focus-within:ring-[#16a34a]">
+
+                    {/* 반 년 전으로 가려고 ◀ 를 여섯 번 누르게 두지 않는다. */}
+                    <label className="relative flex-1 sm:flex-none sm:min-w-[150px] h-11 flex items-center justify-center gap-1.5 rounded-xl text-[15px] font-black tracking-[-0.02em] text-neutral-900 dark:text-white cursor-pointer hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] focus-within:ring-1 focus-within:ring-[#16a34a] transition-colors">
                         {Number(month.slice(0, 4))}년 {Number(month.slice(5, 7))}월
+                        <ChevronDown size={13} strokeWidth={2.6} className="text-neutral-400" />
                         <input
                             type="month"
                             value={month}
@@ -263,31 +319,52 @@ export default function LedgerPage() {
                             aria-label="월 선택"
                         />
                     </label>
+
                     <button
                         type="button"
                         onClick={() => dispatch(setLedgerMonth(shiftMonth(month, 1)))}
                         disabled={month >= thisMonth}
-                        className="w-9 h-9 rounded-xl flex items-center justify-center text-neutral-600 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors"
+                        className="w-11 h-11 rounded-xl flex items-center justify-center text-neutral-600 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27] disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-transparent transition-colors"
                         aria-label="다음 달"
                     >
-                        <ChevronRight size={17} strokeWidth={2.4} />
+                        <ChevronRight size={18} strokeWidth={2.4} />
                     </button>
                 </div>
 
-                {/* ② 요약 */}
-                <div className={cn(CARD_CLS, "grid grid-cols-3")}>
-                    {[
-                        { k: "수입", v: won(income), cls: "text-[#16a34a]" },
-                        { k: "지출", v: won(expense), cls: "text-red-600 dark:text-red-400" },
-                        { k: "잔액", v: `${net > 0 ? "+" : ""}${won(net)}`, cls: net < 0 ? "text-red-600 dark:text-red-400" : "text-[#16a34a]" },
-                    ].map((cell, i) => (
-                        <div key={cell.k} className={cn("py-3.5 px-2 text-center", i < 2 && "border-r border-neutral-100 dark:border-[#35332e]")}>
-                            <div className={FIELD_LABEL_CLS}>{cell.k}</div>
-                            <div className={cn("mt-1 text-[17px] font-black tracking-[-0.02em] tabular-nums", cell.cls)}>
-                                {loading ? "—" : cell.v}
+                {/* ② 요약 — 좁은 화면에서는 잔액을 크게 한 줄, 수입·지출은 아래 두 칸 */}
+                <div className={CARD_CLS}>
+                    <div className="px-4 pt-3.5 pb-3 text-center border-b border-neutral-100 dark:border-[#35332e] sm:hidden">
+                        <div className={FIELD_LABEL_CLS}>잔액</div>
+                        <div className={cn(
+                            "mt-0.5 text-[27px] font-black tracking-[-0.03em] tabular-nums",
+                            net < 0 ? "text-red-600 dark:text-red-400" : "text-[#16a34a]"
+                        )}>
+                            {loading ? "—" : `${net > 0 ? "+" : ""}${won(net)}`}
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-2 sm:grid-cols-3">
+                        <div className="py-3 px-2 text-center border-r border-neutral-100 dark:border-[#35332e]">
+                            <div className={FIELD_LABEL_CLS}>수입</div>
+                            <div className="mt-1 text-[15px] sm:text-[17px] font-black tracking-[-0.02em] tabular-nums text-[#16a34a]">
+                                {loading ? "—" : won(income)}
                             </div>
                         </div>
-                    ))}
+                        <div className="py-3 px-2 text-center sm:border-r sm:border-neutral-100 sm:dark:border-[#35332e]">
+                            <div className={FIELD_LABEL_CLS}>지출</div>
+                            <div className="mt-1 text-[15px] sm:text-[17px] font-black tracking-[-0.02em] tabular-nums text-red-600 dark:text-red-400">
+                                {loading ? "—" : won(expense)}
+                            </div>
+                        </div>
+                        <div className="hidden sm:block py-3 px-2 text-center">
+                            <div className={FIELD_LABEL_CLS}>잔액</div>
+                            <div className={cn(
+                                "mt-1 text-[17px] font-black tracking-[-0.02em] tabular-nums",
+                                net < 0 ? "text-red-600 dark:text-red-400" : "text-[#16a34a]"
+                            )}>
+                                {loading ? "—" : `${net > 0 ? "+" : ""}${won(net)}`}
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
                 {/* ③ 항목별 막대 */}
@@ -302,7 +379,7 @@ export default function LedgerPage() {
                                     onClick={() => setBarKind(k)}
                                     aria-pressed={barKind === k}
                                     className={cn(
-                                        "px-3 py-1.5 text-[11px] font-black transition-colors",
+                                        "px-3 min-h-[34px] text-[11px] font-black transition-colors",
                                         barKind === k
                                             ? k === "income" ? "bg-[#16a34a] text-white" : "bg-red-600 text-white"
                                             : "bg-white dark:bg-[#242320] text-neutral-500 hover:bg-neutral-50 dark:hover:bg-[#35332e]"
@@ -314,123 +391,39 @@ export default function LedgerPage() {
                         </div>
                     </div>
 
-                    <div className="px-4 py-3.5 flex flex-col gap-2.5">
+                    <div className="px-4 py-3.5 flex flex-col gap-3">
                         {buckets.length === 0 ? (
                             <div className="py-3 text-center text-xs text-neutral-400 dark:text-neutral-500">
                                 이 달에 기록된 {barKind === "income" ? "수입" : "지출"}이 없습니다.
                             </div>
                         ) : buckets.map(b => (
-                            <div key={b.label} className="grid grid-cols-[64px_1fr_auto] items-center gap-2.5">
-                                <div className="text-xs font-bold text-neutral-600 dark:text-neutral-400 truncate">{b.label}</div>
-                                <div className="h-2 rounded-full bg-neutral-100 dark:bg-[#2c2b27] overflow-hidden">
-                                    <div
-                                        className={cn("h-full rounded-full transition-all duration-300", barKind === "income" ? "bg-[#16a34a]" : "bg-red-500")}
-                                        style={{ width: `${Math.max(b.pct, 2)}%` }}
-                                    />
-                                </div>
-                                <div className="text-xs font-black tabular-nums text-neutral-800 dark:text-neutral-200 whitespace-nowrap">
+                            /* 이름과 막대를 위아래로 — "주식 배당" 같은 긴 이름이 잘리지 않는다 */
+                            <div key={b.label} className="grid grid-cols-[1fr_auto] gap-x-2 gap-y-1">
+                                <span className="text-xs font-bold text-neutral-600 dark:text-neutral-400">{b.label}</span>
+                                <span className="text-xs font-black tabular-nums text-neutral-800 dark:text-neutral-200 whitespace-nowrap">
                                     {b.sum.toLocaleString("ko-KR")}
                                     <span className="ml-1.5 text-[11px] font-medium text-neutral-400">{b.pct}%</span>
-                                </div>
+                                </span>
+                                <span className="col-span-2 h-2 rounded-full bg-neutral-100 dark:bg-[#2c2b27] overflow-hidden">
+                                    <span
+                                        className={cn("block h-full rounded-full transition-all duration-300", barKind === "income" ? "bg-[#16a34a]" : "bg-red-500")}
+                                        style={{ width: `${Math.max(b.pct, 2)}%` }}
+                                    />
+                                </span>
                             </div>
                         ))}
                     </div>
                 </section>
 
-                {/* ④ 기입 */}
-                {!formOpen ? (
-                    <button
-                        type="button"
-                        onClick={openForm}
-                        className="w-full flex items-center justify-center gap-1.5 py-3.5 rounded-2xl bg-[#16a34a] hover:bg-[#15803d] text-white text-[13px] font-black transition-colors"
-                    >
-                        <Plus size={15} strokeWidth={2.6} />
-                        기입하기
-                    </button>
-                ) : (
-                    <form onSubmit={handleSubmit} className={cn(CARD_CLS, "p-4 flex flex-col gap-3")}>
-                        <div className="flex gap-2.5 flex-wrap">
-                            <div className="flex flex-col gap-1.5 basis-[150px] grow-0">
-                                <label htmlFor="f-date" className={FIELD_LABEL_CLS}>날짜</label>
-                                <input id="f-date" type="date" required value={fDate}
-                                    onChange={e => setFDate(e.target.value)} className={CTL_CLS} />
-                            </div>
-                            <div className="flex flex-col gap-1.5 flex-1 min-w-[140px]">
-                                <span className={FIELD_LABEL_CLS}>구분</span>
-                                <div className="flex rounded-xl border border-neutral-200 dark:border-[#35332e] overflow-hidden">
-                                    {(["income", "expense"] as LedgerKind[]).map(k => (
-                                        <button
-                                            key={k}
-                                            type="button"
-                                            onClick={() => changeKind(k)}
-                                            aria-pressed={fKind === k}
-                                            className={cn(
-                                                "flex-1 py-2 text-xs font-black transition-colors",
-                                                fKind === k
-                                                    ? k === "income" ? "bg-[#16a34a] text-white" : "bg-red-600 text-white"
-                                                    : "bg-[#faf9f7] dark:bg-[#1a1915] text-neutral-500"
-                                            )}
-                                        >
-                                            {k === "income" ? "수입" : "지출"}
-                                        </button>
-                                    ))}
-                                </div>
-                            </div>
-                        </div>
-
-                        <div className="flex gap-2.5 flex-wrap">
-                            <div className="flex flex-col gap-1.5 flex-1 min-w-[130px]">
-                                <label htmlFor="f-cat" className={FIELD_LABEL_CLS}>항목</label>
-                                <select id="f-cat" value={fCategory} onChange={e => setFCategory(e.target.value)} className={CTL_CLS}>
-                                    {categoriesOf(fKind).map(c => (
-                                        <option key={c.key} value={c.key}>{c.label}</option>
-                                    ))}
-                                </select>
-                            </div>
-                            <div className="flex flex-col gap-1.5 flex-1 min-w-[130px]">
-                                <label htmlFor="f-amt" className={FIELD_LABEL_CLS}>금액 (원)</label>
-                                <input
-                                    ref={amountRef}
-                                    id="f-amt" type="text" inputMode="numeric" required placeholder="0"
-                                    value={fAmount}
-                                    onChange={e => {
-                                        const digits = e.target.value.replace(/[^\d]/g, "").slice(0, 12);
-                                        setFAmount(digits ? Number(digits).toLocaleString("ko-KR") : "");
-                                    }}
-                                    className={cn(CTL_CLS, "text-right tabular-nums")}
-                                />
-                            </div>
-                        </div>
-
-                        <div className="flex flex-col gap-1.5">
-                            <label htmlFor="f-memo" className={FIELD_LABEL_CLS}>메모 (선택)</label>
-                            <input id="f-memo" type="text" maxLength={40} placeholder="예: 삼성전자 반기 배당"
-                                value={fMemo} onChange={e => setFMemo(e.target.value)} className={CTL_CLS} />
-                        </div>
-
-                        {(formError ?? error) && (
-                            <p role="alert" className="text-xs font-bold text-red-600 dark:text-red-400">
-                                {formError ?? error}
-                            </p>
-                        )}
-
-                        <div className="flex items-center justify-between gap-2 pt-0.5">
-                            <span className="text-[11px] text-neutral-400 dark:text-neutral-500">
-                                저장해도 폼은 열려 있습니다 — 이어서 기입하세요.
-                            </span>
-                            <div className="flex gap-2 shrink-0">
-                            <button type="button" onClick={() => setFormOpen(false)}
-                                className="px-4 py-2 rounded-xl border border-neutral-200 dark:border-[#3a3834] bg-[#faf9f7] dark:bg-[#1a1915] text-xs font-black text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200/70 dark:hover:bg-[#2c2b27] transition-colors">
-                                닫기
-                            </button>
-                            <button type="submit" disabled={mutating || !fAmount}
-                                className="px-5 py-2 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-xs font-black disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
-                                {mutating ? "저장 중…" : "저장"}
-                            </button>
-                            </div>
-                        </div>
-                    </form>
-                )}
+                {/* ④ 기입 — 데스크톱은 흐름 안의 버튼, 모바일은 아래 고정 FAB */}
+                <button
+                    type="button"
+                    onClick={openAdd}
+                    className="hidden sm:flex w-full items-center justify-center gap-1.5 py-3.5 rounded-2xl bg-[#16a34a] hover:bg-[#15803d] text-white text-[13px] font-black transition-colors"
+                >
+                    <Plus size={15} strokeWidth={2.6} />
+                    기입하기
+                </button>
 
                 {/* ⑤ 내역 */}
                 <section className={cn(CARD_CLS, "overflow-hidden")}>
@@ -444,21 +437,19 @@ export default function LedgerPage() {
                     {loading ? (
                         <div className="divide-y divide-neutral-50 dark:divide-[#35332e]/40">
                             {[0, 1, 2].map(i => (
-                                <div key={i} className="h-[46px] bg-[#faf9f7] dark:bg-[#1f1e1b] animate-pulse" />
+                                <div key={i} className="h-[56px] bg-[#faf9f7] dark:bg-[#1f1e1b] animate-pulse" />
                             ))}
                         </div>
                     ) : entries.length === 0 ? (
                         <div className="py-10 px-4 text-center text-[13px] text-neutral-400 dark:text-neutral-500">
                             <span className="block text-2xl mb-2 opacity-60" aria-hidden>📭</span>
                             이 달에는 아직 기록이 없습니다.
-                            <br />위 “기입하기”로 첫 줄을 남겨보세요.
+                            <br />“기입하기”로 첫 줄을 남겨보세요.
                         </div>
                     ) : (
                         <div>
                             {days.map(day => (
                                 <div key={day.date}>
-                                    {/* 날짜 머리 — 날짜를 줄마다 반복하는 대신 한 번 쓰고,
-                                        그 자리에 그날 수지를 얹는다. */}
                                     <div className="flex items-baseline justify-between gap-3 px-4 py-1.5 bg-[#faf9f7] dark:bg-[#1f1e1b] border-y border-neutral-100 dark:border-[#35332e]">
                                         <span className="text-[11px] font-black text-neutral-500 dark:text-neutral-400 tabular-nums">
                                             {dayLabel(day.date)}
@@ -474,18 +465,19 @@ export default function LedgerPage() {
                                     <div className="divide-y divide-neutral-50 dark:divide-[#35332e]/40">
                                         {day.items.map(e => {
                                             const isIncome = e.kind === "income";
-                                            const confirming = confirmId === e.id;
                                             return (
-                                                <div
+                                                /* 줄 전체가 수정 진입점 — 작은 아이콘을 겨눌 필요가 없다 */
+                                                <button
                                                     key={e.id}
+                                                    type="button"
+                                                    onClick={() => openEdit(e)}
                                                     className={cn(
-                                                        "group grid grid-cols-[auto_1fr_auto_28px] items-center gap-2.5 px-4 py-2.5 transition-colors",
-                                                        confirming
-                                                            ? "bg-red-50 dark:bg-red-950/20"
-                                                            : justAddedId === e.id
-                                                                ? "bg-[#dcfce7]/70 dark:bg-[#052e16]/40"
-                                                                : "hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]"
+                                                        "w-full grid grid-cols-[auto_1fr_auto_auto] items-center gap-2.5 px-3 sm:px-4 py-2.5 min-h-[56px] text-left transition-colors",
+                                                        justAddedId === e.id
+                                                            ? "bg-[#dcfce7]/70 dark:bg-[#052e16]/40"
+                                                            : "hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]"
                                                     )}
+                                                    aria-label={`${e.entry_date} ${categoryLabel(e.kind, e.category)} ${e.amount.toLocaleString("ko-KR")}원 수정`}
                                                 >
                                                     <span className={cn(
                                                         "text-[11px] font-black px-2 py-0.5 rounded-md whitespace-nowrap",
@@ -495,53 +487,20 @@ export default function LedgerPage() {
                                                     )}>
                                                         {categoryLabel(e.kind, e.category)}
                                                     </span>
-
-                                                    {confirming ? (
-                                                        <>
-                                                            <span className="text-xs font-bold text-red-700 dark:text-red-300">
-                                                                삭제할까요? 되돌릴 수 없습니다.
-                                                            </span>
-                                                            <span className="col-span-2 flex items-center justify-end gap-1.5">
-                                                                <button
-                                                                    type="button"
-                                                                    onClick={() => { dispatch(reqDeleteLedgerEntry(e.id)); setConfirmId(null); }}
-                                                                    disabled={mutating}
-                                                                    className="px-2.5 py-1 rounded-lg bg-red-600 hover:bg-red-700 text-white text-[11px] font-black disabled:opacity-50 transition-colors"
-                                                                >
-                                                                    삭제
-                                                                </button>
-                                                                <button
-                                                                    type="button"
-                                                                    onClick={() => setConfirmId(null)}
-                                                                    className="px-2.5 py-1 rounded-lg border border-neutral-200 dark:border-[#3a3834] bg-white dark:bg-[#242320] text-[11px] font-black text-neutral-600 dark:text-neutral-400 hover:bg-neutral-100 dark:hover:bg-[#2c2b27] transition-colors"
-                                                                >
-                                                                    취소
-                                                                </button>
-                                                            </span>
-                                                        </>
-                                                    ) : (
-                                                        <>
-                                                            <span className="text-xs text-neutral-500 dark:text-neutral-400 truncate">{e.memo ?? ""}</span>
-                                                            <span className={cn(
-                                                                "text-[13px] font-black tabular-nums whitespace-nowrap",
-                                                                isIncome ? "text-[#16a34a]" : "text-neutral-900 dark:text-neutral-100"
-                                                            )}>
-                                                                {isIncome ? "+" : "−"}{e.amount.toLocaleString("ko-KR")}
-                                                            </span>
-                                                            <button
-                                                                type="button"
-                                                                onClick={() => setConfirmId(e.id)}
-                                                                disabled={mutating}
-                                                                // 터치 기기에는 hover 가 없다. sm 아래에서는 항상 보이게 두고,
-                                                                // 마우스가 있는 화면에서만 hover 로 드러낸다.
-                                                                className="w-7 h-7 rounded-lg flex items-center justify-center text-neutral-400 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-950/30 dark:hover:text-red-400 disabled:cursor-not-allowed transition-all"
-                                                                aria-label={`${e.entry_date} ${categoryLabel(e.kind, e.category)} ${e.amount.toLocaleString("ko-KR")}원 삭제`}
-                                                            >
-                                                                <Trash2 size={14} />
-                                                            </button>
-                                                        </>
-                                                    )}
-                                                </div>
+                                                    <span className={cn(
+                                                        "text-xs truncate",
+                                                        e.memo ? "text-neutral-500 dark:text-neutral-400" : "text-neutral-300 dark:text-neutral-600 italic"
+                                                    )}>
+                                                        {e.memo || "메모 없음"}
+                                                    </span>
+                                                    <span className={cn(
+                                                        "text-[13px] font-black tabular-nums whitespace-nowrap",
+                                                        isIncome ? "text-[#16a34a]" : "text-neutral-900 dark:text-neutral-100"
+                                                    )}>
+                                                        {isIncome ? "+" : "−"}{e.amount.toLocaleString("ko-KR")}
+                                                    </span>
+                                                    <ChevronRight size={15} strokeWidth={2.4} className="text-neutral-300 dark:text-neutral-600" />
+                                                </button>
                                             );
                                         })}
                                     </div>
@@ -551,12 +510,214 @@ export default function LedgerPage() {
                     )}
                 </section>
 
-                {loadState === "rejected" && !formOpen && (
+                {loadState === "rejected" && !sheetOpen && (
                     <p className="text-center text-xs font-bold text-red-600 dark:text-red-400">
                         내역을 불러오지 못했습니다. {error}
                     </p>
                 )}
             </div>
+
+            {/* 모바일 FAB — 하단 탭바(64px) 위에 떠 있어 어디까지 스크롤해도 닿는다 */}
+            {!sheetOpen && (
+                <button
+                    type="button"
+                    onClick={openAdd}
+                    className="sm:hidden fixed right-4 bottom-[76px] z-40 min-h-[52px] px-5 rounded-full bg-[#16a34a] text-white text-sm font-black flex items-center gap-1.5 shadow-lg shadow-[#16a34a]/40 active:scale-95 transition-transform"
+                >
+                    <Plus size={18} strokeWidth={2.8} />
+                    기입
+                </button>
+            )}
+
+            {/* ── 기입·수정 시트 ── */}
+            {sheetOpen && (
+                <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+                    <div
+                        className="absolute inset-0 bg-neutral-900/45"
+                        onClick={() => setSheetOpen(false)}
+                        aria-hidden
+                    />
+                    <form
+                        onSubmit={handleSubmit}
+                        className="relative w-full sm:max-w-md max-h-[92dvh] overflow-y-auto bg-white dark:bg-[#242320] border-t sm:border border-neutral-200 dark:border-[#35332e] rounded-t-3xl sm:rounded-2xl px-4 pt-2 pb-5 sm:pb-4 shadow-2xl"
+                    >
+                        <div className="sm:hidden w-9 h-1 rounded-full bg-neutral-200 dark:bg-[#35332e] mx-auto mt-1 mb-3" aria-hidden />
+
+                        <div className="flex items-baseline justify-between gap-3 mb-3">
+                            <h2 className="text-[15px] font-black tracking-[-0.02em] text-neutral-900 dark:text-white">
+                                {editing ? "수정하기" : "기입하기"}
+                            </h2>
+                            {editing && (
+                                <span className="text-[11px] text-neutral-400 tabular-nums">
+                                    {fDate.replace(/-/g, ".")} 기록
+                                </span>
+                            )}
+                        </div>
+
+                        {/* 구분 */}
+                        <div className="flex flex-col gap-1.5 mb-3">
+                            <span className={FIELD_LABEL_CLS}>구분</span>
+                            <div className="flex rounded-xl border border-neutral-200 dark:border-[#35332e] overflow-hidden">
+                                {(["income", "expense"] as LedgerKind[]).map(k => (
+                                    <button
+                                        key={k}
+                                        type="button"
+                                        onClick={() => changeKind(k, fCategory)}
+                                        aria-pressed={fKind === k}
+                                        className={cn(
+                                            "flex-1 min-h-[46px] text-sm font-black transition-colors",
+                                            fKind === k
+                                                ? k === "income" ? "bg-[#16a34a] text-white" : "bg-red-600 text-white"
+                                                : "bg-[#faf9f7] dark:bg-[#1a1915] text-neutral-500"
+                                        )}
+                                    >
+                                        {k === "income" ? "수입" : "지출"}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+
+                        {/* 금액 — 이 화면에서 가장 자주 치는 값이라 가장 크게 */}
+                        <div className="flex flex-col gap-1.5 mb-3">
+                            <label htmlFor="f-amt" className={FIELD_LABEL_CLS}>금액</label>
+                            <div className="flex items-baseline gap-1.5 px-3.5 py-2.5 rounded-2xl bg-[#faf9f7] dark:bg-[#1a1915] border border-neutral-200 dark:border-[#35332e] focus-within:border-[#16a34a] focus-within:ring-1 focus-within:ring-[#16a34a]">
+                                <input
+                                    ref={amountRef}
+                                    id="f-amt" type="text" inputMode="numeric" required placeholder="0"
+                                    autoComplete="off"
+                                    value={fAmount}
+                                    onChange={e => {
+                                        const digits = e.target.value.replace(/[^\d]/g, "").slice(0, 12);
+                                        setFAmount(digits ? Number(digits).toLocaleString("ko-KR") : "");
+                                        setFormError(null);
+                                    }}
+                                    className="flex-1 min-w-0 bg-transparent border-none outline-none text-right text-2xl font-black tabular-nums text-neutral-900 dark:text-white placeholder:text-neutral-300 dark:placeholder:text-neutral-600"
+                                />
+                                <span className="text-sm font-black text-neutral-400">원</span>
+                            </div>
+                            <div className="flex gap-1.5">
+                                {QUICK_ADD.map(v => (
+                                    <button
+                                        key={v}
+                                        type="button"
+                                        onClick={() => { setAmountNumber(amountValue() + v); setFormError(null); }}
+                                        className={cn(CHIP_CLS, "flex-1 border-neutral-200 dark:border-[#3a3834] bg-white dark:bg-[#242320] text-neutral-600 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]")}
+                                    >
+                                        +{(v / 10000).toLocaleString("ko-KR")}만
+                                    </button>
+                                ))}
+                                <button
+                                    type="button"
+                                    onClick={() => { setFAmount(""); amountRef.current?.focus(); }}
+                                    className={cn(CHIP_CLS, "w-11 px-0 border-neutral-200 dark:border-[#3a3834] bg-white dark:bg-[#242320] text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]")}
+                                    aria-label="금액 지우기"
+                                >
+                                    ←
+                                </button>
+                            </div>
+                        </div>
+
+                        {/* 항목 — 셀렉트 대신 칩. 한 번 탭으로 고른다 */}
+                        <div className="flex flex-col gap-1.5 mb-3">
+                            <span className={FIELD_LABEL_CLS}>항목</span>
+                            <div className="flex flex-wrap gap-1.5">
+                                {categoriesOf(fKind).map(c => {
+                                    const on = c.key === fCategory;
+                                    return (
+                                        <button
+                                            key={c.key}
+                                            type="button"
+                                            onClick={() => setFCategory(c.key)}
+                                            aria-pressed={on}
+                                            className={cn(
+                                                CHIP_CLS,
+                                                on
+                                                    ? fKind === "income"
+                                                        ? "bg-[#16a34a] border-[#16a34a] text-white"
+                                                        : "bg-red-600 border-red-600 text-white"
+                                                    : "bg-[#faf9f7] dark:bg-[#1a1915] border-neutral-200 dark:border-[#35332e] text-neutral-600 dark:text-neutral-400"
+                                            )}
+                                        >
+                                            {c.label}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
+
+                        {/* 날짜 — 대부분 오늘이라 빠른 선택을 앞에 둔다 */}
+                        <div className="flex flex-col gap-1.5 mb-3">
+                            <label htmlFor="f-date" className={FIELD_LABEL_CLS}>날짜</label>
+                            <div className="flex gap-1.5 items-center">
+                                <button type="button" onClick={() => setFDate(todayKst())}
+                                    className={cn(CHIP_CLS, "border-neutral-200 dark:border-[#3a3834] bg-white dark:bg-[#242320] text-neutral-600 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]")}>
+                                    오늘
+                                </button>
+                                <button type="button" onClick={() => setFDate(shiftDay(todayKst(), -1))}
+                                    className={cn(CHIP_CLS, "border-neutral-200 dark:border-[#3a3834] bg-white dark:bg-[#242320] text-neutral-600 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]")}>
+                                    어제
+                                </button>
+                                <input id="f-date" type="date" required value={fDate}
+                                    onChange={e => setFDate(e.target.value)}
+                                    className={cn(CTL_CLS, "flex-1 tabular-nums")} />
+                            </div>
+                        </div>
+
+                        {/* 메모 */}
+                        <div className="flex flex-col gap-1.5 mb-3">
+                            <label htmlFor="f-memo" className={FIELD_LABEL_CLS}>메모 (선택)</label>
+                            <input id="f-memo" type="text" maxLength={40} placeholder="예: 삼성전자 반기 배당"
+                                value={fMemo} onChange={e => setFMemo(e.target.value)} className={CTL_CLS} />
+                        </div>
+
+                        {(formError ?? error) && (
+                            <p role="alert" className="mb-3 text-xs font-bold text-red-600 dark:text-red-400">
+                                {formError ?? error}
+                            </p>
+                        )}
+
+                        {/* 추가와 수정은 다른 일이라 버튼도 다르다 */}
+                        {editing && askDelete ? (
+                            <div className="flex items-center gap-2">
+                                <span className="flex-1 text-xs font-bold text-red-600 dark:text-red-400">
+                                    삭제할까요? 되돌릴 수 없습니다.
+                                </span>
+                                <button type="button" onClick={() => setAskDelete(false)}
+                                    className="min-h-[50px] px-4 rounded-xl border border-neutral-200 dark:border-[#3a3834] bg-[#faf9f7] dark:bg-[#1a1915] text-sm font-black text-neutral-600 dark:text-neutral-400">
+                                    취소
+                                </button>
+                                <button type="button" onClick={handleDelete} disabled={mutating}
+                                    className="min-h-[50px] px-4 rounded-xl bg-red-600 hover:bg-red-700 text-white text-sm font-black disabled:opacity-50 transition-colors">
+                                    {mutating ? "삭제 중…" : "삭제"}
+                                </button>
+                            </div>
+                        ) : (
+                            <div className="flex gap-2">
+                                {editing && (
+                                    <button type="button" onClick={() => setAskDelete(true)}
+                                        className="min-h-[50px] px-4 rounded-xl border border-red-600/60 text-red-600 dark:text-red-400 text-sm font-black hover:bg-red-50 dark:hover:bg-red-950/20 transition-colors">
+                                        삭제
+                                    </button>
+                                )}
+                                <button type="button" onClick={() => setSheetOpen(false)}
+                                    className="min-h-[50px] px-4 rounded-xl border border-neutral-200 dark:border-[#3a3834] bg-[#faf9f7] dark:bg-[#1a1915] text-sm font-black text-neutral-600 dark:text-neutral-400 hover:bg-neutral-200/70 dark:hover:bg-[#2c2b27] transition-colors">
+                                    {editing ? "취소" : "닫기"}
+                                </button>
+                                <button type="submit" disabled={mutating || !fAmount}
+                                    className="flex-1 min-h-[50px] rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-[15px] font-black disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                                    {mutating ? "저장 중…" : editing ? "수정" : "저장"}
+                                </button>
+                            </div>
+                        )}
+
+                        {!editing && (
+                            <p className="mt-2.5 text-[11px] text-neutral-400 dark:text-neutral-500 text-center">
+                                저장해도 시트는 열려 있습니다 — 이어서 기입하세요.
+                            </p>
+                        )}
+                    </form>
+                </div>
+            )}
         </div>
     );
 }

--- a/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
+++ b/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
@@ -33,5 +33,8 @@ export const getLedger = (month: string) => ledgerRequest(`/user/ledger?month=${
 
 export const addLedgerEntry = (entry: NewLedgerEntry) => ledgerRequest("/user/ledger", "POST", entry);
 
-// 삭제 id 는 쿼리로 보낸다 — 프록시가 non-GET body 에 주문 필드를 병합하기 때문.
+// 수정·삭제의 id 는 쿼리로 보낸다 — 프록시가 non-GET body 에 주문 필드를 병합하기 때문.
+export const updateLedgerEntry = (id: number, entry: NewLedgerEntry) =>
+    ledgerRequest(`/user/ledger?id=${id}`, "PUT", entry);
+
 export const deleteLedgerEntry = (id: number) => ledgerRequest(`/user/ledger?id=${id}`, "DELETE");

--- a/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
+++ b/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
@@ -1,6 +1,9 @@
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { createAppSlice } from "@/lib/createAppSlice";
-import { getLedger, addLedgerEntry, deleteLedgerEntry, type LedgerEntry, type NewLedgerEntry } from "./ledgerAPI";
+import {
+    getLedger, addLedgerEntry, updateLedgerEntry, deleteLedgerEntry,
+    type LedgerEntry, type NewLedgerEntry,
+} from "./ledgerAPI";
 
 /** 사용자가 보는 달은 KST 기준이다 — UTC 로 세면 매달 1일 오전 9시 전에 지난달이 열린다. */
 export function currentMonthKst(): string {
@@ -89,6 +92,35 @@ export const ledgerSlice = createAppSlice({
             }
         ),
 
+        reqUpdateLedgerEntry: create.asyncThunk(
+            async ({ id, entry }: { id: number; entry: NewLedgerEntry }) => {
+                const result = await updateLedgerEntry(id, entry);
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
+            {
+                pending: (state) => { state.mutating = true; state.error = null; },
+                fulfilled: (state, action) => {
+                    state.mutating = false;
+                    const entry = action.payload?.data as LedgerEntry | undefined;
+                    if (!entry) return;
+                    // 날짜를 다른 달로 옮겼으면 이 달 목록에서 빠진다 — 화면이 그 달로
+                    // 따라가면서 다시 조회하므로 여기서는 지우기만 한다.
+                    if (!entry.entry_date.startsWith(state.month)) {
+                        state.entries = state.entries.filter((e) => e.id !== entry.id);
+                        return;
+                    }
+                    state.entries = state.entries
+                        .map((e) => (e.id === entry.id ? entry : e))
+                        .sort(byRecent);
+                },
+                rejected: (state, action) => {
+                    state.mutating = false;
+                    state.error = action.error?.message ?? null;
+                },
+            }
+        ),
+
         reqDeleteLedgerEntry: create.asyncThunk(
             async (id: number) => {
                 const result = await deleteLedgerEntry(id);
@@ -117,7 +149,9 @@ export const ledgerSlice = createAppSlice({
     },
 });
 
-export const { setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqDeleteLedgerEntry } = ledgerSlice.actions;
+export const {
+    setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqUpdateLedgerEntry, reqDeleteLedgerEntry,
+} = ledgerSlice.actions;
 export const {
     selectLedgerMonth,
     selectLedgerEntries,


### PR DESCRIPTION
수정 기능이 없어 잘못 적은 줄은 지우고 다시 넣어야 했습니다. 수정을 붙이면서 추가·수정 UI 를 모바일 기준으로 다시 짰습니다.

> **백엔드 PR 이 함께 필요합니다** — MinSikSon/idiotquant-worker#106 (`PUT /user/ledger`). 워커가 배포되기 전까지 수정 버튼은 404 를 받습니다. D1 작업은 없습니다.

프로토타입: 실제 폰 크기(390×800)로 눌러볼 수 있습니다 — 대화에 공유된 아티팩트 참고.

## 무엇이 바뀌었나

### 줄 전체가 수정 진입점

40px 휴지통 아이콘을 겨누는 대신 **56px 줄 아무 데나 누르면** 수정 시트가 열립니다. 삭제는 그 시트 안으로 들어갔습니다 — 줄에서 아이콘이 빠지니 메모와 금액이 넓어지고, 스치듯 눌러 지우는 사고도 없어집니다.

```
급여   8월 급여              +3,200,000  ›     ← 줄 전체가 버튼
```

### 폼이 바텀시트

모바일은 아래에서 올라오고(손이 닿는 범위), 데스크톱은 가운데 뜹니다. 마크업은 한 벌이고 반응형 클래스만 다릅니다.

### 금액이 가장 큰 입력

`text-2xl` 우측 정렬 + **빠른 금액(+1만 / +5만 / +10만)**. 모바일에서 0 을 여섯 번 치는 게 가장 성가신 일입니다. `←` 로 한 번에 지웁니다.

### 항목은 셀렉트 대신 칩

드롭다운을 열고 고르고 닫는 세 동작이 한 번의 탭이 됩니다.

### 날짜는 오늘·어제가 앞에

대부분 오늘이라 달력을 열 일이 거의 없습니다.

### 저장 결과를 토스트로

시트가 목록을 가려서 "방금 추가된 줄" 하이라이트가 **보이지 않았습니다.** 시트 위에 뜨는 토스트로 알립니다.

### 추가와 수정은 버튼이 다르다

| | 버튼 | 저장 후 |
|---|---|---|
| 기입 | `[닫기] [저장]` | 시트가 열린 채 이어짐 (연속 기입) |
| 수정 | `[삭제] [취소] [수정]` | 닫힘 — 한 건만 고치러 들어온 흐름 |

시트 제목도 "기입하기 / 수정하기"로 갈리고, 수정일 때는 원래 날짜를 함께 보여줍니다.

### 그 밖의 모바일 정리

- **기입 버튼이 FAB** — 하단 탭바 위에 떠 있어 내역이 길어도 스크롤 없이 닿습니다 (데스크톱은 기존 인라인 버튼 유지)
- **좁은 화면 요약은 잔액을 크게 한 줄**, 수입·지출을 아래 두 칸으로. 3칸을 390px 에 넣으면 금액이 잘립니다
- **항목별 막대는 이름과 막대를 위아래로** — "주식 배당" 이 잘리지 않습니다
- **터치 타겟 44px 이상** — 월 이동, 칩, 시트 버튼 전부

## 상태 처리에서 한 가지

수정으로 **날짜를 다른 달로 옮기면** 그 달로 따라갑니다. 슬라이스는 보고 있는 달이 아니면 목록에서 빼기만 하고, 화면이 달을 바꾸면서 다시 조회합니다 — 안 그러면 8월 목록에 7월 줄이 남습니다.

## 변경 파일

| 파일 | 내용 |
|---|---|
| `app/(ledger)/ledger/page.tsx` | 시트·수정·FAB·요약 재배치 |
| `lib/features/ledger/ledgerAPI.ts` | `updateLedgerEntry` |
| `lib/features/ledger/ledgerSlice.tsx` | `reqUpdateLedgerEntry` |

## 검증

- `npx tsc --noEmit` → 에러 0
- `npm run build` → 성공, `/ledger` 라우트 확인

최신 `main`(cfeaeee) 위에서 작업했습니다.

배포 후 수동 확인:
1. 좁은 폭에서 줄을 누르면 시트가 아래에서 올라오고 값이 채워져 있다
2. 금액을 고치고 "수정" → 목록과 합계가 함께 바뀌고 토스트가 뜬다
3. 시트 안 "삭제" → 확인 후 지워진다
4. 수정에서 날짜를 지난달로 바꾸면 화면이 그 달로 따라간다
5. 기입은 저장 후에도 시트가 열려 있고 커서가 금액에 있다

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkWhRiKfTxb61ByrP4YWtB)_