### PR TITLE
내역을 꾹 눌러 끌면 순서·날짜가 바뀐다

### DIFF
--- a/cf-idiotquant/app/(ledger)/ledger/page.tsx
+++ b/cf-idiotquant/app/(ledger)/ledger/page.tsx
@@ -11,6 +11,7 @@ import { PageHeader, PAGE_ACTION_CLS } from "@/components/pageHeader";
 import type { LedgerEntry, NewLedgerEntry } from "@/lib/features/ledger/ledgerAPI";
 import {
     setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqUpdateLedgerEntry, reqDeleteLedgerEntry,
+    reqReorderLedgerEntries,
     reqGetLedgerCategories, reqAddLedgerCategory, reqRenameLedgerCategory, reqDeleteLedgerCategory,
     setActiveOwner, clearLedgerInvite, reqGetLedgerAccess, reqCreateLedgerInvite,
     selectLedgerMonth, selectLedgerEntries, selectLedgerState, selectLedgerCategories,
@@ -21,6 +22,7 @@ import {
 import {
     categoriesOf, categoryLabel, catKey, type LedgerKind, type StoredCategory,
 } from "@/lib/features/ledger/categories";
+import { useEntryDrag } from "./useEntryDrag";
 
 /* ─── 공통 클래스 ──────────────────────────────────────────────── */
 const CTL_CLS =
@@ -247,6 +249,16 @@ export default function LedgerPage() {
             net: items.reduce((s, e) => s + (e.kind === "income" ? e.amount : -e.amount), 0),
         }));
     }, [entries]);
+
+    /* ─── 끌어 옮기기 ─────────────────────────────────────────── */
+    async function handleReorder(date: string, ids: number[]) {
+        const result = await dispatch(reqReorderLedgerEntries({ date, ids }));
+        // 낙관적으로 옮겨둔 자리는 되돌릴 수가 없다 — 실패하면 그 달을 다시 읽는다.
+        if (result.meta.requestStatus !== "fulfilled") dispatch(reqGetLedger(month));
+    }
+
+    const { dragId, dropTarget, rowProps, dayProps, consumeDragClick } =
+        useEntryDrag({ days, onDrop: handleReorder });
 
     /* ─── 시트 열고 닫기 ───────────────────────────────────────── */
     function changeKind(kind: LedgerKind, keep?: string) {
@@ -739,9 +751,18 @@ export default function LedgerPage() {
                 <section className={cn(CARD_CLS, "overflow-hidden")}>
                     <div className="flex items-center justify-between px-4 pt-3 pb-2.5 border-b border-neutral-100 dark:border-[#35332e]">
                         <h2 className={FIELD_LABEL_CLS}>내역</h2>
-                        {entries.length > 0 && (
-                            <span className="text-[11px] font-bold text-neutral-400">{entries.length}건</span>
-                        )}
+                        <div className="flex items-baseline gap-2">
+                            {/* 손잡이를 줄마다 붙이면 목록이 시끄러워진다 — 한 줄로 알린다 */}
+                            {entries.length > 1 && (
+                                <span className="text-[11px] font-bold text-neutral-300 dark:text-neutral-600">
+                                    <span className="sm:hidden">꾹 눌러 끌기</span>
+                                    <span className="hidden sm:inline">꾹 눌러 끌면 순서·날짜가 바뀝니다</span>
+                                </span>
+                            )}
+                            {entries.length > 0 && (
+                                <span className="text-[11px] font-bold text-neutral-400">{entries.length}건</span>
+                            )}
+                        </div>
                     </div>
 
                     {loading ? (
@@ -762,7 +783,12 @@ export default function LedgerPage() {
                                 <div key={day.date}>
                                     <div
                                         id={`ledger-day-${day.date}`}
-                                        className="flex items-baseline justify-between gap-3 px-4 py-1.5 bg-[#faf9f7] dark:bg-[#1f1e1b] border-y border-neutral-100 dark:border-[#35332e] scroll-mt-20"
+                                        {...dayProps(day.date)}
+                                        className={cn(
+                                            "flex items-baseline justify-between gap-3 px-4 py-1.5 bg-[#faf9f7] dark:bg-[#1f1e1b] border-y border-neutral-100 dark:border-[#35332e] scroll-mt-20",
+                                            // 머리글 위에 놓으면 그 날 맨 위로 간다 — 그 사실을 색으로 알린다
+                                            dropTarget?.date === day.date && dropTarget.index === 0 && "bg-[#dcfce7] dark:bg-[#052e16]/60"
+                                        )}
                                     >
                                         <span className="text-[11px] font-black text-neutral-500 dark:text-neutral-400 tabular-nums">
                                             {dayLabel(day.date)}
@@ -776,19 +802,32 @@ export default function LedgerPage() {
                                     </div>
 
                                     <div className="divide-y divide-neutral-50 dark:divide-[#35332e]/40">
-                                        {day.items.map(e => {
+                                        {day.items.map((e, i) => {
                                             const isIncome = e.kind === "income";
+                                            const lifted = dragId === e.id;
+                                            // 놓을 자리는 줄 사이의 선이다 — i 앞, 그리고 마지막이면 뒤에도.
+                                            const lineBefore = dropTarget?.date === day.date && dropTarget.index === i && i > 0;
+                                            const lineAfter =
+                                                dropTarget?.date === day.date &&
+                                                dropTarget.index === i + 1 &&
+                                                i === day.items.length - 1;
                                             return (
-                                                /* 줄 전체가 수정 진입점 — 작은 아이콘을 겨눌 필요가 없다 */
+                                                /* 줄 전체가 수정 진입점 — 작은 아이콘을 겨눌 필요가 없다.
+                                                   꾹 누르면 들려서 순서·날짜를 바꾼다(useEntryDrag). */
                                                 <button
                                                     key={e.id}
                                                     type="button"
-                                                    onClick={() => openEdit(e)}
+                                                    {...rowProps(e.id, day.date)}
+                                                    onClick={() => { if (!consumeDragClick()) openEdit(e); }}
                                                     className={cn(
-                                                        "w-full grid grid-cols-[auto_1fr_auto_auto] items-center gap-2.5 px-3 sm:px-4 py-2.5 min-h-[56px] text-left transition-colors",
-                                                        justAddedId === e.id
-                                                            ? "bg-[#dcfce7]/70 dark:bg-[#052e16]/40"
-                                                            : "hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]"
+                                                        "w-full grid grid-cols-[auto_1fr_auto_auto] items-center gap-2.5 px-3 sm:px-4 py-2.5 min-h-[56px] text-left transition-colors select-none",
+                                                        lineBefore && "shadow-[inset_0_2px_0_0_#16a34a]",
+                                                        lineAfter && "shadow-[inset_0_-2px_0_0_#16a34a]",
+                                                        lifted
+                                                            ? "opacity-45 bg-[#f5f0e8] dark:bg-[#2c2b27]"
+                                                            : justAddedId === e.id
+                                                                ? "bg-[#dcfce7]/70 dark:bg-[#052e16]/40"
+                                                                : "hover:bg-[#f5f0e8] dark:hover:bg-[#2c2b27]"
                                                     )}
                                                     aria-label={`${e.entry_date} ${categoryLabel(e.kind, e.category, customCategories)} ${e.amount.toLocaleString("ko-KR")}원 수정`}
                                                 >

--- a/cf-idiotquant/app/(ledger)/ledger/useEntryDrag.ts
+++ b/cf-idiotquant/app/(ledger)/ledger/useEntryDrag.ts
@@ -1,0 +1,195 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * 내역 줄을 끌어 옮기기.
+ *
+ * 줄 전체가 이미 "누르면 수정" 이라, 끌기와 탭이 같은 손짓을 나눠 쓴다.
+ * 그래서 꾹 눌러야(LONG_PRESS_MS) 들리고, 그 전에 손가락이 움직이면 스크롤로 본다.
+ * 라이브러리를 들이지 않은 이유도 같다 — 이 규칙이 이 화면에만 있는 규칙이라서다.
+ */
+
+const LONG_PRESS_MS = 320;
+/** 들리기 전에 이만큼 움직이면 끌기가 아니라 스크롤이다. */
+const CANCEL_SLOP_PX = 8;
+/** 화면 위아래 이 안쪽에 손가락이 있으면 목록이 따라 흐른다 — 없으면 먼 날로 못 옮긴다. */
+const EDGE_PX = 90;
+const EDGE_SPEED_PX = 14;
+
+export interface DropTarget {
+    date: string;
+    /** 그 날 목록에서 몇 번째 자리에 놓이는가 (0 = 맨 위) */
+    index: number;
+}
+
+interface Day {
+    date: string;
+    items: { id: number }[];
+}
+
+interface Options {
+    days: Day[];
+    /** 놓았을 때 — 도착한 날과 그 날의 새 순서. 같은 자리면 부르지 않는다. */
+    onDrop: (date: string, ids: number[]) => void;
+}
+
+export function useEntryDrag({ days, onDrop }: Options) {
+    const [dragId, setDragId] = useState<number | null>(null);
+    const [dropTarget, setDropTarget] = useState<DropTarget | null>(null);
+
+    /* 이벤트 핸들러는 한 번 붙고 오래 산다 — 최신 값은 ref 로 건넨다. */
+    const daysRef = useRef(days);
+    daysRef.current = days;
+    const onDropRef = useRef(onDrop);
+    onDropRef.current = onDrop;
+
+    const dragIdRef = useRef<number | null>(null);
+    const targetRef = useRef<DropTarget | null>(null);
+    const pressRef = useRef<{ id: number; x: number; y: number; timer: number } | null>(null);
+    const pointerYRef = useRef(0);
+    /** 끌고 나서 올라오는 click 을 삼킨다 — 안 그러면 놓자마자 수정 시트가 열린다. */
+    const draggedRef = useRef(false);
+
+    const clearPress = () => {
+        if (pressRef.current) window.clearTimeout(pressRef.current.timer);
+        pressRef.current = null;
+    };
+
+    const stop = useCallback(() => {
+        clearPress();
+        dragIdRef.current = null;
+        targetRef.current = null;
+        setDragId(null);
+        setDropTarget(null);
+    }, []);
+
+    /** 손가락 아래에 무엇이 있는지 — 스크롤 중에도 맞으려면 매번 물어봐야 한다. */
+    const hitTest = (x: number, y: number): DropTarget | null => {
+        const el = document.elementFromPoint(x, y)?.closest<HTMLElement>("[data-drop]");
+        if (!el) return null;
+
+        const date = el.dataset.date;
+        if (!date) return null;
+
+        // 날짜 머리글에 놓으면 그 날 맨 위.
+        if (el.dataset.drop === "day") return { date, index: 0 };
+
+        const items = daysRef.current.find(d => d.date === date)?.items ?? [];
+        const at = items.findIndex(i => i.id === Number(el.dataset.entryId));
+        if (at === -1) return { date, index: items.length };
+
+        // 줄의 위 절반이면 그 앞, 아래 절반이면 그 뒤.
+        const box = el.getBoundingClientRect();
+        return { date, index: y < box.top + box.height / 2 ? at : at + 1 };
+    };
+
+    /* 끄는 동안의 손짓은 전부 window 에서 듣는다 — 손가락이 줄 밖으로 나가도 놓친이 없다. */
+    useEffect(() => {
+        if (dragId === null) return;
+
+        // 이 시점엔 스크롤이 시작되지 않았다(움직였으면 들리지도 않았다).
+        // touch-action 은 손짓이 시작된 뒤에 바꿔봐야 늦어서, 여기서 직접 막는다.
+        const block = (e: TouchEvent) => e.preventDefault();
+        document.addEventListener("touchmove", block, { passive: false });
+
+        const onMove = (e: PointerEvent) => {
+            pointerYRef.current = e.clientY;
+            const next = hitTest(e.clientX, e.clientY);
+            targetRef.current = next;
+            setDropTarget(next);
+        };
+
+        const onUp = () => {
+            const id = dragIdRef.current;
+            const target = targetRef.current;
+            if (id !== null && target) {
+                const base = daysRef.current.find(d => d.date === target.date)?.items.map(i => i.id) ?? [];
+                const from = base.indexOf(id);
+                // 뽑아낸 자리가 목표보다 앞이면 그만큼 당겨서 꽂아야 한 칸씩 밀린다.
+                const insertAt = from !== -1 && from < target.index ? target.index - 1 : target.index;
+
+                const ids = base.filter(x => x !== id);
+                ids.splice(insertAt, 0, id);
+
+                const sameDay = from !== -1;
+                const moved = !sameDay || from !== insertAt;
+                if (moved) onDropRef.current(target.date, ids);
+            }
+            stop();
+        };
+
+        const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") stop(); };
+
+        window.addEventListener("pointermove", onMove);
+        window.addEventListener("pointerup", onUp);
+        window.addEventListener("pointercancel", stop);
+        window.addEventListener("keydown", onKey);
+
+        // 가장자리에서 목록이 흐른다. 손가락은 그대로인데 밑이 지나가므로 매 프레임 다시 겨눈다.
+        let frame = requestAnimationFrame(function tick() {
+            const y = pointerYRef.current;
+            const dy = y < EDGE_PX ? -EDGE_SPEED_PX : y > window.innerHeight - EDGE_PX ? EDGE_SPEED_PX : 0;
+            if (dy) window.scrollBy(0, dy);
+            frame = requestAnimationFrame(tick);
+        });
+
+        return () => {
+            document.removeEventListener("touchmove", block);
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", onUp);
+            window.removeEventListener("pointercancel", stop);
+            window.removeEventListener("keydown", onKey);
+            cancelAnimationFrame(frame);
+        };
+    }, [dragId, stop]);
+
+    useEffect(() => () => clearPress(), []);
+
+    /** 줄에 그대로 펼쳐 넣는 속성들. data-* 는 손가락 아래를 찾는 데 쓴다. */
+    const rowProps = (id: number, date: string) => ({
+        "data-drop": "entry",
+        "data-entry-id": id,
+        "data-date": date,
+        draggable: false,
+        onPointerDown: (e: React.PointerEvent) => {
+            if (e.button !== 0) return;               // 오른쪽 버튼으로는 끌지 않는다
+            // 지난 손짓이 click 없이 끝났을 수 있다. 여기서 털지 않으면 그 찌꺼기가
+            // 다음 탭 하나를 조용히 삼킨다.
+            draggedRef.current = false;
+            pointerYRef.current = e.clientY;
+            clearPress();
+            pressRef.current = {
+                id, x: e.clientX, y: e.clientY,
+                timer: window.setTimeout(() => {
+                    pressRef.current = null;
+                    draggedRef.current = true;
+                    dragIdRef.current = id;
+                    setDragId(id);
+                    navigator.vibrate?.(15);          // 들렸다는 걸 손으로 알린다
+                }, LONG_PRESS_MS),
+            };
+        },
+        onPointerMove: (e: React.PointerEvent) => {
+            const press = pressRef.current;
+            if (!press) return;
+            // 들리기 전에 움직였다면 스크롤할 생각이었던 것이다.
+            if (Math.hypot(e.clientX - press.x, e.clientY - press.y) > CANCEL_SLOP_PX) clearPress();
+        },
+        onPointerUp: clearPress,
+        onPointerCancel: clearPress,
+        // 꾹 누르면 모바일에서 선택·컨텍스트 메뉴가 뜬다 — 줄에는 어차피 고를 글이 없다.
+        onContextMenu: (e: React.MouseEvent) => { if (dragIdRef.current !== null) e.preventDefault(); },
+    });
+
+    /** 끌고 난 직후의 click 인가? 맞으면 수정 시트를 열지 않는다. */
+    const consumeDragClick = () => {
+        if (!draggedRef.current) return false;
+        draggedRef.current = false;
+        return true;
+    };
+
+    const dayProps = (date: string) => ({ "data-drop": "day", "data-date": date });
+
+    return { dragId, dropTarget, rowProps, dayProps, consumeDragClick };
+}

--- a/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
+++ b/cf-idiotquant/lib/features/ledger/ledgerAPI.ts
@@ -16,6 +16,8 @@ export interface LedgerEntry {
     updated_by?: string | null;
     updated_by_name?: string | null;
     updated_at?: number | null;
+    /** 같은 날 안에서 손으로 정한 순서. 작을수록 위. 0029 이전 줄은 null 이다. */
+    position?: number | null;
 }
 
 export interface NewLedgerEntry {
@@ -73,6 +75,11 @@ export const updateLedgerEntry = (owner: Owner, id: number, entry: NewLedgerEntr
 
 export const deleteLedgerEntry = (owner: Owner, id: number) =>
     ledgerRequest(`/user/ledger${q(`id=${id}`, own(owner))}`, "DELETE");
+
+/** "이 날의 순서는 이것이다". 같은 날 안에서 자리를 바꾼 것도, 다른 날에서
+ *  끌어온 것도 도착한 날의 목록으로는 똑같이 표현된다 — 그래서 부르는 곳도 하나다. */
+export const reorderLedgerEntries = (owner: Owner, date: string, ids: number[]) =>
+    ledgerRequest(`/user/ledger/reorder${q(`date=${date}`, own(owner))}`, "POST", { ids });
 
 /* 사용자가 만든 항목 — 칩으로 무엇을 보여줄지만 정한다. 지워도 과거 내역은 그대로 남는다. */
 export type { StoredCategory };

--- a/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
+++ b/cf-idiotquant/lib/features/ledger/ledgerSlice.tsx
@@ -1,7 +1,7 @@
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { createAppSlice } from "@/lib/createAppSlice";
 import {
-    getLedger, addLedgerEntry, updateLedgerEntry, deleteLedgerEntry,
+    getLedger, addLedgerEntry, updateLedgerEntry, deleteLedgerEntry, reorderLedgerEntries,
     getLedgerCategories, addLedgerCategory, renameLedgerCategory, deleteLedgerCategory,
     getLedgerAccess, createLedgerInvite,
     type LedgerEntry, type NewLedgerEntry, type LedgerAccess, type LedgerMember,
@@ -18,9 +18,13 @@ export function currentMonthKst(): string {
 const ownerOf = (getState: () => unknown) =>
     (getState() as { ledger: { activeOwner: string | null } }).ledger.activeOwner;
 
-/** 최신 날짜가 위. 같은 날은 나중에 넣은 것이 위로 온다 (워커 ORDER BY 와 같은 기준). */
+/** 최신 날짜가 위. 같은 날은 손으로 정한 순서(position)를 따르고, 그 다음이 id 다.
+ *  워커 ORDER BY 와 글자 그대로 같은 기준이어야 한다 — 다르면 저장 직후 화면과
+ *  다시 불러온 화면의 줄 순서가 달라진다. position 이 없던 시절 줄은 -id 로 센다. */
+const posOf = (e: LedgerEntry) => e.position ?? -e.id;
+
 const byRecent = (a: LedgerEntry, b: LedgerEntry) =>
-    b.entry_date.localeCompare(a.entry_date) || b.id - a.id;
+    b.entry_date.localeCompare(a.entry_date) || posOf(a) - posOf(b) || b.id - a.id;
 
 interface LedgerState {
     state: "init" | "pending" | "fulfilled" | "rejected";
@@ -108,6 +112,44 @@ export const ledgerSlice = createAppSlice({
                     state.mutating = false;
                     state.error = action.error?.message ?? null;
                 },
+            }
+        ),
+
+        /**
+         * 끌어놓기 — "이 날의 순서는 이것이다" 하나만 보낸다.
+         * 같은 날 안에서 자리를 바꾼 것도, 다른 날에서 끌어온 것도 도착한 날의
+         * 목록으로는 똑같아서, 부르는 쪽도 받는 쪽도 구분할 일이 없다.
+         */
+        reqReorderLedgerEntries: create.asyncThunk(
+            async ({ date, ids }: { date: string; ids: number[] }, { getState }) => {
+                const result = await reorderLedgerEntries(ownerOf(getState), date, ids);
+                if (result?.success === false) throw new Error(result?.error ?? "API error");
+                return result;
+            },
+            {
+                // 손을 떼는 순간 자리가 잡혀 있어야 한다. 응답을 기다리면 줄이 원래
+                // 자리로 튕겼다가 다시 옮겨가는 게 보인다.
+                pending: (state, action) => {
+                    state.error = null;
+                    const { date, ids } = action.meta.arg;
+                    state.entries = state.entries
+                        .map((e) => {
+                            const index = ids.indexOf(e.id);
+                            return index === -1 ? e : { ...e, entry_date: date, position: index };
+                        })
+                        .sort(byRecent);
+                },
+                // 워커가 그 날을 다시 읽어 준다 — 수정자까지 맞춰진 값으로 갈아끼운다.
+                fulfilled: (state, action) => {
+                    const moved = (action.payload?.data?.entries ?? []) as LedgerEntry[];
+                    if (moved.length === 0) return;
+                    const movedIds = new Set(moved.map((e) => e.id));
+                    state.entries = [...state.entries.filter((e) => !movedIds.has(e.id)), ...moved]
+                        .sort(byRecent);
+                },
+                // 되돌리기는 화면이 그 달을 다시 읽어서 한다 — 여기서 dispatch 하면
+                // 슬라이스가 자기 자신을 부르는 모양이 된다.
+                rejected: (state, action) => { state.error = action.error?.message ?? null; },
             }
         ),
 
@@ -319,6 +361,7 @@ export const ledgerSlice = createAppSlice({
 
 export const {
     setLedgerMonth, reqGetLedger, reqAddLedgerEntry, reqUpdateLedgerEntry, reqDeleteLedgerEntry,
+    reqReorderLedgerEntries,
     reqGetLedgerCategories, reqAddLedgerCategory, reqRenameLedgerCategory, reqDeleteLedgerCategory,
     setActiveOwner, clearLedgerInvite, reqGetLedgerAccess, reqCreateLedgerInvite,
 } = ledgerSlice.actions;


### PR DESCRIPTION
## 무엇

내역 줄을 **꾹 눌러 끌면** 자리를 옮길 수 있다. 같은 날 안에 놓으면 순서만 바뀌고, 다른 날 구역에 놓으면 **날짜까지 바뀐다** — 날짜를 잘못 적었을 때 시트를 열지 않고 고칠 수 있다.

```
8월 20일 ─────────────────  −45,000
  [생활비] 점심          −12,000
━━━━━━━━━━━━━━━━━━━━━━━━━  ← 놓을 자리
  [고정비] 월세      ⇕   −800,000   ← 들린 줄 (흐리게)

8월 19일 ─────────────────  −12,000   ← 머리글에 놓으면 그 날 맨 위
  [생활비] 커피           −4,500
```

## 끌기와 탭이 같은 손짓을 나눠 쓴다

줄 전체가 이미 "누르면 수정" 이라, 여기가 이 기능의 전부다.

| | |
|---|---|
| 톡 누르면 | 수정 시트 (예전 그대로) |
| 320ms 꾹 누르면 | 들린다 (진동으로 알림) |
| 들리기 전에 8px 움직이면 | 끌기가 아니라 스크롤 |

들린 **뒤에** `touchmove` 를 직접 막는다. `touch-action` 은 손짓이 시작된 뒤에 바꿔봐야 늦기 때문이다. 이 시점엔 아직 스크롤이 시작되지 않았다는 게 보장된다 — 움직였으면 들리지도 않았으니까.

끌고 난 직후 올라오는 `click` 은 삼킨다. 안 그러면 놓자마자 수정 시트가 열린다. 그 표시는 다음 `pointerdown` 에서 털어낸다 — 어떤 경로로든 `click` 이 안 오면 찌꺼기가 남아 다음 탭 하나를 조용히 삼키기 때문이다.

**가장자리에서 목록이 흐른다.** 없으면 8월 20일에서 8월 3일로는 옮길 방법이 없다.

## 화면은 두 동작을 구분하지 않는다

워커에 보내는 것이 `{ date, ids }` — "이 날의 순서는 이것이다" 하나뿐이라서다. 같은 날 안에서 옮긴 것도, 다른 날에서 끌어온 것도 도착한 날의 목록으로는 똑같이 표현된다.

**놓는 순간 자리가 잡힌다.** 슬라이스가 `pending` 에서 먼저 옮기고, 응답이 오면 워커가 다시 읽어준 값으로 갈아끼운다. 응답을 기다렸다면 줄이 원래 자리로 튕겼다가 다시 옮겨가는 게 보인다. 실패하면 그 달을 다시 읽어 되돌린다.

정렬 기준은 워커 `ORDER BY` 와 **글자 그대로** 같게 맞췄다(`entry_date DESC, position ASC, id DESC`). 다르면 저장 직후 화면과 다시 불러온 화면의 줄 순서가 달라진다.

## 라이브러리를 안 쓴 이유

이 규칙(꾹 누르기 임계값, 스크롤과의 양보, 날짜 머리글이 곧 드롭 존)이 이 화면에만 있는 규칙이라서다. dnd-kit 을 들이면 의존성과 함께 그 규칙을 우회하는 코드가 같이 온다. `useEntryDrag.ts` 195줄로 끝난다.

## 확인

- `npx tsc --noEmit` — 에러 0
- `npm run build` — 성공

## 함께 필요한 것

워커 짝 PR: `MinSikSon/idiotquant-worker#113` (0029 `position` + reorder 라우트). 배포와 D1 SQL 이 있어야 끌어놓은 자리가 저장됩니다 — SQL 은 그 PR 본문에 있습니다. 0029 백필이 `position = -id` 라 적용해도 지금 목록은 한 줄도 바뀌지 않습니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkWhRiKfTxb61ByrP4YWtB)_