### PR TITLE
가계부 함께 쓰기 — 초대 링크와 가계부 전환

### DIFF
--- a/cf-idiotquant/app/(ledger)/ledger/join/[token]/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/join/[token]/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import Link from "next/link";
+import { Users, Check } from "lucide-react";
+
+import { useAppDispatch } from "@/lib/hooks";
+import { cn } from "@/lib/utils";
+import { PageHeader } from "@/components/pageHeader";
+import { setActiveOwner } from "@/lib/features/ledger/ledgerSlice";
+import {
+    getLedgerInvite, acceptLedgerInvite, type LedgerInvitePreview,
+} from "@/lib/features/ledger/ledgerAPI";
+
+const CARD_CLS =
+    "bg-white dark:bg-[#242320] border border-neutral-200 dark:border-[#35332e] rounded-2xl";
+
+/**
+ * 초대 수락 화면.
+ *
+ * 이 경로는 middleware 의 public 목록에 없다 — 로그인하지 않았으면 자동으로
+ * /login?callbackUrl=/ledger/join/<token> 으로 보내지고, 카카오 가입까지 마치면
+ * 다시 여기로 돌아온다. 그래서 "회원이 아니면 가입" 흐름에 따로 만들 것이 없다.
+ */
+export default function LedgerJoinPage() {
+    const { token } = useParams<{ token: string }>();
+    const { status } = useSession();
+    const router = useRouter();
+    const dispatch = useAppDispatch();
+
+    const [preview, setPreview] = useState<LedgerInvitePreview | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [joining, setJoining] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (status !== "authenticated" || !token) return;
+        let alive = true;
+
+        (async () => {
+            const result = await getLedgerInvite(token);
+            if (!alive) return;
+            if (result?.success === false) setError(result?.error ?? "초대를 확인하지 못했습니다.");
+            else setPreview(result?.data ?? null);
+            setLoading(false);
+        })();
+
+        return () => { alive = false; };
+    }, [status, token]);
+
+    async function handleAccept() {
+        setJoining(true);
+        setError(null);
+
+        const result = await acceptLedgerInvite(token);
+        if (result?.success === false) {
+            setError(result?.error ?? "수락하지 못했습니다.");
+            setJoining(false);
+            return;
+        }
+
+        // 수락하자마자 그 가계부를 펼쳐준다 — 수락하고 다시 찾아 들어가게 두지 않는다.
+        dispatch(setActiveOwner(String(result?.data?.owner_user_id)));
+        router.replace("/ledger");
+    }
+
+    const header = (
+        <PageHeader
+            emoji="📒"
+            title="가계부 초대"
+            containerClassName="max-w-lg mx-auto px-4 sm:px-7"
+        />
+    );
+
+    const shell = (children: React.ReactNode) => (
+        <div className="min-h-screen bg-[#faf9f7] dark:bg-[#1a1915]">
+            {header}
+            <div className="max-w-lg mx-auto px-4 sm:px-7 py-6">
+                <div className={cn(CARD_CLS, "py-10 px-5 text-center")}>{children}</div>
+            </div>
+        </div>
+    );
+
+    // middleware 가 막아주지만, 세션이 정리되는 찰나에 여기로 떨어질 수 있다.
+    if (status === "loading" || (status === "authenticated" && loading)) {
+        return shell(<div className="h-6 w-40 mx-auto bg-[#faf9f7] dark:bg-[#1f1e1b] rounded animate-pulse" />);
+    }
+
+    if (status === "unauthenticated") {
+        return shell(
+            <>
+                <p className="text-[13px] font-bold text-neutral-700 dark:text-neutral-300">
+                    로그인하면 초대를 확인할 수 있습니다.
+                </p>
+                <Link
+                    href={`/login?callbackUrl=/ledger/join/${token}`}
+                    className="inline-block mt-4 px-5 py-2.5 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-xs font-black transition-colors"
+                >
+                    카카오로 계속하기
+                </Link>
+            </>
+        );
+    }
+
+    if (error || !preview) {
+        return shell(
+            <>
+                <p className="text-[13px] font-bold text-neutral-700 dark:text-neutral-300">
+                    {error ?? "초대를 찾을 수 없습니다."}
+                </p>
+                <Link href="/ledger" className="inline-block mt-4 px-5 py-2.5 rounded-xl border border-neutral-200 dark:border-[#3a3834] text-xs font-black text-neutral-600 dark:text-neutral-400">
+                    내 가계부로
+                </Link>
+            </>
+        );
+    }
+
+    const owner = preview.owner_name ?? "상대방";
+
+    if (preview.already_member || preview.is_mine) {
+        return shell(
+            <>
+                <Check size={28} className="mx-auto mb-3 text-[#16a34a]" strokeWidth={2.4} />
+                <p className="text-[13px] font-bold text-neutral-700 dark:text-neutral-300">
+                    {preview.is_mine ? "내가 만든 초대입니다." : `이미 ${owner}님의 가계부에 들어와 있습니다.`}
+                </p>
+                <Link href="/ledger" className="inline-block mt-4 px-5 py-2.5 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-xs font-black transition-colors">
+                    가계부 열기
+                </Link>
+            </>
+        );
+    }
+
+    if (preview.expired || preview.used) {
+        return shell(
+            <>
+                <p className="text-[13px] font-bold text-neutral-700 dark:text-neutral-300">
+                    {preview.used ? "이미 사용된 초대입니다." : "기한이 지난 초대입니다."}
+                </p>
+                <p className="mt-1.5 text-xs text-neutral-400 dark:text-neutral-500">
+                    {owner}님께 새 링크를 받아주세요.
+                </p>
+            </>
+        );
+    }
+
+    return shell(
+        <>
+            <Users size={28} className="mx-auto mb-3 text-[#16a34a]" strokeWidth={2.2} />
+            <p className="text-[15px] font-black text-neutral-900 dark:text-white">
+                {owner}님이 가계부에 초대했습니다
+            </p>
+            {/* 수락하면 무엇을 보게 되는지 먼저 알린다 — 눌러본 뒤에 알면 늦다. */}
+            <p className="mt-2 text-xs text-neutral-500 dark:text-neutral-400 leading-relaxed">
+                수락하면 {owner}님의 <b className="text-neutral-700 dark:text-neutral-300">모든 내역을 보고 함께 기입·수정</b>할 수 있습니다.
+                <br />내 가계부는 그대로 남고, 상단에서 오갈 수 있습니다.
+            </p>
+
+            <button
+                type="button"
+                onClick={handleAccept}
+                disabled={joining}
+                className="w-full min-h-[50px] mt-5 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-sm font-black disabled:opacity-50 transition-colors"
+            >
+                {joining ? "들어가는 중…" : "수락하고 함께 쓰기"}
+            </button>
+            <Link href="/ledger" className="block mt-2 text-xs font-bold text-neutral-400 dark:text-neutral-500">
+                나중에
+            </Link>
+        </>
+    );
+}

--- a/cf-idiotquant/app/(ledger)/ledger/join/[token]/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/join/[token]/page.tsx
@@ -14,6 +14,10 @@ import {
     getLedgerInvite, acceptLedgerInvite, type LedgerInvitePreview,
 } from "@/lib/features/ledger/ledgerAPI";
 
+// 토큰이 주소에 들어가는 유일한 동적 라우트다 — 정적으로 구울 수 없고,
+// Cloudflare Pages 빌드는 그런 경로에 edge 런타임을 요구한다.
+export const runtime = "edge";
+
 const CARD_CLS =
     "bg-white dark:bg-[#242320] border border-neutral-200 dark:border-[#35332e] rounded-2xl";
 

--- a/cf-idiotquant/app/(ledger)/ledger/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/page.tsx
@@ -3,16 +3,18 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, ChevronDown, Plus, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronDown, Plus, X, Users, Link2, Check } from "lucide-react";
 
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { cn } from "@/lib/utils";
-import { PageHeader } from "@/components/pageHeader";
+import { PageHeader, PAGE_ACTION_CLS } from "@/components/pageHeader";
 import type { LedgerEntry, NewLedgerEntry } from "@/lib/features/ledger/ledgerAPI";
 import {
     setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqUpdateLedgerEntry, reqDeleteLedgerEntry,
     reqGetLedgerCategories, reqAddLedgerCategory, reqDeleteLedgerCategory,
+    setActiveOwner, clearLedgerInvite, reqGetLedgerAccess, reqCreateLedgerInvite,
     selectLedgerMonth, selectLedgerEntries, selectLedgerState, selectLedgerCategories,
+    selectActiveOwner, selectLedgerAccess, selectLedgerMembers, selectLedgerInviteToken,
     selectLedgerMutating, selectLedgerError,
     currentMonthKst,
 } from "@/lib/features/ledger/ledgerSlice";
@@ -89,6 +91,10 @@ function monthGrid(month: string): (string | null)[] {
 /** 모바일에서 0 을 여섯 번 치는 게 가장 성가시다. 지금 값에 더한다. */
 const QUICK_ADD = [10000, 50000, 100000];
 
+/** 초대 링크. 카톡으로 그대로 붙여넣을 수 있게 절대 주소로 만든다. */
+const inviteUrl = (token: string) =>
+    `${typeof window === "undefined" ? "" : window.location.origin}/ledger/join/${token}`;
+
 export default function LedgerPage() {
     const { status } = useSession();
     const dispatch = useAppDispatch();
@@ -97,11 +103,17 @@ export default function LedgerPage() {
     const entries = useAppSelector(selectLedgerEntries);
     const loadState = useAppSelector(selectLedgerState);
     const customCategories = useAppSelector(selectLedgerCategories);
+    const activeOwner = useAppSelector(selectActiveOwner);
+    const ledgers = useAppSelector(selectLedgerAccess);
+    const members = useAppSelector(selectLedgerMembers);
+    const inviteToken = useAppSelector(selectLedgerInviteToken);
     const mutating = useAppSelector(selectLedgerMutating);
     const error = useAppSelector(selectLedgerError);
 
     const [barKind, setBarKind] = useState<LedgerKind>("income");
     const [calendarOpen, setCalendarOpen] = useState(false);
+    const [shareOpen, setShareOpen] = useState(false);
+    const [copied, setCopied] = useState(false);
 
     /* 시트 — editingId 가 null 이면 기입, 값이 있으면 그 줄을 수정한다 */
     const [sheetOpen, setSheetOpen] = useState(false);
@@ -134,12 +146,18 @@ export default function LedgerPage() {
     useEffect(() => {
         if (status !== "authenticated") return;
         dispatch(reqGetLedger(month));
-    }, [dispatch, status, month]);
+    }, [dispatch, status, month, activeOwner]);
 
-    // 항목은 월과 무관하다 — 화면이 열릴 때 한 번만 가져온다.
+    // 항목은 월과 무관하지만 가계부마다 다르다 — 가계부가 바뀌면 다시 가져온다.
     useEffect(() => {
         if (status !== "authenticated") return;
         dispatch(reqGetLedgerCategories());
+    }, [dispatch, status, activeOwner]);
+
+    // 볼 수 있는 가계부 목록. 초대를 수락하고 돌아왔을 때도 여기서 반영된다.
+    useEffect(() => {
+        if (status !== "authenticated") return;
+        dispatch(reqGetLedgerAccess());
     }, [dispatch, status]);
 
     useEffect(() => {
@@ -368,12 +386,33 @@ export default function LedgerPage() {
     const signedOut = status === "unauthenticated";
     const loading = status === "loading" || (loadState === "pending" && entries.length === 0);
 
+    /* 남의 가계부를 보고 있으면 그 사실이 제목에 드러나야 한다 —
+       어느 장부에 적고 있는지 모르면 잘못 적는다. */
+    const activeLedger = ledgers.find(l => l.owner_user_id === activeOwner);
+    const viewingShared = activeOwner !== null;
+
     const header = (
         <PageHeader
             emoji="📒"
-            title="가계부"
-            meta={<><span>로그인 사용자 전용</span><span aria-hidden>·</span><span>내 계정에만 저장됩니다</span></>}
+            title={viewingShared ? `${activeLedger?.owner_name ?? "공유"}님의 가계부` : "가계부"}
+            meta={
+                viewingShared
+                    ? <><span>함께 쓰는 가계부</span><span aria-hidden>·</span><span>기입·수정이 모두 반영됩니다</span></>
+                    : members.length > 0
+                        ? <><span>{members.length}명과 함께 쓰는 중</span><span aria-hidden>·</span><span>내 계정에 저장됩니다</span></>
+                        : <><span>로그인 사용자 전용</span><span aria-hidden>·</span><span>내 계정에만 저장됩니다</span></>
+            }
             containerClassName="max-w-3xl mx-auto px-4 sm:px-7"
+            actions={
+                <button
+                    type="button"
+                    onClick={() => { setShareOpen(true); setCopied(false); dispatch(clearLedgerInvite()); }}
+                    className={PAGE_ACTION_CLS}
+                >
+                    <Users size={14} />
+                    공유
+                </button>
+            }
         />
     );
 
@@ -415,6 +454,32 @@ export default function LedgerPage() {
             )}
 
             <div className="max-w-3xl mx-auto px-4 sm:px-7 py-5 space-y-3.5">
+
+                {/* ⓪ 가계부 전환 — 볼 수 있는 가계부가 둘 이상일 때만 나온다.
+                    혼자 쓰는 사람에게는 없던 UI 가 생기지 않는다. */}
+                {ledgers.length > 1 && (
+                    <div className={cn(CARD_CLS, "flex gap-1.5 p-1.5 overflow-x-auto")}>
+                        {ledgers.map(l => {
+                            const on = l.is_mine ? activeOwner === null : activeOwner === l.owner_user_id;
+                            return (
+                                <button
+                                    key={l.owner_user_id}
+                                    type="button"
+                                    onClick={() => dispatch(setActiveOwner(l.is_mine ? null : l.owner_user_id))}
+                                    aria-pressed={on}
+                                    className={cn(
+                                        "shrink-0 min-h-[40px] px-3.5 rounded-xl text-[13px] font-bold transition-colors",
+                                        on
+                                            ? "bg-[#16a34a] text-white"
+                                            : "bg-[#faf9f7] dark:bg-[#1a1915] text-neutral-600 dark:text-neutral-400 hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]"
+                                    )}
+                                >
+                                    {l.is_mine ? "내 가계부" : `${l.owner_name ?? "공유"}님`}
+                                </button>
+                            );
+                        })}
+                    </div>
+                )}
 
                 {/* ① 월 선택 — 터치 타겟 44px. 달을 누르면 달력이 아래로 펼쳐진다. */}
                 <div className={CARD_CLS}>
@@ -737,6 +802,92 @@ export default function LedgerPage() {
                     <Plus size={18} strokeWidth={2.8} />
                     기입
                 </button>
+            )}
+
+            {/* ── 공유 시트 ── */}
+            {shareOpen && (
+                <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+                    <div className="absolute inset-0 bg-neutral-900/45" onClick={() => setShareOpen(false)} aria-hidden />
+                    <div className="relative w-full sm:max-w-md max-h-[92dvh] overflow-y-auto bg-white dark:bg-[#242320] border-t sm:border border-neutral-200 dark:border-[#35332e] rounded-t-3xl sm:rounded-2xl px-4 pt-2 pb-5 sm:pb-4 shadow-2xl">
+                        <div className="sm:hidden w-9 h-1 rounded-full bg-neutral-200 dark:bg-[#35332e] mx-auto mt-1 mb-3" aria-hidden />
+                        <h2 className="text-[15px] font-black tracking-[-0.02em] text-neutral-900 dark:text-white mb-1">
+                            함께 쓰기
+                        </h2>
+                        <p className="text-xs text-neutral-500 dark:text-neutral-400 mb-4">
+                            초대한 사람은 <b className="text-neutral-700 dark:text-neutral-300">내 가계부의 모든 내역을 보고 함께 기입·수정</b>할 수 있습니다.
+                        </p>
+
+                        {/* 지금 들어와 있는 사람 */}
+                        <div className="flex flex-col gap-1.5 mb-4">
+                            <span className={FIELD_LABEL_CLS}>함께 쓰는 사람</span>
+                            {members.length === 0 ? (
+                                <p className="text-xs text-neutral-400 dark:text-neutral-500 py-1">아직 없습니다.</p>
+                            ) : (
+                                <div className="flex flex-col gap-1">
+                                    {members.map(m => (
+                                        <div key={m.user_id} className="flex items-center gap-2 px-3 py-2 rounded-xl bg-[#faf9f7] dark:bg-[#1a1915]">
+                                            <span className="w-6 h-6 rounded-full bg-neutral-200 dark:bg-[#4a4641] flex items-center justify-center text-[10px] font-black text-neutral-700 dark:text-neutral-200">
+                                                {m.name?.[0] ?? "?"}
+                                            </span>
+                                            <span className="text-[13px] font-bold text-neutral-700 dark:text-neutral-300">
+                                                {m.name ?? "이름 없음"}
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+
+                        {/* 초대 링크 */}
+                        <div className="flex flex-col gap-1.5">
+                            <span className={FIELD_LABEL_CLS}>초대 링크</span>
+                            {inviteToken ? (
+                                <>
+                                    <div className="px-3 py-2.5 rounded-xl bg-[#faf9f7] dark:bg-[#1a1915] border border-neutral-200 dark:border-[#35332e] text-[11px] font-mono break-all text-neutral-600 dark:text-neutral-400">
+                                        {inviteUrl(inviteToken)}
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={async () => {
+                                            await navigator.clipboard?.writeText(inviteUrl(inviteToken));
+                                            setCopied(true);
+                                            setToast("링크를 복사했습니다");
+                                        }}
+                                        className="min-h-[48px] rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-sm font-black flex items-center justify-center gap-1.5 transition-colors"
+                                    >
+                                        {copied ? <Check size={16} strokeWidth={2.6} /> : <Link2 size={16} strokeWidth={2.4} />}
+                                        {copied ? "복사했습니다" : "링크 복사"}
+                                    </button>
+                                    <p className="text-[11px] text-neutral-400 dark:text-neutral-500">
+                                        한 사람만 쓸 수 있고 7일 뒤 만료됩니다. 받는 분이 회원이 아니어도 링크를 열면 카카오 가입 후 바로 들어옵니다.
+                                    </p>
+                                </>
+                            ) : (
+                                <button
+                                    type="button"
+                                    onClick={() => dispatch(reqCreateLedgerInvite())}
+                                    disabled={mutating}
+                                    className="min-h-[48px] rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-sm font-black flex items-center justify-center gap-1.5 disabled:opacity-50 transition-colors"
+                                >
+                                    <Link2 size={16} strokeWidth={2.4} />
+                                    {mutating ? "만드는 중…" : "초대 링크 만들기"}
+                                </button>
+                            )}
+                        </div>
+
+                        {error && (
+                            <p role="alert" className="mt-3 text-xs font-bold text-red-600 dark:text-red-400">{error}</p>
+                        )}
+
+                        <button
+                            type="button"
+                            onClick={() => setShareOpen(false)}
+                            className="w-full min-h-[48px] mt-3 rounded-xl border border-neutral-200 dark:border-[#3a3834] bg-[#faf9f7] dark:bg-[#1a1915] text-sm font-black text-neutral-600 dark:text-neutral-400"
+                        >
+                            닫기
+                        </button>
+                    </div>
+                </div>
             )}
 
             {/* ── 기입·수정 시트 ── */}

--- a/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
+++ b/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
@@ -29,23 +29,72 @@ async function ledgerRequest(subUrl: string, method = "GET", body?: object) {
     return res.json();
 }
 
-export const getLedger = (month: string) => ledgerRequest(`/user/ledger?month=${month}`);
+/* owner 는 "어느 가계부인가" 다. 비우면 내 것 — 워커도 같은 규칙이라
+   혼자 쓰는 사람의 요청은 예전과 완전히 같은 모양으로 나간다. */
+type Owner = string | null;
+const own = (owner: Owner) => (owner ? `owner=${encodeURIComponent(owner)}` : "");
+const q = (...parts: string[]) => {
+    const joined = parts.filter(Boolean).join("&");
+    return joined ? `?${joined}` : "";
+};
 
-export const addLedgerEntry = (entry: NewLedgerEntry) => ledgerRequest("/user/ledger", "POST", entry);
+export const getLedger = (owner: Owner, month: string) =>
+    ledgerRequest(`/user/ledger${q(`month=${month}`, own(owner))}`);
+
+export const addLedgerEntry = (owner: Owner, entry: NewLedgerEntry) =>
+    ledgerRequest(`/user/ledger${q(own(owner))}`, "POST", entry);
 
 // 수정·삭제의 id 는 쿼리로 보낸다 — 프록시가 non-GET body 에 주문 필드를 병합하기 때문.
-export const updateLedgerEntry = (id: number, entry: NewLedgerEntry) =>
-    ledgerRequest(`/user/ledger?id=${id}`, "PUT", entry);
+export const updateLedgerEntry = (owner: Owner, id: number, entry: NewLedgerEntry) =>
+    ledgerRequest(`/user/ledger${q(`id=${id}`, own(owner))}`, "PUT", entry);
 
-export const deleteLedgerEntry = (id: number) => ledgerRequest(`/user/ledger?id=${id}`, "DELETE");
+export const deleteLedgerEntry = (owner: Owner, id: number) =>
+    ledgerRequest(`/user/ledger${q(`id=${id}`, own(owner))}`, "DELETE");
 
 /* 사용자가 만든 항목 — 칩으로 무엇을 보여줄지만 정한다. 지워도 과거 내역은 그대로 남는다. */
 export type { StoredCategory };
 
-export const getLedgerCategories = () => ledgerRequest("/user/ledger/categories");
+export const getLedgerCategories = (owner: Owner) =>
+    ledgerRequest(`/user/ledger/categories${q(own(owner))}`);
 
-export const addLedgerCategory = (kind: LedgerKind, label: string) =>
-    ledgerRequest("/user/ledger/categories", "POST", { kind, label });
+export const addLedgerCategory = (owner: Owner, kind: LedgerKind, label: string) =>
+    ledgerRequest(`/user/ledger/categories${q(own(owner))}`, "POST", { kind, label });
 
-export const deleteLedgerCategory = (id: number) =>
-    ledgerRequest(`/user/ledger/categories?id=${id}`, "DELETE");
+export const deleteLedgerCategory = (owner: Owner, id: number) =>
+    ledgerRequest(`/user/ledger/categories${q(`id=${id}`, own(owner))}`, "DELETE");
+
+/* ── 공유 ── */
+
+export interface LedgerAccess {
+    owner_user_id: string;
+    owner_name: string | null;
+    is_mine: boolean;
+}
+
+export interface LedgerMember {
+    user_id: string;
+    name: string | null;
+    joined_at: number;
+}
+
+export interface LedgerInvitePreview {
+    owner_user_id: string;
+    owner_name: string | null;
+    expired: boolean;
+    used: boolean;
+    already_member: boolean;
+    is_mine: boolean;
+}
+
+/** 내가 볼 수 있는 가계부 + 내 가계부에 들어와 있는 사람들 */
+export const getLedgerAccess = () => ledgerRequest("/user/ledger/access");
+
+/** 초대 링크 발급 (내 가계부만) */
+export const createLedgerInvite = () => ledgerRequest("/user/ledger/invite", "POST");
+
+/** 수락 전 미리보기 — 누가 불렀는지, 아직 살아 있는지 */
+export const getLedgerInvite = (token: string) =>
+    ledgerRequest(`/user/ledger/invite?token=${encodeURIComponent(token)}`);
+
+export const acceptLedgerInvite = (token: string) =>
+    ledgerRequest(`/user/ledger/invite?token=${encodeURIComponent(token)}`, "POST");

--- a/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
+++ b/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
@@ -20,13 +20,28 @@ export interface NewLedgerEntry {
 
 async function ledgerRequest(subUrl: string, method = "GET", body?: object) {
     const url = `/api/proxy${subUrl}`;
-    const res = await fetch(url, {
-        method,
-        credentials: "include",
-        headers: { "content-type": "application/json" },
-        ...(body ? { body: JSON.stringify(body) } : {}),
-    });
-    return res.json();
+
+    let res: Response;
+    try {
+        res = await fetch(url, {
+            method,
+            credentials: "include",
+            headers: { "content-type": "application/json" },
+            ...(body ? { body: JSON.stringify(body) } : {}),
+        });
+    } catch {
+        return { success: false, error: "서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요." };
+    }
+
+    // 워커가 예외를 던지면 JSON 대신 오류 페이지가 돌아온다. 그대로 res.json() 을 부르면
+    // 브라우저가 만든 파싱 오류(사파리는 "The string did not match the expected pattern.")가
+    // 그대로 화면에 뜨는데, 무엇이 잘못됐는지 알 길이 없다 — 우리 형식으로 바꿔 돌려준다.
+    const text = await res.text();
+    try {
+        return JSON.parse(text);
+    } catch {
+        return { success: false, error: `서버 응답을 읽지 못했습니다 (HTTP ${res.status}).` };
+    }
 }
 
 /* owner 는 "어느 가계부인가" 다. 비우면 내 것 — 워커도 같은 규칙이라

--- a/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
+++ b/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
@@ -3,7 +3,8 @@ import { createAppSlice } from "@/lib/createAppSlice";
 import {
     getLedger, addLedgerEntry, updateLedgerEntry, deleteLedgerEntry,
     getLedgerCategories, addLedgerCategory, deleteLedgerCategory,
-    type LedgerEntry, type NewLedgerEntry,
+    getLedgerAccess, createLedgerInvite,
+    type LedgerEntry, type NewLedgerEntry, type LedgerAccess, type LedgerMember,
 } from "./ledgerAPI";
 import type { LedgerKind, StoredCategory } from "./categories";
 
@@ -11,6 +12,11 @@ import type { LedgerKind, StoredCategory } from "./categories";
 export function currentMonthKst(): string {
     return new Date(Date.now() + 9 * 60 * 60 * 1000).toISOString().slice(0, 7);
 }
+
+/** thunk 안에서 "지금 보고 있는 가계부" 를 꺼낸다.
+ *  store 를 import 하면 순환이 되므로 필요한 모양만 좁게 적는다. */
+const ownerOf = (getState: () => unknown) =>
+    (getState() as { ledger: { activeOwner: string | null } }).ledger.activeOwner;
 
 /** 최신 날짜가 위. 같은 날은 나중에 넣은 것이 위로 온다 (워커 ORDER BY 와 같은 기준). */
 const byRecent = (a: LedgerEntry, b: LedgerEntry) =>
@@ -21,6 +27,11 @@ interface LedgerState {
     month: string;              // 'YYYY-MM'
     entries: LedgerEntry[];
     categories: StoredCategory[];   // 사용자가 만든 항목 (프리셋은 categories.ts 상수)
+    /** null 이면 내 가계부. 값이 있으면 그 사람 가계부를 보고 있다. */
+    activeOwner: string | null;
+    ledgers: LedgerAccess[];        // 내가 볼 수 있는 가계부 (내 것이 항상 첫 번째)
+    members: LedgerMember[];        // 내 가계부에 들어와 있는 사람들
+    inviteToken: string | null;
     mutating: boolean;
     error: string | null;
 }
@@ -30,6 +41,10 @@ const initialState: LedgerState = {
     month: currentMonthKst(),
     entries: [],
     categories: [],
+    activeOwner: null,
+    ledgers: [],
+    members: [],
+    inviteToken: null,
     mutating: false,
     error: null,
 };
@@ -49,8 +64,8 @@ export const ledgerSlice = createAppSlice({
         }),
 
         reqGetLedger: create.asyncThunk(
-            async (month: string) => {
-                const result = await getLedger(month);
+            async (month: string, { getState }) => {
+                const result = await getLedger(ownerOf(getState), month);
                 if (result?.success === false) throw new Error(result?.error ?? "API error");
                 return result;
             },
@@ -72,8 +87,8 @@ export const ledgerSlice = createAppSlice({
         ),
 
         reqAddLedgerEntry: create.asyncThunk(
-            async (entry: NewLedgerEntry) => {
-                const result = await addLedgerEntry(entry);
+            async (entry: NewLedgerEntry, { getState }) => {
+                const result = await addLedgerEntry(ownerOf(getState), entry);
                 if (result?.success === false) throw new Error(result?.error ?? "API error");
                 return result;
             },
@@ -96,10 +111,66 @@ export const ledgerSlice = createAppSlice({
             }
         ),
 
+        /* ── 공유 ── */
+
+        /** 보는 가계부를 바꾼다. 달 전환과 같은 이유로 목록을 비운다 —
+            남의 가계부 제목 아래에 내 합계가 잠깐이라도 떠 있으면 안 된다. */
+        setActiveOwner: create.reducer((state, action: PayloadAction<string | null>) => {
+            if (state.activeOwner === action.payload) return;
+            state.activeOwner = action.payload;
+            state.entries = [];
+            state.categories = [];
+            state.state = "pending";
+            state.error = null;
+        }),
+
+        clearLedgerInvite: create.reducer((state) => { state.inviteToken = null; }),
+
+        reqGetLedgerAccess: create.asyncThunk(
+            async () => {
+                const result = await getLedgerAccess();
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
+            {
+                fulfilled: (state, action) => {
+                    state.ledgers = (action.payload?.data?.ledgers ?? []) as LedgerAccess[];
+                    state.members = (action.payload?.data?.members ?? []) as LedgerMember[];
+                    // 나가 있던 가계부에서 빠졌다면 내 것으로 되돌린다 — 아니면 계속 404 를 받는다.
+                    if (state.activeOwner && !state.ledgers.some(l => l.owner_user_id === state.activeOwner)) {
+                        state.activeOwner = null;
+                        state.entries = [];
+                        state.categories = [];
+                    }
+                },
+                // 공유를 못 불러와도 내 가계부는 그대로 쓸 수 있다 — 화면을 막지 않는다.
+                rejected: () => {},
+            }
+        ),
+
+        reqCreateLedgerInvite: create.asyncThunk(
+            async () => {
+                const result = await createLedgerInvite();
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
+            {
+                pending: (state) => { state.mutating = true; state.error = null; state.inviteToken = null; },
+                fulfilled: (state, action) => {
+                    state.mutating = false;
+                    state.inviteToken = (action.payload?.data?.token as string) ?? null;
+                },
+                rejected: (state, action) => {
+                    state.mutating = false;
+                    state.error = action.error?.message ?? null;
+                },
+            }
+        ),
+
         /* ── 사용자 항목 ── 월과 무관해서 화면이 열릴 때 한 번만 부른다 ── */
         reqGetLedgerCategories: create.asyncThunk(
-            async () => {
-                const result = await getLedgerCategories();
+            async (_: void, { getState }) => {
+                const result = await getLedgerCategories(ownerOf(getState));
                 if (result?.success === false) throw new Error(result?.error ?? "API error");
                 return result;
             },
@@ -113,8 +184,8 @@ export const ledgerSlice = createAppSlice({
         ),
 
         reqAddLedgerCategory: create.asyncThunk(
-            async ({ kind, label }: { kind: LedgerKind; label: string }) => {
-                const result = await addLedgerCategory(kind, label);
+            async ({ kind, label }: { kind: LedgerKind; label: string }, { getState }) => {
+                const result = await addLedgerCategory(ownerOf(getState), kind, label);
                 if (result?.success === false) throw new Error(result?.error ?? "API error");
                 return result;
             },
@@ -136,8 +207,8 @@ export const ledgerSlice = createAppSlice({
         ),
 
         reqDeleteLedgerCategory: create.asyncThunk(
-            async (id: number) => {
-                const result = await deleteLedgerCategory(id);
+            async (id: number, { getState }) => {
+                const result = await deleteLedgerCategory(ownerOf(getState), id);
                 if (result?.success === false) throw new Error(result?.error ?? "API error");
                 return id;
             },
@@ -155,8 +226,8 @@ export const ledgerSlice = createAppSlice({
         ),
 
         reqUpdateLedgerEntry: create.asyncThunk(
-            async ({ id, entry }: { id: number; entry: NewLedgerEntry }) => {
-                const result = await updateLedgerEntry(id, entry);
+            async ({ id, entry }: { id: number; entry: NewLedgerEntry }, { getState }) => {
+                const result = await updateLedgerEntry(ownerOf(getState), id, entry);
                 if (result?.success === false) throw new Error(result?.error ?? "API error");
                 return result;
             },
@@ -184,8 +255,8 @@ export const ledgerSlice = createAppSlice({
         ),
 
         reqDeleteLedgerEntry: create.asyncThunk(
-            async (id: number) => {
-                const result = await deleteLedgerEntry(id);
+            async (id: number, { getState }) => {
+                const result = await deleteLedgerEntry(ownerOf(getState), id);
                 if (result?.success === false) throw new Error(result?.error ?? "API error");
                 return id;
             },
@@ -206,6 +277,10 @@ export const ledgerSlice = createAppSlice({
         selectLedgerMonth: (state) => state.month,
         selectLedgerEntries: (state) => state.entries,
         selectLedgerCategories: (state) => state.categories,
+        selectActiveOwner: (state) => state.activeOwner,
+        selectLedgerAccess: (state) => state.ledgers,
+        selectLedgerMembers: (state) => state.members,
+        selectLedgerInviteToken: (state) => state.inviteToken,
         selectLedgerState: (state) => state.state,
         selectLedgerMutating: (state) => state.mutating,
         selectLedgerError: (state) => state.error,
@@ -215,11 +290,16 @@ export const ledgerSlice = createAppSlice({
 export const {
     setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqUpdateLedgerEntry, reqDeleteLedgerEntry,
     reqGetLedgerCategories, reqAddLedgerCategory, reqDeleteLedgerCategory,
+    setActiveOwner, clearLedgerInvite, reqGetLedgerAccess, reqCreateLedgerInvite,
 } = ledgerSlice.actions;
 export const {
     selectLedgerMonth,
     selectLedgerEntries,
     selectLedgerCategories,
+    selectActiveOwner,
+    selectLedgerAccess,
+    selectLedgerMembers,
+    selectLedgerInviteToken,
     selectLedgerState,
     selectLedgerMutating,
     selectLedgerError,


### PR DESCRIPTION
가계부가 한 사람에게 묶여 있어 부부·가족이 같이 쓸 수 없었습니다. 초대 링크로 사람을 불러 같이 적을 수 있게 합니다.

> **백엔드 PR 이 함께 필요합니다** — MinSikSon/idiotquant-worker#108. D1 테이블 2개를 대시보드 Console 에서 만들어야 합니다(백엔드 PR 본문에 붙여넣을 SQL 이 있습니다).
>
> **#714 위에 쌓았습니다.** 같은 파일을 크게 건드려 base 를 `claude/ledger-calendar` 로 뒀습니다. **#713 → #714 → 이 PR 순서로** 봐주세요.

## 흐름

```
소유자                                     초대받는 사람
──────                                     ────────────
[공유] → 초대 링크 만들기
       → 링크 복사 → 카톡으로 전송  ─────▶  링크 열기
                                          (미가입) → 카카오 가입
                                          → "○○님이 초대했습니다" → 수락
                                          → 그 가계부가 바로 열림
```

**미가입자 흐름은 새로 만든 것이 없습니다.** `/ledger/join/<token>` 이 `middleware` 의 public 목록에 없어 자동으로 `/login?callbackUrl=/ledger/join/<token>` 으로 가고, 카카오 가입을 마치면 그대로 돌아옵니다. 미들웨어는 손대지 않았습니다.

## 설계에서 고른 것들

**전환 UI 는 볼 수 있는 가계부가 둘 이상일 때만 나옵니다.**
혼자 쓰는 분에게는 없던 것이 생기지 않습니다 — 화면이 그대로입니다.

**남의 가계부를 보고 있으면 제목이 "○○님의 가계부" 로 바뀝니다.**
어느 장부에 적고 있는지 모르면 잘못 적습니다.

**`owner` 는 슬라이스에 두고 thunk 가 직접 읽습니다.**
호출부마다 넘기면 언젠가 하나를 빠뜨리고, **그 하나가 남의 가계부에 내 기록을 남깁니다.** `ownerOf(getState)` 한 줄이 모든 요청에 붙습니다.

**가계부를 바꿀 때 내역과 항목을 비웁니다.**
달 전환과 같은 이유입니다 — 남의 가계부 제목 아래 내 합계가 잠깐이라도 떠 있으면 안 됩니다. 항목도 가계부마다 다르므로 함께 비웁니다.

**access 응답에 내가 없으면 `activeOwner` 를 내 것으로 되돌립니다.**
내보내진 뒤에도 붙잡고 있으면 계속 404 를 받습니다.

**수락 화면이 "무엇을 보게 되는지" 를 누르기 전에 말합니다.**
상대의 모든 내역이 보인다는 건 눌러본 뒤에 알면 늦습니다. 공유 시트에서도 초대하는 쪽에 같은 문장을 보여줍니다.

**수락 직후 그 가계부를 펼쳐줍니다.** 수락하고 다시 찾아 들어가게 두지 않습니다.

## 변경 파일

| 파일 | 내용 |
|---|---|
| `app/(ledger)/ledger/join/[token]/page.tsx` | 수락 화면 (신규) |
| `app/(ledger)/ledger/page.tsx` | 가계부 전환, 공유 시트, 제목 전환 |
| `lib/features/ledger/ledgerAPI.ts` | 모든 호출에 `owner`, access·invite 추가 |
| `lib/features/ledger/ledgerSlice.tsx` | `activeOwner`·`ledgers`·`members`·`inviteToken` |

## 검증

- `npx tsc --noEmit` → 에러 0
- `npm run build` → 성공, `/ledger` 와 `/ledger/join/[token]` 라우트 확인

배포 후 수동 확인:
1. 혼자 쓰는 계정에서는 전환 UI 가 **보이지 않는다**
2. [공유] → 링크 만들기 → 복사 → 다른 계정(또는 시크릿 창)에서 열기
3. 로그아웃 상태로 열면 로그인으로 가고, 카카오 가입 후 수락 화면으로 돌아온다
4. 수락하면 그 가계부가 바로 열리고, 상단에 전환 버튼이 두 개 생긴다
5. 공유 가계부에서 기입하면 소유자 쪽에서도 보인다
6. 같은 링크를 다시 열면 "이미 들어와 있습니다"
7. 소유자 쪽 [공유] 에 들어온 사람이 보인다

## 이번 범위 밖

멤버 내보내기 · 스스로 나가기 · 초대 링크 폐기 · 누가 적었는지 표시는 넣지 않았습니다(요청하신 범위 그대로). 필요해지면 `ledger_members` 에 `DELETE` 하나만 붙이면 됩니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkWhRiKfTxb61ByrP4YWtB)_