### PR TITLE
가계부 항목 직접 추가

### DIFF
--- a/cf-idiotquant/app/(ledger)/ledger/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, ChevronDown, Plus, Trash2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronDown, Plus, X } from "lucide-react";
 
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { cn } from "@/lib/utils";
@@ -11,12 +11,13 @@ import { PageHeader } from "@/components/pageHeader";
 import type { LedgerEntry, NewLedgerEntry } from "@/lib/features/ledger/ledgerAPI";
 import {
     setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqUpdateLedgerEntry, reqDeleteLedgerEntry,
-    selectLedgerMonth, selectLedgerEntries, selectLedgerState,
+    reqGetLedgerCategories, reqAddLedgerCategory, reqDeleteLedgerCategory,
+    selectLedgerMonth, selectLedgerEntries, selectLedgerState, selectLedgerCategories,
     selectLedgerMutating, selectLedgerError,
     currentMonthKst,
 } from "@/lib/features/ledger/ledgerSlice";
 import {
-    categoriesOf, categoryLabel, type LedgerKind,
+    categoriesOf, categoryLabel, customKey, type LedgerKind,
 } from "@/lib/features/ledger/categories";
 
 /* ─── 공통 클래스 ──────────────────────────────────────────────── */
@@ -70,6 +71,7 @@ export default function LedgerPage() {
     const month = useAppSelector(selectLedgerMonth);
     const entries = useAppSelector(selectLedgerEntries);
     const loadState = useAppSelector(selectLedgerState);
+    const customCategories = useAppSelector(selectLedgerCategories);
     const mutating = useAppSelector(selectLedgerMutating);
     const error = useAppSelector(selectLedgerError);
 
@@ -87,6 +89,11 @@ export default function LedgerPage() {
     const [formError, setFormError] = useState<string | null>(null);
     const amountRef = useRef<HTMLInputElement>(null);
 
+    // 항목 만들기 — 시트 안에서 칩 줄 아래로 펼친다
+    const [newCatOpen, setNewCatOpen] = useState(false);
+    const [newCatLabel, setNewCatLabel] = useState("");
+    const newCatRef = useRef<HTMLInputElement>(null);
+
     // 시트가 목록을 가리므로 저장 결과는 시트 위에 뜨는 토스트로 알린다.
     const [toast, setToast] = useState<string | null>(null);
     const [justAddedId, setJustAddedId] = useState<number | null>(null);
@@ -102,6 +109,12 @@ export default function LedgerPage() {
         if (status !== "authenticated") return;
         dispatch(reqGetLedger(month));
     }, [dispatch, status, month]);
+
+    // 항목은 월과 무관하다 — 화면이 열릴 때 한 번만 가져온다.
+    useEffect(() => {
+        if (status !== "authenticated") return;
+        dispatch(reqGetLedgerCategories());
+    }, [dispatch, status]);
 
     useEffect(() => {
         if (!toast) return;
@@ -136,15 +149,19 @@ export default function LedgerPage() {
     const buckets = useMemo(() => {
         const total = barKind === "income" ? income : expense;
         if (!total) return [];
-        return categoriesOf(barKind)
-            .map(c => ({
-                label: c.label,
-                sum: entries
-                    .filter(e => e.kind === barKind && e.category === c.key)
-                    .reduce((s, e) => s + e.amount, 0),
+        /* 지운 항목으로 적어둔 내역도 막대에 나와야 한다 — 목록을 돌지 않고
+           내역에 실제로 쓰인 키를 모아 접는다. */
+        const sums = new Map<string, number>();
+        for (const e of entries) {
+            if (e.kind !== barKind) continue;
+            sums.set(e.category, (sums.get(e.category) ?? 0) + e.amount);
+        }
+        return [...sums]
+            .map(([key, sum]) => ({
+                label: categoryLabel(barKind, key),
+                sum,
+                pct: Math.round((sum / total) * 100),
             }))
-            .filter(b => b.sum > 0)
-            .map(b => ({ ...b, pct: Math.round((b.sum / total) * 100) }))
             .sort((a, b) => b.sum - a.sum);
     }, [entries, barKind, income, expense]);
 
@@ -166,8 +183,28 @@ export default function LedgerPage() {
     /* ─── 시트 열고 닫기 ───────────────────────────────────────── */
     function changeKind(kind: LedgerKind, keep?: string) {
         setFKind(kind);
-        const list = categoriesOf(kind);
+        setNewCatOpen(false);
+        const list = categoriesOf(kind, customCategories);
         setFCategory(keep && list.some(c => c.key === keep) ? keep : list[0].key);
+    }
+
+    async function handleAddCategory() {
+        const label = newCatLabel.trim();
+        if (!label) return;
+        const result = await dispatch(reqAddLedgerCategory({ kind: fKind, label }));
+        if (result.meta.requestStatus !== "fulfilled") return;
+        // 방금 만든 항목을 바로 고른 상태로 둔다 — 만들고 또 눌러야 하면 두 번 일하는 셈이다.
+        setFCategory(customKey(label));
+        setNewCatLabel("");
+        setNewCatOpen(false);
+    }
+
+    async function handleDeleteCategory(id: number, label: string) {
+        const result = await dispatch(reqDeleteLedgerCategory(id));
+        if (result.meta.requestStatus !== "fulfilled") return;
+        // 고른 항목이 사라졌으면 첫 칸으로 되돌린다.
+        if (fCategory === customKey(label)) setFCategory(categoriesOf(fKind, [])[0].key);
+        setToast("항목을 지웠습니다 (기록은 그대로)");
     }
 
     function openAdd() {
@@ -666,28 +703,88 @@ export default function LedgerPage() {
                         <div className="flex flex-col gap-1.5 mb-3">
                             <span className={FIELD_LABEL_CLS}>항목</span>
                             <div className="flex flex-wrap gap-1.5">
-                                {categoriesOf(fKind).map(c => {
+                                {categoriesOf(fKind, customCategories).map(c => {
                                     const on = c.key === fCategory;
+                                    const mine = c.id !== undefined;
                                     return (
-                                        <button
-                                            key={c.key}
-                                            type="button"
-                                            onClick={() => setFCategory(c.key)}
-                                            aria-pressed={on}
-                                            className={cn(
-                                                CHIP_CLS,
-                                                on
-                                                    ? fKind === "income"
-                                                        ? "bg-[#16a34a] border-[#16a34a] text-white"
-                                                        : "bg-red-600 border-red-600 text-white"
-                                                    : "bg-[#faf9f7] dark:bg-[#1a1915] border-neutral-200 dark:border-[#35332e] text-neutral-600 dark:text-neutral-400"
+                                        <span key={c.key} className="inline-flex">
+                                            <button
+                                                type="button"
+                                                onClick={() => setFCategory(c.key)}
+                                                aria-pressed={on}
+                                                className={cn(
+                                                    CHIP_CLS,
+                                                    // 내가 만든 항목은 고른 동안만 × 가 붙으므로 오른쪽을 붙여 잇는다
+                                                    on && mine && "rounded-r-none border-r-0",
+                                                    on
+                                                        ? fKind === "income"
+                                                            ? "bg-[#16a34a] border-[#16a34a] text-white"
+                                                            : "bg-red-600 border-red-600 text-white"
+                                                        : "bg-[#faf9f7] dark:bg-[#1a1915] border-neutral-200 dark:border-[#35332e] text-neutral-600 dark:text-neutral-400"
+                                                )}
+                                            >
+                                                {c.label}
+                                            </button>
+                                            {/* 지우기는 고른 항목에만 — 칩마다 × 가 붙으면 고르다가 지운다.
+                                                항목만 사라지고 그 항목으로 적어둔 기록은 남는다. */}
+                                            {on && mine && (
+                                                <button
+                                                    type="button"
+                                                    onClick={() => handleDeleteCategory(c.id!, c.label)}
+                                                    disabled={mutating}
+                                                    className={cn(
+                                                        CHIP_CLS, "w-9 px-0 rounded-l-none border-l-0 flex items-center justify-center",
+                                                        fKind === "income"
+                                                            ? "bg-[#16a34a] border-[#16a34a] text-white/80 hover:text-white"
+                                                            : "bg-red-600 border-red-600 text-white/80 hover:text-white"
+                                                    )}
+                                                    aria-label={`${c.label} 항목 지우기`}
+                                                >
+                                                    <X size={14} strokeWidth={2.6} />
+                                                </button>
                                             )}
-                                        >
-                                            {c.label}
-                                        </button>
+                                        </span>
                                     );
                                 })}
+
+                                {!newCatOpen && (
+                                    <button
+                                        type="button"
+                                        onClick={() => { setNewCatOpen(true); setTimeout(() => newCatRef.current?.focus(), 30); }}
+                                        className={cn(CHIP_CLS, "flex items-center gap-1 border-dashed border-neutral-300 dark:border-[#4a4641] bg-transparent text-neutral-500 dark:text-neutral-400")}
+                                    >
+                                        <Plus size={13} strokeWidth={2.8} />
+                                        항목
+                                    </button>
+                                )}
                             </div>
+
+                            {newCatOpen && (
+                                <div className="flex gap-1.5">
+                                    <input
+                                        ref={newCatRef}
+                                        type="text"
+                                        maxLength={12}
+                                        placeholder={fKind === "income" ? "예: 부업" : "예: 여행"}
+                                        value={newCatLabel}
+                                        onChange={e => setNewCatLabel(e.target.value)}
+                                        onKeyDown={e => {
+                                            // 시트가 form 안이라 Enter 가 저장으로 새면 항목만 만들려다 기입이 된다.
+                                            if (e.key === "Enter") { e.preventDefault(); handleAddCategory(); }
+                                        }}
+                                        className={cn(CTL_CLS, "flex-1")}
+                                    />
+                                    <button type="button" onClick={handleAddCategory}
+                                        disabled={mutating || !newCatLabel.trim()}
+                                        className="min-h-[44px] px-4 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-xs font-black disabled:opacity-50 transition-colors">
+                                        추가
+                                    </button>
+                                    <button type="button" onClick={() => { setNewCatOpen(false); setNewCatLabel(""); }}
+                                        className="min-h-[44px] px-3 rounded-xl border border-neutral-200 dark:border-[#3a3834] bg-[#faf9f7] dark:bg-[#1a1915] text-xs font-black text-neutral-500">
+                                        취소
+                                    </button>
+                                </div>
+                            )}
                         </div>
 
                         {/* 날짜 — 대부분 오늘이라 빠른 선택을 앞에 둔다 */}

--- a/cf-idiotquant/lib/features/ledger/categories.ts
+++ b/cf-idiotquant/lib/features/ledger/categories.ts
@@ -1,4 +1,4 @@
-// 가계부 항목 프리셋. 폼 select · 리스트 배지 · 항목별 막대가 같은 출처를 쓰도록 한곳에 둔다.
+// 가계부 항목. 프리셋은 여기 상수로, 사용자가 만든 것은 D1(ledger_categories)에서 온다.
 // 워커는 category 를 문자열로만 저장한다 — 라벨 해석은 전부 여기서 한다.
 
 export type LedgerKind = "income" | "expense";
@@ -6,6 +6,8 @@ export type LedgerKind = "income" | "expense";
 export interface LedgerCategory {
     key: string;
     label: string;
+    /** 사용자가 만든 항목만 D1 행 id 를 갖는다. 프리셋은 지울 수 없다. */
+    id?: number;
 }
 
 export const INCOME_CATEGORIES: LedgerCategory[] = [
@@ -22,9 +24,38 @@ export const EXPENSE_CATEGORIES: LedgerCategory[] = [
     { key: "etc", label: "기타" },
 ];
 
-export const categoriesOf = (kind: LedgerKind) =>
+export const presetsOf = (kind: LedgerKind) =>
     kind === "income" ? INCOME_CATEGORIES : EXPENSE_CATEGORIES;
 
-/** 라벨을 못 찾으면 키를 그대로 보여준다 — 프리셋이 바뀌어도 옛 내역이 빈칸이 되지 않는다. */
-export const categoryLabel = (kind: LedgerKind, key: string) =>
-    categoriesOf(kind).find((c) => c.key === key)?.label ?? key;
+/* 사용자 항목의 키는 라벨을 그대로 담는다 (custom:여행).
+   덕분에 항목을 지워도 그 항목으로 적어둔 내역이 이름을 잃지 않는다 —
+   키 하나에서 라벨이 복원되므로 참조가 끊길 자리가 없다. */
+const CUSTOM_PREFIX = "custom:";
+export const customKey = (label: string) => `${CUSTOM_PREFIX}${label}`;
+export const isCustomKey = (key: string) => key.startsWith(CUSTOM_PREFIX);
+
+/** D1 에서 온 항목 한 줄 (kind 별로 나눠 쓰기 위해 kind 를 그대로 갖고 다닌다) */
+export interface StoredCategory {
+    id: number;
+    kind: LedgerKind;
+    label: string;
+}
+
+/** 프리셋 뒤에 사용자 항목을 붙인 목록. 폼 칩이 이걸 그린다. */
+export function categoriesOf(kind: LedgerKind, custom: StoredCategory[] = []): LedgerCategory[] {
+    const mine = custom
+        .filter((c) => c.kind === kind)
+        .map((c) => ({ key: customKey(c.label), label: c.label, id: c.id }));
+    return [...presetsOf(kind), ...mine];
+}
+
+/**
+ * 키를 라벨로. 프리셋에 없으면 custom: 접두사를 벗겨 쓰고, 그것도 아니면 키를 그대로 보여준다
+ * — 프리셋이 바뀌어도, 항목을 지워도 옛 내역이 빈칸이 되지 않는다.
+ */
+export function categoryLabel(kind: LedgerKind, key: string) {
+    const preset = presetsOf(kind).find((c) => c.key === key);
+    if (preset) return preset.label;
+    if (isCustomKey(key)) return key.slice(CUSTOM_PREFIX.length);
+    return key;
+}

--- a/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
+++ b/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
@@ -1,4 +1,4 @@
-import type { LedgerKind } from "./categories";
+import type { LedgerKind, StoredCategory } from "./categories";
 
 export interface LedgerEntry {
     id: number;
@@ -38,3 +38,14 @@ export const updateLedgerEntry = (id: number, entry: NewLedgerEntry) =>
     ledgerRequest(`/user/ledger?id=${id}`, "PUT", entry);
 
 export const deleteLedgerEntry = (id: number) => ledgerRequest(`/user/ledger?id=${id}`, "DELETE");
+
+/* 사용자가 만든 항목 — 칩으로 무엇을 보여줄지만 정한다. 지워도 과거 내역은 그대로 남는다. */
+export type { StoredCategory };
+
+export const getLedgerCategories = () => ledgerRequest("/user/ledger/categories");
+
+export const addLedgerCategory = (kind: LedgerKind, label: string) =>
+    ledgerRequest("/user/ledger/categories", "POST", { kind, label });
+
+export const deleteLedgerCategory = (id: number) =>
+    ledgerRequest(`/user/ledger/categories?id=${id}`, "DELETE");

--- a/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
+++ b/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
@@ -2,8 +2,10 @@ import type { PayloadAction } from "@reduxjs/toolkit";
 import { createAppSlice } from "@/lib/createAppSlice";
 import {
     getLedger, addLedgerEntry, updateLedgerEntry, deleteLedgerEntry,
+    getLedgerCategories, addLedgerCategory, deleteLedgerCategory,
     type LedgerEntry, type NewLedgerEntry,
 } from "./ledgerAPI";
+import type { LedgerKind, StoredCategory } from "./categories";
 
 /** 사용자가 보는 달은 KST 기준이다 — UTC 로 세면 매달 1일 오전 9시 전에 지난달이 열린다. */
 export function currentMonthKst(): string {
@@ -18,6 +20,7 @@ interface LedgerState {
     state: "init" | "pending" | "fulfilled" | "rejected";
     month: string;              // 'YYYY-MM'
     entries: LedgerEntry[];
+    categories: StoredCategory[];   // 사용자가 만든 항목 (프리셋은 categories.ts 상수)
     mutating: boolean;
     error: string | null;
 }
@@ -26,6 +29,7 @@ const initialState: LedgerState = {
     state: "init",
     month: currentMonthKst(),
     entries: [],
+    categories: [],
     mutating: false,
     error: null,
 };
@@ -92,6 +96,64 @@ export const ledgerSlice = createAppSlice({
             }
         ),
 
+        /* ── 사용자 항목 ── 월과 무관해서 화면이 열릴 때 한 번만 부른다 ── */
+        reqGetLedgerCategories: create.asyncThunk(
+            async () => {
+                const result = await getLedgerCategories();
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
+            {
+                fulfilled: (state, action) => {
+                    state.categories = (action.payload?.data ?? []) as StoredCategory[];
+                },
+                // 항목을 못 불러와도 프리셋으로는 기입할 수 있다 — 화면을 막지 않는다.
+                rejected: () => {},
+            }
+        ),
+
+        reqAddLedgerCategory: create.asyncThunk(
+            async ({ kind, label }: { kind: LedgerKind; label: string }) => {
+                const result = await addLedgerCategory(kind, label);
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
+            {
+                pending: (state) => { state.mutating = true; state.error = null; },
+                fulfilled: (state, action) => {
+                    state.mutating = false;
+                    const category = action.payload?.data as StoredCategory | undefined;
+                    if (!category) return;
+                    // 같은 이름을 다시 넣으면 워커가 기존 행을 그대로 준다 — 중복으로 쌓지 않는다.
+                    if (state.categories.some((c) => c.id === category.id)) return;
+                    state.categories = [...state.categories, category];
+                },
+                rejected: (state, action) => {
+                    state.mutating = false;
+                    state.error = action.error?.message ?? null;
+                },
+            }
+        ),
+
+        reqDeleteLedgerCategory: create.asyncThunk(
+            async (id: number) => {
+                const result = await deleteLedgerCategory(id);
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return id;
+            },
+            {
+                pending: (state) => { state.mutating = true; state.error = null; },
+                fulfilled: (state, action) => {
+                    state.mutating = false;
+                    state.categories = state.categories.filter((c) => c.id !== action.payload);
+                },
+                rejected: (state, action) => {
+                    state.mutating = false;
+                    state.error = action.error?.message ?? null;
+                },
+            }
+        ),
+
         reqUpdateLedgerEntry: create.asyncThunk(
             async ({ id, entry }: { id: number; entry: NewLedgerEntry }) => {
                 const result = await updateLedgerEntry(id, entry);
@@ -143,6 +205,7 @@ export const ledgerSlice = createAppSlice({
     selectors: {
         selectLedgerMonth: (state) => state.month,
         selectLedgerEntries: (state) => state.entries,
+        selectLedgerCategories: (state) => state.categories,
         selectLedgerState: (state) => state.state,
         selectLedgerMutating: (state) => state.mutating,
         selectLedgerError: (state) => state.error,
@@ -151,10 +214,12 @@ export const ledgerSlice = createAppSlice({
 
 export const {
     setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqUpdateLedgerEntry, reqDeleteLedgerEntry,
+    reqGetLedgerCategories, reqAddLedgerCategory, reqDeleteLedgerCategory,
 } = ledgerSlice.actions;
 export const {
     selectLedgerMonth,
     selectLedgerEntries,
+    selectLedgerCategories,
     selectLedgerState,
     selectLedgerMutating,
     selectLedgerError,


### PR DESCRIPTION
프리셋 여덟 개로는 각자의 씀씀이를 담기 어렵습니다. 기입 시트 안에서 항목을 만들고 지울 수 있게 합니다.

> **백엔드 PR 이 함께 필요합니다** — MinSikSon/idiotquant-worker#107 (`/user/ledger/categories` + `ledger_categories` 테이블). D1 테이블은 대시보드 Console 에서 SQL 한 번으로 만들 수 있습니다(백엔드 PR 본문 참고).

## 화면

기입 시트의 항목 칩 줄 끝에 **`＋ 항목`** 이 붙습니다. 누르면 아래로 입력칸이 열리고, 만든 항목은 **바로 고른 상태**가 됩니다 — 만들고 또 눌러야 하면 두 번 일하는 셈입니다.

```
[급여] [주식 배당] [이자] [기타] [부업] [＋ 항목]
                                  ↑ 내가 만든 것
```

## 설계에서 고른 것들

### 항목 키가 이름을 품는다

사용자 항목의 키는 `custom:여행` 입니다. 덕분에 **항목을 지워도 그 항목으로 적어둔 내역이 이름을 잃지 않습니다** — 키 하나에서 라벨이 복원되므로 참조가 끊길 자리가 아예 없습니다. `categoryLabel` 도 인자를 늘리지 않아도 됩니다.

### 항목별 막대의 집계 방식을 바꿨다

기존에는 **목록을 돌며 그 항목의 내역을 세는** 방식이었습니다. 이러면 지운 항목의 지출이 막대에서 통째로 사라집니다 — 합계에는 남아 있는데 어디에 썼는지만 없어지는 셈입니다.

**내역에 실제로 쓰인 키를 모아 접는** 방식으로 바꿨습니다. 지운 항목도 이름과 함께 그대로 나옵니다.

### 지우기 × 는 고른 항목에만

칩마다 × 가 붙으면 고르다가 지웁니다. 선택은 의도적인 동작이니, 고른 뒤 바로 옆에 × 를 둡니다. 확인을 따로 묻지 않는 이유는 **이 동작이 가계부 데이터를 지우지 않기 때문**입니다 — 칩만 사라집니다. 토스트로 그렇게 알립니다.

### Enter 가 저장으로 새지 않게

시트 전체가 `form` 이라 항목 입력칸에서 Enter 를 누르면 기입이 저장됩니다. `preventDefault` 로 막고 항목 추가만 실행합니다.

### 항목 조회 실패가 화면을 막지 않는다

항목은 월과 무관해서 화면이 열릴 때 한 번만 부릅니다. 실패해도 `rejected` 에서 아무것도 하지 않습니다 — 프리셋만으로도 기입은 됩니다.

## 변경 파일

| 파일 | 내용 |
|---|---|
| `lib/features/ledger/categories.ts` | `custom:` 키 규약, `categoriesOf(kind, custom)`, `categoryLabel` 복원 |
| `lib/features/ledger/ledgerAPI.ts` | 항목 GET·POST·DELETE |
| `lib/features/ledger/ledgerSlice.tsx` | `categories` 상태 + 3개 thunk |
| `app/(ledger)/ledger/page.tsx` | `＋ 항목` 칩·입력칸, 커스텀 칩 ×, 막대 집계 방식 변경 |

## 검증

- `npx tsc --noEmit` → 에러 0
- `npm run build` → 성공, `/ledger` 라우트 확인

최신 `main`(4f84195) 위에서 작업했습니다.

배포 후 수동 확인:
1. `＋ 항목` → "여행" 입력 → 추가하면 칩이 생기고 바로 선택돼 있다
2. 그 항목으로 기입하면 내역·막대에 "여행"으로 나온다
3. "여행" 칩을 고른 뒤 × → 칩은 사라지지만 **내역의 "여행" 기록과 막대는 그대로**
4. 같은 이름을 다시 추가해도 칩이 두 개 생기지 않는다
5. 수입/지출을 바꾸면 그 구분의 항목만 보인다

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkWhRiKfTxb61ByrP4YWtB)_