### PR TITLE
가계부 항목 이름 바꾸기 — 고른 항목에 연필 버튼

### DIFF
--- a/cf-idiotquant/app/(ledger)/ledger/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import { ChevronLeft, ChevronRight, ChevronDown, Plus, X, Users, Link2, Check } from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronDown, Plus, X, Pencil, Users, Link2, Check } from "lucide-react";
 
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { cn } from "@/lib/utils";
@@ -11,7 +11,7 @@ import { PageHeader, PAGE_ACTION_CLS } from "@/components/pageHeader";
 import type { LedgerEntry, NewLedgerEntry } from "@/lib/features/ledger/ledgerAPI";
 import {
     setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqUpdateLedgerEntry, reqDeleteLedgerEntry,
-    reqGetLedgerCategories, reqAddLedgerCategory, reqDeleteLedgerCategory,
+    reqGetLedgerCategories, reqAddLedgerCategory, reqRenameLedgerCategory, reqDeleteLedgerCategory,
     setActiveOwner, clearLedgerInvite, reqGetLedgerAccess, reqCreateLedgerInvite,
     selectLedgerMonth, selectLedgerEntries, selectLedgerState, selectLedgerCategories,
     selectActiveOwner, selectLedgerAccess, selectLedgerMembers, selectLedgerInviteToken,
@@ -19,7 +19,7 @@ import {
     currentMonthKst,
 } from "@/lib/features/ledger/ledgerSlice";
 import {
-    categoriesOf, categoryLabel, customKey, type LedgerKind,
+    categoriesOf, categoryLabel, catKey, type LedgerKind, type StoredCategory,
 } from "@/lib/features/ledger/categories";
 
 /* ─── 공통 클래스 ──────────────────────────────────────────────── */
@@ -130,6 +130,8 @@ export default function LedgerPage() {
     // 항목 만들기 — 시트 안에서 칩 줄 아래로 펼친다
     const [newCatOpen, setNewCatOpen] = useState(false);
     const [newCatLabel, setNewCatLabel] = useState("");
+    /** null 이면 새로 만드는 중, 값이 있으면 그 항목의 이름을 고치는 중 — 입력 줄은 하나다. */
+    const [catEditId, setCatEditId] = useState<number | null>(null);
     const newCatRef = useRef<HTMLInputElement>(null);
 
     // 시트가 목록을 가리므로 저장 결과는 시트 위에 뜨는 토스트로 알린다.
@@ -202,7 +204,7 @@ export default function LedgerPage() {
         }
         return [...sums]
             .map(([key, sum]) => ({
-                label: categoryLabel(barKind, key),
+                label: categoryLabel(barKind, key, customCategories),
                 sum,
                 pct: Math.round((sum / total) * 100),
             }))
@@ -238,27 +240,52 @@ export default function LedgerPage() {
     /* ─── 시트 열고 닫기 ───────────────────────────────────────── */
     function changeKind(kind: LedgerKind, keep?: string) {
         setFKind(kind);
-        setNewCatOpen(false);
+        closeCatForm();
         const list = categoriesOf(kind, customCategories);
         setFCategory(keep && list.some(c => c.key === keep) ? keep : list[0].key);
     }
 
-    async function handleAddCategory() {
+    function closeCatForm() {
+        setNewCatOpen(false);
+        setNewCatLabel("");
+        setCatEditId(null);
+    }
+
+    function openCatForm(edit?: { id: number; label: string }) {
+        setCatEditId(edit?.id ?? null);
+        setNewCatLabel(edit?.label ?? "");
+        setNewCatOpen(true);
+        setTimeout(() => newCatRef.current?.select(), 30);
+    }
+
+    /** 입력 줄 하나가 만들기와 이름 고치기를 겸한다 — 열려 있는 동안 무엇을 하는지는 catEditId 가 안다. */
+    async function handleSaveCategory() {
         const label = newCatLabel.trim();
         if (!label) return;
+
+        if (catEditId !== null) {
+            const result = await dispatch(reqRenameLedgerCategory({ id: catEditId, label }));
+            if (result.meta.requestStatus !== "fulfilled") return;
+            // 내역은 이 항목의 id 를 가리키고 있어 목록·막대의 이름이 저절로 따라온다.
+            closeCatForm();
+            setToast("이름을 바꿨습니다");
+            return;
+        }
+
         const result = await dispatch(reqAddLedgerCategory({ kind: fKind, label }));
         if (result.meta.requestStatus !== "fulfilled") return;
         // 방금 만든 항목을 바로 고른 상태로 둔다 — 만들고 또 눌러야 하면 두 번 일하는 셈이다.
-        setFCategory(customKey(label));
-        setNewCatLabel("");
-        setNewCatOpen(false);
+        const created = (result.payload as { data?: StoredCategory } | undefined)?.data;
+        if (created) setFCategory(catKey(created.id));
+        closeCatForm();
     }
 
     async function handleDeleteCategory(id: number, label: string) {
-        const result = await dispatch(reqDeleteLedgerCategory(id));
+        const result = await dispatch(reqDeleteLedgerCategory({ id, label }));
         if (result.meta.requestStatus !== "fulfilled") return;
         // 고른 항목이 사라졌으면 첫 칸으로 되돌린다.
-        if (fCategory === customKey(label)) setFCategory(categoriesOf(fKind, [])[0].key);
+        if (fCategory === catKey(id)) setFCategory(categoriesOf(fKind, [])[0].key);
+        closeCatForm();
         setToast("항목을 지웠습니다 (기록은 그대로)");
     }
 
@@ -752,7 +779,7 @@ export default function LedgerPage() {
                                                             ? "bg-[#dcfce7]/70 dark:bg-[#052e16]/40"
                                                             : "hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]"
                                                     )}
-                                                    aria-label={`${e.entry_date} ${categoryLabel(e.kind, e.category)} ${e.amount.toLocaleString("ko-KR")}원 수정`}
+                                                    aria-label={`${e.entry_date} ${categoryLabel(e.kind, e.category, customCategories)} ${e.amount.toLocaleString("ko-KR")}원 수정`}
                                                 >
                                                     <span className={cn(
                                                         "text-[11px] font-black px-2 py-0.5 rounded-md whitespace-nowrap",
@@ -760,7 +787,7 @@ export default function LedgerPage() {
                                                             ? "bg-[#dcfce7] text-[#16a34a] dark:bg-[#052e16]/60 dark:text-[#16a34a]"
                                                             : "bg-red-100 text-red-600 dark:bg-red-950/40 dark:text-red-400"
                                                     )}>
-                                                        {categoryLabel(e.kind, e.category)}
+                                                        {categoryLabel(e.kind, e.category, customCategories)}
                                                     </span>
                                                     <span className={cn(
                                                         "text-xs truncate",
@@ -1016,23 +1043,40 @@ export default function LedgerPage() {
                                             >
                                                 {c.label}
                                             </button>
-                                            {/* 지우기는 고른 항목에만 — 칩마다 × 가 붙으면 고르다가 지운다.
-                                                항목만 사라지고 그 항목으로 적어둔 기록은 남는다. */}
+                                            {/* 이름 고치기·지우기는 고른 항목에만 — 칩마다 붙으면 고르다가 누른다.
+                                                이름을 바꿔도 그 항목으로 적어둔 기록은 새 이름으로 함께 따라오고,
+                                                지우면 항목만 사라지고 기록은 그때의 이름으로 남는다. */}
                                             {on && mine && (
-                                                <button
-                                                    type="button"
-                                                    onClick={() => handleDeleteCategory(c.id!, c.label)}
-                                                    disabled={mutating}
-                                                    className={cn(
-                                                        CHIP_CLS, "w-9 px-0 rounded-l-none border-l-0 flex items-center justify-center",
-                                                        fKind === "income"
-                                                            ? "bg-[#16a34a] border-[#16a34a] text-white/80 hover:text-white"
-                                                            : "bg-red-600 border-red-600 text-white/80 hover:text-white"
-                                                    )}
-                                                    aria-label={`${c.label} 항목 지우기`}
-                                                >
-                                                    <X size={14} strokeWidth={2.6} />
-                                                </button>
+                                                <>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => openCatForm({ id: c.id!, label: c.label })}
+                                                        disabled={mutating}
+                                                        className={cn(
+                                                            CHIP_CLS, "w-9 px-0 rounded-none border-l-0 border-r-0 flex items-center justify-center",
+                                                            fKind === "income"
+                                                                ? "bg-[#16a34a] border-[#16a34a] text-white/80 hover:text-white"
+                                                                : "bg-red-600 border-red-600 text-white/80 hover:text-white"
+                                                        )}
+                                                        aria-label={`${c.label} 항목 이름 바꾸기`}
+                                                    >
+                                                        <Pencil size={13} strokeWidth={2.6} />
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleDeleteCategory(c.id!, c.label)}
+                                                        disabled={mutating}
+                                                        className={cn(
+                                                            CHIP_CLS, "w-9 px-0 rounded-l-none border-l-0 flex items-center justify-center",
+                                                            fKind === "income"
+                                                                ? "bg-[#16a34a] border-[#16a34a] text-white/80 hover:text-white"
+                                                                : "bg-red-600 border-red-600 text-white/80 hover:text-white"
+                                                        )}
+                                                        aria-label={`${c.label} 항목 지우기`}
+                                                    >
+                                                        <X size={14} strokeWidth={2.6} />
+                                                    </button>
+                                                </>
                                             )}
                                         </span>
                                     );
@@ -1041,7 +1085,7 @@ export default function LedgerPage() {
                                 {!newCatOpen && (
                                     <button
                                         type="button"
-                                        onClick={() => { setNewCatOpen(true); setTimeout(() => newCatRef.current?.focus(), 30); }}
+                                        onClick={() => openCatForm()}
                                         className={cn(CHIP_CLS, "flex items-center gap-1 border-dashed border-neutral-300 dark:border-[#4a4641] bg-transparent text-neutral-500 dark:text-neutral-400")}
                                     >
                                         <Plus size={13} strokeWidth={2.8} />
@@ -1061,20 +1105,26 @@ export default function LedgerPage() {
                                         onChange={e => setNewCatLabel(e.target.value)}
                                         onKeyDown={e => {
                                             // 시트가 form 안이라 Enter 가 저장으로 새면 항목만 만들려다 기입이 된다.
-                                            if (e.key === "Enter") { e.preventDefault(); handleAddCategory(); }
+                                            if (e.key === "Enter") { e.preventDefault(); handleSaveCategory(); }
                                         }}
                                         className={cn(CTL_CLS, "flex-1")}
+                                        aria-label={catEditId !== null ? "항목 새 이름" : "새 항목 이름"}
                                     />
-                                    <button type="button" onClick={handleAddCategory}
+                                    <button type="button" onClick={handleSaveCategory}
                                         disabled={mutating || !newCatLabel.trim()}
                                         className="min-h-[44px] px-4 rounded-xl bg-[#16a34a] hover:bg-[#15803d] text-white text-xs font-black disabled:opacity-50 transition-colors">
-                                        추가
+                                        {catEditId !== null ? "저장" : "추가"}
                                     </button>
-                                    <button type="button" onClick={() => { setNewCatOpen(false); setNewCatLabel(""); }}
+                                    <button type="button" onClick={closeCatForm}
                                         className="min-h-[44px] px-3 rounded-xl border border-neutral-200 dark:border-[#3a3834] bg-[#faf9f7] dark:bg-[#1a1915] text-xs font-black text-neutral-500">
                                         취소
                                     </button>
                                 </div>
+                            )}
+                            {catEditId !== null && (
+                                <p className="text-[11px] font-bold text-neutral-400 dark:text-neutral-500">
+                                    이름만 바뀝니다 — 이 항목으로 적어둔 기록은 그대로 따라옵니다.
+                                </p>
                             )}
                         </div>
 

--- a/cf-idiotquant/lib/features/ledger/categories.ts
+++ b/cf-idiotquant/lib/features/ledger/categories.ts
@@ -27,12 +27,16 @@ export const EXPENSE_CATEGORIES: LedgerCategory[] = [
 export const presetsOf = (kind: LedgerKind) =>
     kind === "income" ? INCOME_CATEGORIES : EXPENSE_CATEGORIES;
 
-/* 사용자 항목의 키는 라벨을 그대로 담는다 (custom:여행).
-   덕분에 항목을 지워도 그 항목으로 적어둔 내역이 이름을 잃지 않는다 —
-   키 하나에서 라벨이 복원되므로 참조가 끊길 자리가 없다. */
-const CUSTOM_PREFIX = "custom:";
-export const customKey = (label: string) => `${CUSTOM_PREFIX}${label}`;
-export const isCustomKey = (key: string) => key.startsWith(CUSTOM_PREFIX);
+/* 사용자 항목의 키는 항목 "행"을 가리킨다 (cat:12).
+   라벨을 키에 담으면(custom:여행) 이름 한 번 바꿀 때마다 내역을 전부 훑어야 한다.
+   id 를 가리키면 이름은 ledger_categories 한 행만 고치면 끝난다. */
+const CAT_PREFIX = "cat:";
+export const catKey = (id: number) => `${CAT_PREFIX}${id}`;
+
+/* 지운 항목으로 적어둔 내역은 custom:<지울 때의 라벨> 로 굳어 있다 (워커가 지우기
+   직전에 바꿔둔다). 가리킬 행이 없어진 뒤에도 이름이 남게 하는 유일한 방법이다. */
+const FROZEN_PREFIX = "custom:";
+export const frozenKey = (label: string) => `${FROZEN_PREFIX}${label}`;
 
 /** D1 에서 온 항목 한 줄 (kind 별로 나눠 쓰기 위해 kind 를 그대로 갖고 다닌다) */
 export interface StoredCategory {
@@ -45,17 +49,24 @@ export interface StoredCategory {
 export function categoriesOf(kind: LedgerKind, custom: StoredCategory[] = []): LedgerCategory[] {
     const mine = custom
         .filter((c) => c.kind === kind)
-        .map((c) => ({ key: customKey(c.label), label: c.label, id: c.id }));
+        .map((c) => ({ key: catKey(c.id), label: c.label, id: c.id }));
     return [...presetsOf(kind), ...mine];
 }
 
 /**
- * 키를 라벨로. 프리셋에 없으면 custom: 접두사를 벗겨 쓰고, 그것도 아니면 키를 그대로 보여준다
- * — 프리셋이 바뀌어도, 항목을 지워도 옛 내역이 빈칸이 되지 않는다.
+ * 키를 라벨로. 프리셋 → 사용자 항목(id 로 찾음) → 굳어버린 라벨 → 키 그대로.
+ * 어느 단계에서 멈추든 빈칸이 되지 않는 것이 이 함수의 유일한 약속이다.
  */
-export function categoryLabel(kind: LedgerKind, key: string) {
+export function categoryLabel(kind: LedgerKind, key: string, custom: StoredCategory[] = []) {
     const preset = presetsOf(kind).find((c) => c.key === key);
     if (preset) return preset.label;
-    if (isCustomKey(key)) return key.slice(CUSTOM_PREFIX.length);
+
+    if (key.startsWith(CAT_PREFIX)) {
+        const id = Number(key.slice(CAT_PREFIX.length));
+        // 이름이 목록에 없다 = 그 항목이 지워졌거나 목록을 아직 못 받았다.
+        return custom.find((c) => c.id === id)?.label ?? "지운 항목";
+    }
+
+    if (key.startsWith(FROZEN_PREFIX)) return key.slice(FROZEN_PREFIX.length);
     return key;
 }

--- a/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
+++ b/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
@@ -75,6 +75,10 @@ export const getLedgerCategories = (owner: Owner) =>
 export const addLedgerCategory = (owner: Owner, kind: LedgerKind, label: string) =>
     ledgerRequest(`/user/ledger/categories${q(own(owner))}`, "POST", { kind, label });
 
+/* 이름만 바꾼다. 내역은 이 항목의 id 를 가리키고 있어 한 행만 고치면 전부 따라온다. */
+export const renameLedgerCategory = (owner: Owner, id: number, label: string) =>
+    ledgerRequest(`/user/ledger/categories${q(`id=${id}`, own(owner))}`, "PUT", { label });
+
 export const deleteLedgerCategory = (owner: Owner, id: number) =>
     ledgerRequest(`/user/ledger/categories${q(`id=${id}`, own(owner))}`, "DELETE");
 

--- a/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
+++ b/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
@@ -2,11 +2,11 @@ import type { PayloadAction } from "@reduxjs/toolkit";
 import { createAppSlice } from "@/lib/createAppSlice";
 import {
     getLedger, addLedgerEntry, updateLedgerEntry, deleteLedgerEntry,
-    getLedgerCategories, addLedgerCategory, deleteLedgerCategory,
+    getLedgerCategories, addLedgerCategory, renameLedgerCategory, deleteLedgerCategory,
     getLedgerAccess, createLedgerInvite,
     type LedgerEntry, type NewLedgerEntry, type LedgerAccess, type LedgerMember,
 } from "./ledgerAPI";
-import type { LedgerKind, StoredCategory } from "./categories";
+import { catKey, frozenKey, type LedgerKind, type StoredCategory } from "./categories";
 
 /** 사용자가 보는 달은 KST 기준이다 — UTC 로 세면 매달 1일 오전 9시 전에 지난달이 열린다. */
 export function currentMonthKst(): string {
@@ -206,8 +206,31 @@ export const ledgerSlice = createAppSlice({
             }
         ),
 
+        /** 이름 바꾸기 — 항목 한 줄만 갈아끼운다. 내역은 이 항목의 id 를 가리키고
+         *  있어 화면의 라벨이 저절로 따라온다(다시 조회할 것이 없다). */
+        reqRenameLedgerCategory: create.asyncThunk(
+            async ({ id, label }: { id: number; label: string }, { getState }) => {
+                const result = await renameLedgerCategory(ownerOf(getState), id, label);
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
+            {
+                pending: (state) => { state.mutating = true; state.error = null; },
+                fulfilled: (state, action) => {
+                    state.mutating = false;
+                    const category = action.payload?.data as StoredCategory | undefined;
+                    if (!category) return;
+                    state.categories = state.categories.map((c) => (c.id === category.id ? category : c));
+                },
+                rejected: (state, action) => {
+                    state.mutating = false;
+                    state.error = action.error?.message ?? null;
+                },
+            }
+        ),
+
         reqDeleteLedgerCategory: create.asyncThunk(
-            async (id: number, { getState }) => {
+            async ({ id }: { id: number; label: string }, { getState }) => {
                 const result = await deleteLedgerCategory(ownerOf(getState), id);
                 if (result?.success === false) throw new Error(result?.error ?? "API error");
                 return id;
@@ -217,6 +240,13 @@ export const ledgerSlice = createAppSlice({
                 fulfilled: (state, action) => {
                     state.mutating = false;
                     state.categories = state.categories.filter((c) => c.id !== action.payload);
+                    // 워커가 지우기 직전에 그 내역들을 custom:<라벨> 로 굳혔다. 화면의 내역도
+                    // 같은 값으로 맞춰두지 않으면 다시 조회하기 전까지 "지운 항목"으로 보인다.
+                    const frozen = frozenKey(action.meta.arg.label);
+                    const key = catKey(action.payload);
+                    state.entries = state.entries.map((e) =>
+                        e.category === key ? { ...e, category: frozen } : e
+                    );
                 },
                 rejected: (state, action) => {
                     state.mutating = false;
@@ -289,7 +319,7 @@ export const ledgerSlice = createAppSlice({
 
 export const {
     setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqUpdateLedgerEntry, reqDeleteLedgerEntry,
-    reqGetLedgerCategories, reqAddLedgerCategory, reqDeleteLedgerCategory,
+    reqGetLedgerCategories, reqAddLedgerCategory, reqRenameLedgerCategory, reqDeleteLedgerCategory,
     setActiveOwner, clearLedgerInvite, reqGetLedgerAccess, reqCreateLedgerInvite,
 } = ledgerSlice.actions;
 export const {


### PR DESCRIPTION
## 무엇

내가 만든 가계부 항목의 **이름을 고칠 수 있게** 했다. 고른 칩에만 연필이 붙고, 누르면 아래 입력 줄이 그 이름으로 채워진다. 바꾸면 목록·막대·달력의 라벨이 **다시 조회 없이** 함께 따라온다.

```
[급여] [주식 배당] [이자] [기타] [여행 ✏ ×] [+ 항목]
                                  ↑ 고른 항목에만
┌──────────────────────────────┐
│ 휴가              [저장] [취소] │
└──────────────────────────────┘
이름만 바뀝니다 — 이 항목으로 적어둔 기록은 그대로 따라옵니다.
```

## 어떻게 — 칩 키가 라벨에서 id 로

핵심은 UI 가 아니라 키 모양이다.

```diff
- custom:여행     ← 라벨을 통째로 품음. 이름을 바꾸면 내역을 전부 훑어야 함
+ cat:12          ← ledger_categories.id 를 가리킴. 이름은 한 행만 고치면 됨
```

내역이 항목 행을 가리키므로 라벨 해석은 `categoryLabel(kind, key, categories)` 한 곳에서 한다: 프리셋 → 사용자 항목(id 로 찾음) → 굳은 라벨 → 키 그대로. **어느 단계에서 멈추든 빈칸이 되지 않는 것**이 이 함수의 유일한 약속이다.

`custom:<라벨>` 도 계속 읽는다. 항목을 지우면 워커가 그 내역들을 `custom:<그때 라벨>` 로 굳혀두기 때문이다 — 가리킬 행이 없어진 뒤에도 이름이 남게 하는 유일한 방법이다. 그래서 슬라이스의 삭제 처리도 화면의 내역을 같은 값으로 맞춘다. 안 그러면 다시 조회하기 전까지 "지운 항목" 으로 보인다.

## UI 는 줄 하나를 겸하게

입력 줄을 새로 만들지 않았다. `catEditId` 가 `null` 이면 추가, 값이 있으면 그 항목의 이름을 고치는 중이고, 버튼 글자만 `추가`/`저장` 으로 바뀐다. 연필·× 는 예전 규칙 그대로 **고른 칩에만** 붙는다 — 칩마다 붙으면 고르다가 누른다.

## 확인

- `npx tsc --noEmit` — 에러 0
- `npm run build` — 성공, `/ledger` 그대로

(#716 머지 후 `main` 최신 tip 위에 다시 올려 재검증했습니다. diff 는 이제 이 변경 한 커밋뿐입니다.)

## 함께 필요한 것

워커 짝 PR: `MinSikSon/idiotquant-worker#111` (PUT `/user/ledger/categories?id=` + 0027 마이그레이션). 그쪽 배포가 있어야 이름 바꾸기가 실제로 동작합니다. **0027 D1 SQL 은 이미 적용 완료** — `ledger_entries` 의 `custom:식비` 한 건이 `cat:1` 로 옮겨진 것을 확인했습니다.