### PR TITLE
내역을 누르면 기록자·수정자를 보여준다

### DIFF
--- a/cf-idiotquant/app/(ledger)/ledger/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/page.tsx
@@ -60,6 +60,12 @@ function dayLabel(date: string) {
     return `${d}일 (${WEEKDAY[new Date(Date.UTC(y, m - 1, d)).getUTCDay()]})`;
 }
 
+/** epoch 초 → '8월 20일'. 워커는 UTC 로 도니 보는 사람 기준으로 9시간 당겨 읽는다. */
+function stampKst(sec: number) {
+    const d = new Date((sec + 9 * 60 * 60) * 1000);
+    return `${d.getUTCMonth() + 1}월 ${d.getUTCDate()}일`;
+}
+
 const won = (n: number) => `${n.toLocaleString("ko-KR")}원`;
 const signed = (n: number) => `${n > 0 ? "+" : n < 0 ? "−" : ""}${Math.abs(n).toLocaleString("ko-KR")}`;
 
@@ -144,6 +150,11 @@ export default function LedgerPage() {
 
     const thisMonth = currentMonthKst();
     const editing = editingId !== null;
+    const editingEntry = editingId === null ? null : entries.find(e => e.id === editingId) ?? null;
+
+    /* 기록자를 보여줄 이유는 "누가 넣었지"를 물을 사람이 있을 때뿐이다.
+       혼자 쓰는 가계부에서는 답이 언제나 나 하나라 줄만 늘어난다. */
+    const shared = activeOwner !== null || members.length > 0;
 
     useEffect(() => {
         if (status !== "authenticated") return;
@@ -1152,6 +1163,22 @@ export default function LedgerPage() {
                             <input id="f-memo" type="text" maxLength={40} placeholder="예: 삼성전자 반기 배당"
                                 value={fMemo} onChange={e => setFMemo(e.target.value)} className={CTL_CLS} />
                         </div>
+
+                        {/* 누가 적었고 누가 고쳤는가 — 함께 쓰는 가계부에서만.
+                            0028 이전 내역은 기록이 없어 줄 자체를 띄우지 않는다(빈칸도, 지어낸 이름도 두지 않는다). */}
+                        {shared && editingEntry?.created_by && (
+                            <div className="mb-3 pt-3 border-t border-neutral-100 dark:border-[#2c2b27] flex flex-col gap-0.5">
+                                <p className="text-[11px] font-bold text-neutral-400 dark:text-neutral-500">
+                                    기록 {editingEntry.created_by_name ?? "알 수 없음"} · {stampKst(editingEntry.created_at)}
+                                </p>
+                                {/* 고친 적이 없으면 기록 줄과 같은 말이 된다 — 달라졌을 때만 보탠다. */}
+                                {editingEntry.updated_at != null && editingEntry.updated_at !== editingEntry.created_at && (
+                                    <p className="text-[11px] font-bold text-neutral-400 dark:text-neutral-500">
+                                        수정 {editingEntry.updated_by_name ?? "알 수 없음"} · {stampKst(editingEntry.updated_at)}
+                                    </p>
+                                )}
+                            </div>
+                        )}
 
                         {(formError ?? error) && (
                             <p role="alert" className="mb-3 text-xs font-bold text-red-600 dark:text-red-400">

--- a/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
+++ b/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
@@ -8,6 +8,14 @@ export interface LedgerEntry {
     amount: number;       // 원 단위 양수. 부호는 kind 가 정한다.
     memo: string | null;
     created_at: number;
+    /* 누가 적었고 누가 고쳤는가. 이름은 워커가 users 에서 붙여 준다 —
+       남의 가계부를 볼 때 프론트에는 id 로 이름을 찾을 표가 없다.
+       0028 이전에 적힌 내역은 전부 null 이다. */
+    created_by?: string | null;
+    created_by_name?: string | null;
+    updated_by?: string | null;
+    updated_by_name?: string | null;
+    updated_at?: number | null;
 }
 
 export interface NewLedgerEntry {


### PR DESCRIPTION
## 무엇

내역을 눌러 수정 시트를 열면 맨 아래에 누가 적었고 누가 고쳤는지가 보인다.

```
메모 (선택)
┌──────────────────────────────┐
│ 삼성전자 반기 배당              │
└──────────────────────────────┘
──────────────────────────────
기록 박영희 · 8월 20일
수정 김민식 · 8월 21일
        [삭제]  [저장]
```

## 언제 보이나 — 세 가지 조건

셋 다 "없는 걸 그럴듯하게 채우지 않는다" 는 같은 규칙에서 나온다.

1. **함께 쓰는 가계부일 때만.** 혼자 쓰면 답이 언제나 나 하나라 줄만 늘어난다. (`activeOwner !== null || members.length > 0`)
2. **`created_by` 가 있을 때만.** 0028 이전에 적힌 내역은 누가 적었는지 알 방법이 없다 — 빈칸도, 지어낸 이름도 두지 않고 줄 자체를 띄우지 않는다.
3. **수정 줄은 실제로 고쳐졌을 때만.** `updated_at === created_at` 이면 두 줄이 같은 말이다.

## 이름은 어디서 오나

워커가 `users` 를 LEFT JOIN 해서 `created_by_name` / `updated_by_name` 을 실어 보낸다. 프론트에서 id 로 찾지 않는 이유는 **남의 가계부를 볼 때 찾을 표가 없어서**다 — 내가 가진 멤버 목록은 내 가계부의 것이지 그 사람 것이 아니다.

날짜는 `stampKst()` 로 KST 기준 '8월 20일'. 워커가 UTC 로 돌기 때문에 9시간 당겨 읽는다(페이지의 다른 날짜 계산과 같은 기준).

## 확인

- `npx tsc --noEmit` — 에러 0
- `npm run build` — 성공

(#718 머지 후 `main` 최신 tip 위에 다시 올려 재검증했습니다. diff 는 이제 이 변경 한 커밋뿐입니다 — 2 files, +35.)

## 함께 필요한 것

워커 짝 PR: `MinSikSon/idiotquant-worker#112` (0028 + 기록자 저장). **D1 컬럼을 먼저 만들고 배포**해야 합니다 — 순서가 뒤집히면 기입·수정이 깨집니다. SQL 은 그 PR 본문에 있습니다.